### PR TITLE
fix: correctness fixes in fallback context + summary backfill (cleanup PR1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Fixed
 
-- Session-start context no longer injects untruncated exchange text on the uncached fallback path. The fallback now builds its summary through the same canonical builder as the cached path, so long exchanges are mid-truncated identically.
-- Summary backfill no longer permanently marks a branch failed on a transient DB error (only genuine content errors get the sentinel), and a sentinel-marked branch is no longer re-selected forever — the error sentinel is excluded from the eligible set, so the documented "avoid infinite retry" guarantee now actually holds.
-- `token_snapshots`/`turn_tool_calls` column migrations use explicit existence checks instead of swallowing `OperationalError`, so a real schema error surfaces instead of being silently ignored.
+- Session-start context no longer injects untruncated exchange text on the uncached fallback path. The fallback now builds its summary through the same canonical builder as the cached path, so long exchanges are mid-truncated identically. (#2)
+- Summary backfill no longer permanently marks a branch failed on a transient DB error (only genuine content errors get the sentinel), and a sentinel-marked branch is no longer re-selected forever — the error sentinel is excluded from the eligible set, so the documented "avoid infinite retry" guarantee now actually holds. (#2)
+- `token_snapshots`/`turn_tool_calls` column migrations use explicit existence checks instead of swallowing `OperationalError`, so a real schema error surfaces instead of being silently ignored. (#2)
 - Importing a session whose content all filters out (tool results, notifications, empty text) no longer crashes with `sqlite3.IntegrityError: FOREIGN KEY constraint failed`. `find_all_branches` inserts branch rows before content filtering, so a zero-message session still has children; the `total_messages == 0` cleanup now tears down `branch_messages → branches → sessions` in FK order instead of a bare session delete. Surfaced importing a large transcript set onto a fresh machine. The test fixtures now enable `PRAGMA foreign_keys = ON` to match production, so the existing FK-safe guard tests actually enforce the constraint.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- Session-start context no longer injects untruncated exchange text on the uncached fallback path. The fallback now builds its summary through the same canonical builder as the cached path, so long exchanges are mid-truncated identically.
+- Summary backfill no longer permanently marks a branch failed on a transient DB error (only genuine content errors get the sentinel), and a sentinel-marked branch is no longer re-selected forever — the error sentinel is excluded from the eligible set, so the documented "avoid infinite retry" guarantee now actually holds.
+- `token_snapshots`/`turn_tool_calls` column migrations use explicit existence checks instead of swallowing `OperationalError`, so a real schema error surfaces instead of being silently ignored.
 - Importing a session whose content all filters out (tool results, notifications, empty text) no longer crashes with `sqlite3.IntegrityError: FOREIGN KEY constraint failed`. `find_all_branches` inserts branch rows before content filtering, so a zero-message session still has children; the `total_messages == 0` cleanup now tears down `branch_messages → branches → sessions` in FK order instead of a bare session delete. Surfaced importing a large transcript set onto a fresh machine. The test fixtures now enable `PRAGMA foreign_keys = ON` to match production, so the existing FK-safe guard tests actually enforce the constraint.
 
 ### Added

--- a/src/ccrecall/db.py
+++ b/src/ccrecall/db.py
@@ -32,9 +32,10 @@ CONFIG_PATH = Path.home() / ".claude-memory" / "config.json"
 EMBEDDABLE_BRANCH_FILTER = (
     "is_active = 1 AND context_summary IS NOT NULL AND context_summary != ''"
 )
-# Sentinel written to embedding_version when a branch's summary can't be embedded
-# (tokenizer overflow, malformed content). Excluded from eligibility so it isn't
-# retried forever; counted separately as "errored".
+# Sentinel written to a branch's embedding_version or summary_version when its
+# content can't be embedded or summarized (tokenizer overflow, malformed content).
+# Excluded from eligibility so it isn't retried forever; counted separately as
+# "errored".
 CONTENT_ERROR_VERSION = -1
 
 # Default settings

--- a/src/ccrecall/hooks/backfill_summaries.py
+++ b/src/ccrecall/hooks/backfill_summaries.py
@@ -8,12 +8,13 @@ with summary_version = -1 to avoid infinite retry.
 """
 
 from ccrecall.db import (
+    CONTENT_ERROR_VERSION,
     DEFAULT_DB_PATH,
     get_db_connection,
     load_settings,
     setup_logging,
 )
-from ccrecall.summarizer import compute_context_summary
+from ccrecall.summarizer import SUMMARY_VERSION, compute_context_summary
 
 BATCH_SIZE = 50
 
@@ -48,34 +49,45 @@ def _main():
         cursor.execute(
             """
             SELECT id FROM branches
-            WHERE summary_version IS NULL OR summary_version < 3
+            WHERE summary_version IS NULL
+               OR (summary_version < ? AND summary_version != ?)
             LIMIT ?
         """,
-            (BATCH_SIZE,),
+            (SUMMARY_VERSION, CONTENT_ERROR_VERSION, BATCH_SIZE),
         )
         rows = cursor.fetchall()
 
         if not rows:
             break
 
-        for (branch_id,) in rows:
-            try:
-                summary_md, summary_json = compute_context_summary(cursor, branch_id)
-                cursor.execute(
-                    """
-                    UPDATE branches SET context_summary = ?, context_summary_json = ?, summary_version = 3
-                    WHERE id = ?
-                """,
-                    (summary_md, summary_json, branch_id),
-                )
-                total_updated += 1
-            except Exception as e:
-                # Mark as errored to avoid infinite retry
-                cursor.execute(
-                    "UPDATE branches SET summary_version = -1 WHERE id = ?",
-                    (branch_id,),
-                )
-                logger.error(f"Backfill: branch {branch_id} failed: {e}")
+        try:
+            for (branch_id,) in rows:
+                try:
+                    summary_md, summary_json = compute_context_summary(cursor, branch_id)
+                    cursor.execute(
+                        """
+                        UPDATE branches SET context_summary = ?, context_summary_json = ?, summary_version = ?
+                        WHERE id = ?
+                    """,
+                        (summary_md, summary_json, SUMMARY_VERSION, branch_id),
+                    )
+                    total_updated += 1
+                except (ValueError, TypeError, KeyError) as e:
+                    # Per-row content error (malformed summary data): mark the
+                    # sentinel so it isn't retried forever. Infra errors fall
+                    # through to the outer handler instead of poisoning the row.
+                    cursor.execute(
+                        "UPDATE branches SET summary_version = ? WHERE id = ?",
+                        (CONTENT_ERROR_VERSION, branch_id),
+                    )
+                    logger.error(f"Backfill: branch {branch_id} content error: {e}")
+        except Exception as e:
+            # Infra/session failure (locked DB, I/O): abort without marking
+            # further rows — they stay eligible next run. Commit prior batches.
+            logger.error(f"Backfill: session failure, aborting: {e}")
+            conn.commit()
+            conn.close()
+            return
 
         conn.commit()
 

--- a/src/ccrecall/hooks/memory_context.py
+++ b/src/ccrecall/hooks/memory_context.py
@@ -42,8 +42,7 @@ from ccrecall.session_tail import (
     transcript_for_uuid,
 )
 from ccrecall.summarizer import (
-    build_exchange_pairs,
-    detect_disposition,
+    build_context_summary_json,
     render_context_summary,
 )
 
@@ -319,67 +318,25 @@ def select_sessions(
 
 
 def _build_fallback_context(session: dict) -> str:
+    """Fallback for sessions without a cached context_summary.
+
+    Builds the structured summary through the canonical
+    build_context_summary_json so exchange text is truncated identically to the
+    cached path, then renders it. One builder means the two paths can't drift —
+    a hand-rolled copy here previously emitted untruncated exchange text.
     """
-    Fallback for sessions without cached context_summary.
-    Constructs a summary_json dict from raw session data and delegates
-    to render_context_summary() — no duplicated rendering logic here.
-    """
-    messages = session.get("messages", [])
-    exchanges = build_exchange_pairs(messages) if messages else []
-    files = session.get("files_modified", [])
-    commits = session.get("commits", [])
-
-    # Build topic from first exchange
-    topic = exchanges[0]["user"][:120] if exchanges else ""
-
-    # Derive disposition, passing commits for metadata-based detection
-    disposition = detect_disposition(exchanges, commits=commits) if exchanges else ""
-
-    exchange_count = session.get("exchange_count", len(exchanges))
-
-    # Build first_exchanges (up to 2)
-    first_exchanges = [
-        {"user": ex["user"], "assistant": ex["assistant"], "timestamp": ex["timestamp"]}
-        for ex in exchanges[:2]
-    ]
-
-    # Build last_exchanges (up to 6 for long sessions, all for short)
-    if len(exchanges) <= 8:
-        last_exchanges = [
-            {
-                "user": ex["user"],
-                "assistant": ex["assistant"],
-                "timestamp": ex["timestamp"],
-            }
-            for ex in exchanges
-        ]
-    else:
-        last_exchanges = [
-            {
-                "user": ex["user"],
-                "assistant": ex["assistant"],
-                "timestamp": ex["timestamp"],
-            }
-            for ex in exchanges[-6:]
-        ]
-
-    summary_json = {
-        "version": 3,
-        "topic": topic,
-        "disposition": disposition,
-        "first_exchanges": first_exchanges,
-        "last_exchanges": last_exchanges,
-        "metadata": {
-            "exchange_count": exchange_count,
-            "files_modified": files,
-            "commits": commits,
-            "tool_counts": {},
-            "started_at": session.get("started_at"),
-            "ended_at": session.get("ended_at"),
-            "git_branch": session.get("git_branch"),
-        },
+    # tool_counts isn't carried on the session dict that reaches this fallback
+    # path; build_context_summary_json defaults a missing key to {}.
+    branch_row = {
+        "files_modified": session.get("files_modified", []),
+        "commits": session.get("commits", []),
+        "git_branch": session.get("git_branch"),
+        "started_at": session.get("started_at"),
+        "ended_at": session.get("ended_at"),
     }
-
+    if "exchange_count" in session:
+        branch_row["exchange_count"] = session["exchange_count"]
+    summary_json = build_context_summary_json(branch_row, session.get("messages", []))
     return render_context_summary(summary_json)
 
 

--- a/src/ccrecall/hooks/memory_setup.py
+++ b/src/ccrecall/hooks/memory_setup.py
@@ -10,7 +10,13 @@ import tempfile
 import time
 from pathlib import Path
 
-from ccrecall.db import DEFAULT_DB_PATH, get_db_connection, load_settings
+from ccrecall.db import (
+    CONTENT_ERROR_VERSION,
+    DEFAULT_DB_PATH,
+    get_db_connection,
+    load_settings,
+)
+from ccrecall.summarizer import SUMMARY_VERSION
 
 # PID files live in the same directory as the DB
 _PID_DIR = DEFAULT_DB_PATH.parent
@@ -100,7 +106,9 @@ def _needs_backfill(settings: dict | None = None) -> bool:
             conn.close()
             return False
         cursor.execute(
-            "SELECT COUNT(*) FROM branches WHERE summary_version IS NULL OR summary_version < 3"
+            "SELECT COUNT(*) FROM branches WHERE summary_version IS NULL"
+            " OR (summary_version < ? AND summary_version != ?)",
+            (SUMMARY_VERSION, CONTENT_ERROR_VERSION),
         )
         count = cursor.fetchone()[0]
         conn.close()

--- a/src/ccrecall/token_schema.py
+++ b/src/ccrecall/token_schema.py
@@ -142,26 +142,27 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
       imported_at DATETIME DEFAULT CURRENT_TIMESTAMP
     );
     """)
-    # Add data_source column if missing
+    # Add columns missing on databases created before they existed. Use an
+    # explicit existence check (not catch-and-pass on OperationalError) so the
+    # ALTER only fires when genuinely needed and a real error surfaces instead
+    # of being swallowed.
+    snap_cols = {row[1] for row in conn.execute("PRAGMA table_info(token_snapshots)")}
     for col, typedef in [
         ("data_source", "TEXT"),
         ("cache_read_tokens", "INTEGER DEFAULT 0"),
         ("cache_creation_tokens", "INTEGER DEFAULT 0"),
     ]:
-        try:
+        if col not in snap_cols:
             conn.execute(f"ALTER TABLE token_snapshots ADD COLUMN {col} {typedef}")
-        except sqlite3.OperationalError:
-            pass
-    # Add new workflow-analytics columns if missing (v2 schema)
+    # Workflow-analytics columns (v2 schema) on turn_tool_calls.
+    ttc_cols = {row[1] for row in conn.execute("PRAGMA table_info(turn_tool_calls)")}
     for col, typedef in [
         ("skill_name", "TEXT"),
         ("subagent_type", "TEXT"),
         ("agent_model", "TEXT"),
     ]:
-        try:
+        if col not in ttc_cols:
             conn.execute(f"ALTER TABLE turn_tool_calls ADD COLUMN {col} {typedef}")
-        except sqlite3.OperationalError:
-            pass
     # Create indexes for new columns (safe after ALTER TABLE)
     for idx_sql in [
         "CREATE INDEX IF NOT EXISTS idx_ttc_skill ON turn_tool_calls(skill_name)",

--- a/tests/test_context_injection.py
+++ b/tests/test_context_injection.py
@@ -526,6 +526,33 @@ class TestBuildFallbackContext:
         assert "[Tool: Bash]" not in result
         assert "Here is the content" in result
 
+    def test_long_exchange_text_truncated(self):
+        """Fallback mid-truncates long exchange text like the cached path.
+
+        Regression: the fallback used to hand-build the summary without
+        truncate_mid, injecting unbounded exchange text into the context.
+        The marker sits in the cut zone (between the kept front and back).
+        """
+        long_assistant = "HEAD" + "x" * 350 + "ZZUNIQUEZZ" + "y" * 700 + "TAIL"
+        session = {
+            "started_at": "2025-01-15T14:30:00Z",
+            "ended_at": "2025-01-15T15:00:00Z",
+            "files_modified": [],
+            "commits": [],
+            "messages": [
+                {"role": "user", "content": "go", "timestamp": "2025-01-15T14:30:00Z"},
+                {
+                    "role": "assistant",
+                    "content": long_assistant,
+                    "timestamp": "2025-01-15T14:31:00Z",
+                },
+            ],
+        }
+        result = _build_fallback_context(session)
+        assert "[... truncated ...]" in result
+        assert "ZZUNIQUEZZ" not in result
+        assert "HEAD" + "x" * 40 in result  # distinctive front run was kept
+
     def test_no_messages(self):
         session = {
             "started_at": "2025-01-15T14:30:00Z",

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -2,6 +2,7 @@
 
 import inspect
 import json
+import logging
 import sqlite3
 
 import pytest
@@ -15,7 +16,7 @@ from ccrecall.summarizer import (
     compute_context_summary,
     render_context_summary,
 )
-from ccrecall.db import SCHEMA, _migrate_columns
+from ccrecall.db import CONTENT_ERROR_VERSION, SCHEMA, _migrate_columns
 
 
 class TestTruncateMid:
@@ -618,19 +619,87 @@ class TestNeedsBackfillVersionBump:
         )
         conn.close()
 
-    def test_backfill_summaries_uses_version_3_threshold(self):
-        """Verify backfill_summaries.py source contains 'summary_version < 3' (not 2)."""
+    def test_backfill_summaries_uses_version_constants(self):
+        """backfill_summaries ties its threshold/sentinel to the shared constants.
+
+        SUMMARY_VERSION is the canonical 3 and CONTENT_ERROR_VERSION the -1
+        sentinel — using the constants (not stale literals) keeps a future
+        version bump from silently desyncing this hook.
+        """
         source = inspect.getsource(backfill_summaries)
-        assert "summary_version < 3" in source, (
-            "backfill_summaries.py must query for summary_version < 3"
+        assert "SUMMARY_VERSION" in source, (
+            "backfill_summaries.py must gate on the SUMMARY_VERSION constant"
         )
-        assert "summary_version = 3" in source, (
-            "backfill_summaries.py must write summary_version = 3"
+        assert "CONTENT_ERROR_VERSION" in source, (
+            "backfill_summaries.py must use the CONTENT_ERROR_VERSION sentinel"
         )
 
-    def test_memory_setup_uses_version_3_threshold(self):
-        """Verify memory_setup.py _needs_backfill uses 'summary_version < 3' (not 2)."""
+    def test_memory_setup_uses_version_constant(self):
+        """_needs_backfill ties its threshold to SUMMARY_VERSION, not a literal."""
         source = inspect.getsource(memory_setup._needs_backfill)
-        assert "summary_version < 3" in source, (
-            "_needs_backfill() must check for summary_version < 3"
+        assert "SUMMARY_VERSION" in source, (
+            "_needs_backfill() must check against the SUMMARY_VERSION constant"
         )
+
+
+class TestBackfillErrorHandling:
+    """backfill_summaries separates per-row content errors from infra failures."""
+
+    STARTING_VERSION = 2  # eligible (< SUMMARY_VERSION), not the error sentinel
+
+    def _seed(self, path):
+        conn = sqlite3.connect(str(path))
+        conn.executescript(SCHEMA)
+        conn.commit()
+        _migrate_columns(conn)
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO projects (path, key, name) VALUES (?, ?, ?)",
+            ("/test/proj", "-test-proj", "proj"),
+        )
+        cur.execute("INSERT INTO sessions (uuid, project_id) VALUES (?, ?)", ("sess-1", 1))
+        cur.execute(
+            "INSERT INTO branches (session_id, leaf_uuid, is_active, summary_version)"
+            " VALUES (1, 'leaf-1', 1, ?)",
+            (self.STARTING_VERSION,),
+        )
+        conn.commit()
+        conn.close()
+
+    def _run_with_raise(self, path, monkeypatch, exc):
+        monkeypatch.setattr(
+            backfill_summaries, "load_settings", lambda: {"db_path": str(path)}
+        )
+        monkeypatch.setattr(
+            backfill_summaries, "setup_logging", lambda s: logging.getLogger("test-backfill")
+        )
+
+        def boom(cursor, branch_id):
+            raise exc
+
+        monkeypatch.setattr(backfill_summaries, "compute_context_summary", boom)
+        backfill_summaries._main()
+
+    def _version(self, path):
+        conn = sqlite3.connect(str(path))
+        v = conn.execute("SELECT summary_version FROM branches WHERE id = 1").fetchone()[0]
+        conn.close()
+        return v
+
+    def test_content_error_marks_sentinel(self, tmp_path, monkeypatch):
+        """A content error (ValueError) marks the row with the error sentinel and stops retrying."""
+        db = tmp_path / "c.db"
+        self._seed(db)
+        self._run_with_raise(db, monkeypatch, ValueError("malformed summary"))
+        assert self._version(db) == CONTENT_ERROR_VERSION
+
+    def test_infra_error_does_not_poison_row(self, tmp_path, monkeypatch):
+        """A transient infra error leaves the row eligible (not marked errored).
+
+        Regression: a bare ``except Exception`` used to mark the row -1 on any
+        failure, permanently poisoning it after a transient DB error.
+        """
+        db = tmp_path / "c.db"
+        self._seed(db)
+        self._run_with_raise(db, monkeypatch, sqlite3.OperationalError("database is locked"))
+        assert self._version(db) == self.STARTING_VERSION  # unchanged — still eligible


### PR DESCRIPTION
First cleanup PR after the full package clean-code review — the four **correctness-adjacent** findings (latent bugs, not style). Each is verified against the code and pinned by a test.

### Fallback context truncation
`_build_fallback_context` (the uncached SessionStart path) hand-built the summary dict **without `truncate_mid`**, so it injected *unbounded* exchange text into session context where the cached path truncates. It now delegates to the canonical `build_context_summary_json`, so the two paths can't drift — fixing the truncation gap and deleting the duplicated builder in one move.

### Summary-backfill error taxonomy
Two bugs in `backfill_summaries`:
- A bare `except Exception` marked a branch `summary_version = -1` on *any* failure, so a transient DB error (locked DB, I/O) **permanently poisoned** the row. The catch is now narrowed to content errors `(ValueError, TypeError, KeyError)`; infra errors hit an outer handler that aborts the run without marking, leaving the row eligible next time (mirrors the embeddings backfill's taxonomy).
- The eligibility SELECT didn't exclude the `-1` sentinel, so an errored branch was **re-selected forever** — the docstring's "mark -1 to avoid infinite retry" never actually held. The sentinel is now excluded (in both the runner SELECT and `_needs_backfill`'s count).

### Schema migration no longer swallows errors
`token_schema.ensure_schema` wrapped `ALTER TABLE … ADD COLUMN` in `except OperationalError: pass` — which also swallowed real errors and fired dead no-op ALTERs (the columns already exist in the current `CREATE TABLE`). Replaced with explicit `PRAGMA table_info` existence checks, matching `db.py:_migrate_columns`.

### Constants over literals
`backfill_summaries` and `memory_setup` now use the existing `SUMMARY_VERSION` / `CONTENT_ERROR_VERSION` constants instead of bare `3` / `-1`, so a future version bump can't silently desync these hooks.

---

**Notes**
- Sentinel-exclusion queries use the version-portable `summary_version != ?` form (with explicit `IS NULL`) rather than `IS NOT ?`, avoiding the SQLite 3.38 floor on parameterized `IS NOT` — safe across all deployment machines.
- Tests: fallback truncation pin, plus content-error-marks-sentinel and infra-error-doesn't-poison. 579 pass, ruff clean.
- Reviewers (code/integration/wtf) run; integration **APPROVE**, the one HIGH (SQLite `IS NOT ?` floor) resolved via the portable form.
- Deferred to a later pass (pre-existing, out of scope): `db.py:573` `data_source` ALTER still swallows; `backfill_embeddings.py:370` hardcodes `-1` instead of the constant.
