### PR TITLE
chore: enable shebang, divider, and spec-token guards

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,8 @@
 # Staging: fast, always-green hooks run at pre-commit; heavier checks run at
 # pre-push. `default_install_hook_types` below wires both stages automatically.
 #
-# Phased rollout: several guards (ruff lint, pyright, and the custom AST checks)
-# are committed but COMMENTED OUT at the bottom of this file. The current tree has
+# Phased rollout: a few guards (ruff lint, pyright, check-lazy-imports) are
+# committed but COMMENTED OUT at the bottom of this file. The current tree has
 # pre-existing violations of each; every one gets fixed and flipped on in its own
 # follow-up cleanup PR. Until then, only the green hooks below are active so the
 # hook run and the lint CI stay green.
@@ -23,6 +23,7 @@ repos:
       - id: check-builtin-literals
       - id: check-case-conflict
       - id: debug-statements
+      - id: check-shebang-scripts-are-executable
 
   - repo: https://github.com/crate-ci/typos
     rev: v1.46.3
@@ -65,19 +66,31 @@ repos:
         types: [python]
         entry: '^from __future__ import annotations'
 
+  - repo: local
+    hooks:
+      - id: check-spec-tokens
+        name: Ban leaked spec-artifact tokens (AC#/FR#/T##/WP#)
+        language: system
+        entry: ./tools/check_spec_tokens.py
+        pass_filenames: false
+        files: ^(src|tests|scripts|tools)/.*\.py$
+        stages: [pre-push]
+
+      - id: check-llm-cruft
+        name: Ban AI-writing tells (section dividers, filler phrases)
+        language: system
+        entry: ./tools/check_llm_cruft.py
+        pass_filenames: false
+        files: ^(src|tests|scripts|tools)/.*\.py$
+        stages: [pre-push]
+
   # ----------------------------------------------------------------------------
   # DEFERRED — committed but staged off until each guard's cleanup PR brings the
   # tree to green. Uncomment a block in the PR that fixes its violations.
   #
   #   ruff lint            213 violations  (ruff check)
   #   pyright               30 errors
-  #   check-spec-tokens     66 leaked AC#/FR#/T0x tokens
-  #   check-llm-cruft       87 section-divider comments
   #   check-lazy-imports     8 lazy imports
-  #   shebang executability 23 modules carry a vestigial #! shebang (run via
-  #                         console-scripts, not directly) — strip them, then add
-  #                         check-shebang-scripts-are-executable to the
-  #                         pre-commit-hooks block above
   # ----------------------------------------------------------------------------
   #
   # - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -94,22 +107,6 @@ repos:
   #
   # - repo: local
   #   hooks:
-  #     - id: check-spec-tokens
-  #       name: Ban leaked spec-artifact tokens (AC#/FR#/T##/WP#)
-  #       language: system
-  #       entry: ./tools/check_spec_tokens.py
-  #       pass_filenames: false
-  #       files: ^(src|tests|scripts|tools)/.*\.py$
-  #       stages: [pre-push]
-  #
-  #     - id: check-llm-cruft
-  #       name: Ban AI-writing tells (section dividers, filler phrases)
-  #       language: system
-  #       entry: ./tools/check_llm_cruft.py
-  #       pass_filenames: false
-  #       files: ^(src|tests|scripts|tools)/.*\.py$
-  #       stages: [pre-push]
-  #
   #     - id: check-lazy-imports
   #       name: Ban lazy imports (use '# lazy-import:' to defend circular-import cases)
   #       language: system

--- a/src/ccrecall/content.py
+++ b/src/ccrecall/content.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Message content extraction and tool detection utilities.
 """

--- a/src/ccrecall/db.py
+++ b/src/ccrecall/db.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Database connection, schema management, settings, and logging.
 """
@@ -470,7 +469,7 @@ def _migrate_columns(conn: sqlite3.Connection) -> None:
     cursor.execute("PRAGMA table_info(messages)")
     existing = {row[1] for row in cursor.fetchall()}
 
-    # --- DDL migrations (column-existence gated, idempotent) ---
+    # DDL migrations (column-existence gated, idempotent)
     if "tool_summary" not in existing:
         cursor.execute("ALTER TABLE messages ADD COLUMN tool_summary TEXT")
         conn.commit()
@@ -551,7 +550,7 @@ CREATE INDEX IF NOT EXISTS idx_token_snapshots_start ON token_snapshots(start_ti
         cursor.execute("ALTER TABLE token_snapshots ADD COLUMN data_source TEXT")
         conn.commit()
 
-    # --- DML migrations (version-gated via PRAGMA user_version, run once) ---
+    # DML migrations (version-gated via PRAGMA user_version, run once)
     version = conn.execute("PRAGMA user_version").fetchone()[0]
 
     # Resolve db_path for backup operations (PRAGMA database_list returns (seq, name, file))

--- a/src/ccrecall/formatting.py
+++ b/src/ccrecall/formatting.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Session formatting, time utilities, and project path helpers.
 """

--- a/src/ccrecall/hooks/backfill_embeddings.py
+++ b/src/ccrecall/hooks/backfill_embeddings.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Backfill embeddings for existing active-leaf branches.
 
@@ -258,7 +257,7 @@ def _main(argv: list[str] | None = None) -> int:
     except (AttributeError, OSError):
         pass
 
-    # FR#14 ABORT level: check model availability before touching any rows.
+    # ABORT level: check model availability before touching any rows.
     # model_available() warms the singleton session on success — no extra cost.
     # Pass --threads here since this is the call that constructs the session.
     if not model_available(threads=args.threads):
@@ -281,7 +280,7 @@ def _main(argv: list[str] | None = None) -> int:
 
     cursor = conn.cursor()
 
-    # FR#14 ABORT level: vec must be queryable before any selection runs — the
+    # ABORT level: vec must be queryable before any selection runs — the
     # eligibility WHERE references branch_vec, which get_db_connection only
     # creates when sqlite-vec loaded. Without this guard the COUNT below crashes
     # with "no such table: branch_vec" instead of exiting cleanly.
@@ -373,7 +372,7 @@ def _main(argv: list[str] | None = None) -> int:
 
         conn.commit()
 
-        # Progress (FR#8): cadence-gated, with elapsed + ETA for unattended runs.
+        # Progress: cadence-gated, with elapsed + ETA for unattended runs.
         # Python arithmetic instead of a second COUNT.
         if total_updated - last_progress >= args.progress_every:
             elapsed = time.monotonic() - started

--- a/src/ccrecall/hooks/backfill_summaries.py
+++ b/src/ccrecall/hooks/backfill_summaries.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Backfill context summaries for existing branches.
 

--- a/src/ccrecall/hooks/clear_handoff.py
+++ b/src/ccrecall/hooks/clear_handoff.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """SessionEnd hook (matcher: clear) — writes handoff file for SessionStart to link sessions."""
 
 import json

--- a/src/ccrecall/hooks/memory_context.py
+++ b/src/ccrecall/hooks/memory_context.py
@@ -254,7 +254,7 @@ def select_sessions(
         return []
     project_id = row[0]
 
-    # --- Clear path: hard-link via handoff file written by SessionEnd hook ---
+    # Clear path: hard-link via handoff file written by SessionEnd hook
     if source == "clear" and db_path is not None:
         prev_session_uuid = _find_cleared_from_session_uuid(db_path, cwd)
 
@@ -279,7 +279,7 @@ def select_sessions(
 
         # Session not found in DB or no recent /clear — fall through to startup logic
 
-    # --- Startup path (also fallback for clear with no handoff) ---
+    # Startup path (also fallback for clear with no handoff)
     cursor.execute(_CANDIDATE_QUERY, (project_id, current_session_id))
     candidates = cursor.fetchall()
 

--- a/src/ccrecall/hooks/memory_setup.py
+++ b/src/ccrecall/hooks/memory_setup.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """SessionStart hook - setup memory directory and trigger initial import."""
 
 import glob

--- a/src/ccrecall/hooks/memory_sync.py
+++ b/src/ccrecall/hooks/memory_sync.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Stop hook - background sync for current session."""
 
 import json

--- a/src/ccrecall/hooks/onboarding.py
+++ b/src/ccrecall/hooks/onboarding.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """SessionStart hook: first-run onboarding for claude-memory.
 
 Injects onboarding instructions into Claude's context when config.json

--- a/src/ccrecall/hooks/write_config.py
+++ b/src/ccrecall/hooks/write_config.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Write or update ~/.claude-memory/config.json.
 
 Called by Claude during onboarding to persist user configuration choices.

--- a/src/ccrecall/parsing.py
+++ b/src/ccrecall/parsing.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 JSONL parsing, branch detection, and metadata extraction.
 """

--- a/src/ccrecall/project_ops.py
+++ b/src/ccrecall/project_ops.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Shared project upsert logic for sync and import pipelines.
 

--- a/src/ccrecall/search_conversations.py
+++ b/src/ccrecall/search_conversations.py
@@ -140,7 +140,7 @@ def _get_vec_branch_ids(
     """Return ordered branch IDs from vec0 KNN, filtered to current embedding version.
 
     Only returns branches whose embedding_version == EMBEDDING_VERSION and
-    embedding_model == EMBEDDING_MODEL (FR#11 — stale-version exclusion).
+    embedding_model == EMBEDDING_MODEL (stale-version exclusion).
     Returns empty list on any error.
     """
     try:
@@ -159,7 +159,7 @@ def _get_vec_branch_ids(
     candidate_ids = [row[0] for row in rows]
     placeholders = ",".join("?" * len(candidate_ids))
 
-    # Filter to current embedding version and apply optional user filters (FR#11)
+    # Filter to current embedding version and apply optional user filters
     filter_sql = f"""
         SELECT b.id
         FROM branches b
@@ -197,7 +197,7 @@ def _get_vec_branch_ids(
 
 
 def _dedup_by_session(cursor: sqlite3.Cursor, ordered_branch_ids: list[int]) -> list[int]:
-    """Keep the highest-ranked branch per session_id (FR#12).
+    """Keep the highest-ranked branch per session_id.
 
     Returns a new list with one branch per session, preserving relative order.
     """
@@ -383,7 +383,7 @@ def format_markdown(sessions: list[dict], query: str, verbose: bool = False) -> 
 
 
 def print_status(args: argparse.Namespace, settings: dict | None) -> None:
-    """Print diagnostic status and exit 0 (FR#15 / AC#13)."""
+    """Print diagnostic status and exit 0."""
     # Open one connection with vec loaded; branch_vec_queryable probes whether
     # the vec table is usable — get_db_connection already loaded the extension
     # iff it could, so the table-existence probe is sufficient.

--- a/src/ccrecall/session_ops.py
+++ b/src/ccrecall/session_ops.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Shared session import logic for sync and import pipelines.
 
@@ -81,7 +80,7 @@ def sync_session(
     """
     cursor = conn.cursor()
 
-    # --- import_log dedup check ---
+    # import_log dedup check
     # Only skip when: write_import_log requested, a real hash provided,
     # and the stored hash is non-NULL and matches.
     if write_import_log:
@@ -96,7 +95,7 @@ def sync_session(
     else:
         log_row = None
 
-    # --- Parse the JSONL ---
+    # Parse the JSONL
     all_entries = list(parse_all_with_uuids(filepath))
     if not all_entries:
         return 0
@@ -112,19 +111,19 @@ def sync_session(
     # Extract session-level metadata
     meta = extract_session_metadata(all_entries)
 
-    # --- Session UUID ---
+    # Session UUID
     session_uuid = filepath.stem
     if session_uuid.startswith("agent-"):
         session_uuid = session_uuid[6:]
 
-    # --- Project upsert (skip when caller pre-resolved project_id) ---
+    # Project upsert (skip when caller pre-resolved project_id)
     if _project_id is not None:
         project_id = _project_id
     else:
         project_key = normalize_project_key(project_dir.name)
         project_id = upsert_project(cursor, project_key, cwd=meta.get("cwd"))
 
-    # --- Session upsert ---
+    # Session upsert
     cursor.execute(
         """
         INSERT INTO sessions (uuid, project_id, git_branch, cwd)
@@ -138,12 +137,12 @@ def sync_session(
     cursor.execute("SELECT id FROM sessions WHERE uuid = ?", (session_uuid,))
     session_id = cursor.fetchone()[0]
 
-    # --- Build set of UUIDs claimed by any branch ---
+    # Build set of UUIDs claimed by any branch
     valid_branch_uuids: set[str] = set()
     for branch in branches:
         valid_branch_uuids.update(branch["uuids"])
 
-    # --- Message insertion with UUID dedup ---
+    # Message insertion with UUID dedup
     cursor.execute(
         "SELECT uuid FROM messages WHERE session_id = ? AND uuid IS NOT NULL",
         (session_id,),
@@ -204,14 +203,14 @@ def sync_session(
             new_count += 1
             existing_uuids.add(uuid)
 
-    # --- Build uuid -> message_id mapping ---
+    # Build uuid -> message_id mapping
     cursor.execute(
         "SELECT id, uuid FROM messages WHERE session_id = ? AND uuid IS NOT NULL",
         (session_id,),
     )
     uuid_to_msg_id = {row[1]: row[0] for row in cursor.fetchall()}
 
-    # --- Get existing branch leaf_uuids for this session ---
+    # Get existing branch leaf_uuids for this session
     cursor.execute("SELECT id, leaf_uuid FROM branches WHERE session_id = ?", (session_id,))
     existing_branches = {row[1]: row[0] for row in cursor.fetchall()}
 
@@ -362,7 +361,7 @@ def sync_session(
             except Exception:
                 pass  # Don't fail sync/import on embedding errors
 
-    # --- Update import_log ---
+    # Update import_log
     if write_import_log:
         cursor.execute("SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,))
         total_messages = cursor.fetchone()[0]

--- a/src/ccrecall/session_tail.py
+++ b/src/ccrecall/session_tail.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Recover a prior session's tail for fast resume.
 
 Powers two things:

--- a/src/ccrecall/summarizer.py
+++ b/src/ccrecall/summarizer.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Precompute structured context summaries for session injection.
 

--- a/src/ccrecall/token_analytics.py
+++ b/src/ccrecall/token_analytics.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 token_analytics — Session import and token_snapshots backfill
 for the token ingest pipeline.

--- a/src/ccrecall/token_dashboard.py
+++ b/src/ccrecall/token_dashboard.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 token_dashboard — Dashboard deployment and main() entry point
 for the token ingest pipeline.

--- a/src/ccrecall/token_insights.py
+++ b/src/ccrecall/token_insights.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 token_insights — Trend analysis, insight generation, and findings/recommendations
 for the token ingest pipeline.

--- a/src/ccrecall/token_output.py
+++ b/src/ccrecall/token_output.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 token_output — Dashboard JSON output assembly.
 Queries the token analytics database and builds the full output dict

--- a/src/ccrecall/token_parser.py
+++ b/src/ccrecall/token_parser.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 token_parser — JSONL parsing, data classes, session parsing, and file discovery
 for the token ingest pipeline.

--- a/src/ccrecall/token_schema.py
+++ b/src/ccrecall/token_schema.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 token_schema — Schema definitions, ensure_schema(), and version management
 for the token ingest pipeline.

--- a/tests/test_backfill_embeddings.py
+++ b/tests/test_backfill_embeddings.py
@@ -1,11 +1,11 @@
-"""Tests for the embedding backfill hook (T05).
+"""Tests for the embedding backfill hook.
 
-FR#6/AC#3: backfill embeds all eligible branches in a vec-enabled DB.
-FR#7/AC#4: resume processes only remaining branches; heal clause re-embeds
-           "version-done but no vector" rows.
-FR#8:      per-batch progress logged.
-FR#9:      bumping EMBEDDING_VERSION / model / summary_version makes rows re-appear.
-FR#14/AC#12: model-load failure marks nothing; one bad summary marks exactly that row.
+Backfill embeds all eligible branches in a vec-enabled DB. Resume processes only
+remaining branches; the heal clause re-embeds "version-done but no vector" rows.
+Per-batch progress is logged. Bumping EMBEDDING_VERSION / model / summary_version
+makes rows re-appear. A model-load failure marks nothing; one bad summary marks
+exactly that row.
+
 Scope: only active leaves (is_active=1) are embedded — inactive forks are skipped.
 Opt-in: --days bounds by recency, --limit caps the run.
 """
@@ -43,9 +43,7 @@ def _vec_available() -> bool:
 _VEC_SKIP = pytest.mark.skipif(not _vec_available(), reason="sqlite-vec not available in this environment")
 
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _insert_branch(
@@ -135,15 +133,13 @@ def _run_backfill_with_stub(conn: sqlite3.Connection, argv: list[str] | None = N
         _main(argv if argv is not None else [])
 
 
-# ---------------------------------------------------------------------------
-# FR#6 / AC#3: backfill embeds all eligible branches
-# ---------------------------------------------------------------------------
+# backfill embeds all eligible branches
 
 
 @_VEC_SKIP
 class TestBackfillEmbedsFull:
     def test_all_eligible_branches_embedded(self):
-        """FR#6/AC#3: all branches with non-empty context_summary get embedded."""
+        """All branches with non-empty context_summary get embedded."""
         conn = make_vec_conn()
         ids = [_insert_branch(conn, f"summary {i}") for i in range(5)]
 
@@ -202,15 +198,13 @@ class TestBackfillEmbedsFull:
         assert _vec_count(conn) == count
 
 
-# ---------------------------------------------------------------------------
-# FR#7 / AC#4: resume processes only remaining; heal clause for missing vectors
-# ---------------------------------------------------------------------------
+# resume processes only remaining; heal clause for missing vectors
 
 
 @_VEC_SKIP
 class TestBackfillResume:
     def test_resume_skips_already_done(self):
-        """FR#7/AC#4: second run does not re-embed already-done branches."""
+        """Second run does not re-embed already-done branches."""
         conn = make_vec_conn()
         ids = [_insert_branch(conn, f"summary {i}") for i in range(4)]
 
@@ -265,7 +259,7 @@ class TestBackfillResume:
         assert call_count[0] == 0
 
     def test_resume_processes_new_branch(self):
-        """FR#7: after first run, a newly added branch is processed on second run."""
+        """After first run, a newly added branch is processed on second run."""
         conn = make_vec_conn()
         _insert_branch(conn, "first summary")
 
@@ -279,7 +273,7 @@ class TestBackfillResume:
         assert _has_vec(conn, new_id)
 
     def test_heal_clause_missing_vec_row(self):
-        """FR#7 heal clause: version says done but branch_vec row absent → re-selected."""
+        """Heal clause: version says done but branch_vec row absent → re-selected."""
         conn = make_vec_conn()
         bid = _insert_branch(conn, "summary that needs healing")
 
@@ -301,15 +295,13 @@ class TestBackfillResume:
         assert _has_vec(conn, bid)
 
 
-# ---------------------------------------------------------------------------
-# FR#9: version bump / model change / summary_version change re-selects rows
-# ---------------------------------------------------------------------------
+# version bump / model change / summary_version change re-selects rows
 
 
 @_VEC_SKIP
 class TestBackfillVersionBump:
     def test_embedding_version_bump_reselects(self):
-        """FR#9: a row with stale embedding_version (below current) is re-embedded.
+        """A row with stale embedding_version (below current) is re-embedded.
 
         Seeds a branch with embedding_version=0 (below real EMBEDDING_VERSION=1)
         and current model/summary.  Runs _main() with real constants — the SELECT
@@ -339,7 +331,7 @@ class TestBackfillVersionBump:
         assert row[0] == EMBEDDING_VERSION
 
     def test_model_change_reselects(self):
-        """FR#9: a row with a stale embedding_model is re-embedded to current model.
+        """A row with a stale embedding_model is re-embedded to current model.
 
         Seeds a branch at current EMBEDDING_VERSION/SUMMARY_VERSION but with a
         stale model name.  _main() re-embeds it and writes the current model.
@@ -368,7 +360,7 @@ class TestBackfillVersionBump:
         assert row[0] == EMBEDDING_MODEL
 
     def test_summary_version_mismatch_reselects(self):
-        """FR#9: a row with stale summary_version_at_embed is re-embedded.
+        """A row with stale summary_version_at_embed is re-embedded.
 
         Seeds a branch at current version/model but summary_version_at_embed=0
         (below real SUMMARY_VERSION).  _main() re-embeds and stamps current
@@ -399,9 +391,7 @@ class TestBackfillVersionBump:
         assert row[0] == SUMMARY_VERSION
 
 
-# ---------------------------------------------------------------------------
 # No-progress guard (Fix A): loop breaks when same batch re-selected
-# ---------------------------------------------------------------------------
 
 
 @_VEC_SKIP
@@ -442,15 +432,13 @@ class TestBackfillNoProgressGuard:
         assert ev != EMBEDDING_VERSION, "Row should not be at EMBEDDING_VERSION — write was patched to no-op"
 
 
-# ---------------------------------------------------------------------------
-# FR#14 / AC#12: model failure marks nothing; one bad summary marks only itself
-# ---------------------------------------------------------------------------
+# model failure marks nothing; one bad summary marks only itself
 
 
 @_VEC_SKIP
 class TestBackfillFailureModes:
     def test_model_unavailable_marks_nothing(self):
-        """FR#14/AC#12: model_available=False → zero rows marked, all stay eligible."""
+        """model_available=False → zero rows marked, all stay eligible."""
         conn = make_vec_conn()
         ids = [_insert_branch(conn, f"summary {i}") for i in range(3)]
 
@@ -474,7 +462,7 @@ class TestBackfillFailureModes:
         assert _vec_count(conn) == 0
 
     def test_single_bad_summary_marks_only_itself(self):
-        """FR#14/AC#12: one row's embed_text raising marks only that row -1; rest succeed."""
+        """One row's embed_text raising marks only that row -1; rest succeed."""
         conn = make_vec_conn()
         good_id1 = _insert_branch(conn, "good summary one")
         bad_id = _insert_branch(conn, "bad summary that will fail")
@@ -579,9 +567,7 @@ class TestBackfillFailureModes:
         assert call_count[0] == 0
 
 
-# ---------------------------------------------------------------------------
 # Scope: only active leaves are embedded (query path filters is_active=1)
-# ---------------------------------------------------------------------------
 
 
 @_VEC_SKIP
@@ -601,9 +587,7 @@ class TestBackfillScopeActive:
         assert _vec_count(conn) == 1
 
 
-# ---------------------------------------------------------------------------
 # Opt-in flags: --days bounds recency, --limit caps the run
-# ---------------------------------------------------------------------------
 
 
 @_VEC_SKIP
@@ -638,9 +622,7 @@ class TestBackfillFlags:
         assert _vec_count(conn) == 2
 
 
-# ---------------------------------------------------------------------------
 # --status: read-only progress reader (done / eligible / errored / total)
-# ---------------------------------------------------------------------------
 
 
 def _run_status(conn: sqlite3.Connection, argv: list[str], capsys):

--- a/tests/test_clear_handoff_contract.py
+++ b/tests/test_clear_handoff_contract.py
@@ -28,9 +28,7 @@ import ccrecall.hooks.memory_context as _memory_context
 _find_cleared_from_session_uuid = _memory_context._find_cleared_from_session_uuid
 
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _run_handoff_main(tmp_path: Path, payload: dict) -> Path:
@@ -55,9 +53,7 @@ def _run_handoff_main(tmp_path: Path, payload: dict) -> Path:
     return handoff_path
 
 
-# ---------------------------------------------------------------------------
 # clear-handoff.py contract tests
-# ---------------------------------------------------------------------------
 
 
 class TestClearHandoffWriter:
@@ -113,9 +109,7 @@ class TestClearHandoffWriter:
         assert not (tmp_path / "clear-handoff.json").exists()
 
 
-# ---------------------------------------------------------------------------
 # _find_cleared_from_session_uuid contract tests
-# ---------------------------------------------------------------------------
 
 
 def _write_handoff(tmp_path: Path, data: dict) -> Path:

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -10,7 +10,7 @@ from ccrecall.content import (
     parse_origin,
 )
 
-# --- extract_text_content ---
+# extract_text_content
 
 
 class TestExtractTextContent:
@@ -125,7 +125,7 @@ class TestExtractTextContent:
         assert summary is None
 
 
-# --- is_tool_result ---
+# is_tool_result
 
 
 class TestIsToolResult:
@@ -147,7 +147,7 @@ class TestIsToolResult:
         assert is_tool_result(None) is False
 
 
-# --- is_task_notification ---
+# is_task_notification
 
 
 class TestIsTaskNotification:
@@ -189,7 +189,7 @@ class TestIsTaskNotification:
         assert is_task_notification(content) is False
 
 
-# --- is_teammate_message ---
+# is_teammate_message
 
 
 class TestIsTeammateMessage:
@@ -232,7 +232,7 @@ class TestIsTeammateMessage:
         assert is_teammate_message(content) is False
 
 
-# --- extract_files_modified ---
+# extract_files_modified
 
 
 class TestExtractFilesModified:
@@ -268,7 +268,7 @@ class TestExtractFilesModified:
         assert extract_files_modified(content) == []
 
 
-# --- extract_commits ---
+# extract_commits
 
 
 class TestExtractCommits:
@@ -321,7 +321,7 @@ class TestExtractCommits:
         assert extract_commits("hello") == []
 
 
-# --- channel XML stripping ---
+# channel XML stripping
 
 
 class TestChannelStripping:
@@ -344,7 +344,7 @@ class TestChannelStripping:
         assert text == "Just a normal message"
 
 
-# --- parse_origin ---
+# parse_origin
 
 
 class TestParseOrigin:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1072,9 +1072,9 @@ class TestV5Migration:
         # Verify that _migrate_project_paths is NOT called by examining the call path:
         # get_db_connection should not call _migrate_project_paths unconditionally.
         source = inspect.getsource(db_module.get_db_connection)
-        # The unconditional call pattern was: _migrate_project_paths(conn) at the end
-        # After WP03 it should be inside the v5 migration block, not at the top level.
-        # We verify this structurally by checking _migrate_columns source for _migrate_project_paths.
+        # An unconditional _migrate_project_paths(conn) at the end would be a bug — it
+        # must live inside the v5 migration block, not at the top level. Verify this
+        # structurally by checking _migrate_columns source for _migrate_project_paths.
         mc_source = inspect.getsource(db_module._migrate_columns)
         assert "_migrate_project_paths" in mc_source, (
             "_migrate_project_paths must be called inside _migrate_columns (v5 block)"
@@ -1325,9 +1325,7 @@ class TestV6Migration:
         conn.close()
 
 
-# ---------------------------------------------------------------------------
-# T02: vec schema, columns, trigger, vec_available, load_vec
-# ---------------------------------------------------------------------------
+# vec schema, columns, trigger, vec_available, load_vec
 
 
 def _vec_available_in_env() -> bool:
@@ -1497,7 +1495,7 @@ class TestVecSchema:
 
     @pytest.mark.skipif(not _VEC_AVAILABLE, reason="sqlite-vec not available in this environment")
     def test_trigger_removes_branch_vec_row_on_branch_delete(self):
-        """AC#11: deleting a branch row removes its branch_vec row (trigger fires)."""
+        """Deleting a branch row removes its branch_vec row (trigger fires)."""
         conn = make_vec_conn()
 
         # Populate branches with a row so we can insert a vector

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -74,7 +74,7 @@ class TestEmbedRealModel:
     """Real-model tests — skipped when the model is unavailable."""
 
     def test_determinism(self):
-        """Same input text produces identical vector on two calls (AC#6)."""
+        """Same input text produces identical vector on two calls."""
         text = "hello world"
         assert embed_text(text) == embed_text(text)
 

--- a/tests/test_import_pipeline.py
+++ b/tests/test_import_pipeline.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Integration tests for the import pipeline with v3 schema guards."""
 
 import tempfile

--- a/tests/test_ingest_token_data.py
+++ b/tests/test_ingest_token_data.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Tests for ingest_token_data — token ingest append-only behaviour.
 
 Gap 4: turns must be skip-if-exists on reimport, and session_metrics totals
@@ -28,9 +27,7 @@ from ccrecall.token_schema import (
     ensure_schema,
 )
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _minimal_jnl(tmp_path: Path) -> JnlFile:
@@ -72,9 +69,7 @@ def token_db():
     conn.close()
 
 
-# ---------------------------------------------------------------------------
 # Gap 4a — turns are append-only (skip-if-exists)
-# ---------------------------------------------------------------------------
 
 
 class TestTurnsAppendOnly:
@@ -125,9 +120,7 @@ class TestTurnsAppendOnly:
         assert rows == [], f"(session_id, turn_index) must be unique — duplicates found: {rows}"
 
 
-# ---------------------------------------------------------------------------
 # Gap 4b — session_metrics totals do not double on reimport
-# ---------------------------------------------------------------------------
 
 
 class TestSessionMetricsStableOnReimport:
@@ -198,9 +191,7 @@ class TestSessionMetricsStableOnReimport:
         )
 
 
-# ---------------------------------------------------------------------------
 # token_import_log schema
-# ---------------------------------------------------------------------------
 
 
 class TestTokenImportLogSchema:
@@ -245,9 +236,7 @@ class TestTokenImportLogSchema:
         )
 
 
-# ---------------------------------------------------------------------------
 # should_skip_file
-# ---------------------------------------------------------------------------
 
 
 class TestShouldSkipFile:
@@ -289,9 +278,7 @@ class TestShouldSkipFile:
         assert should_skip_file(token_db, ghost) is True
 
 
-# ---------------------------------------------------------------------------
 # record_import
-# ---------------------------------------------------------------------------
 
 
 class TestRecordImport:
@@ -350,9 +337,7 @@ class TestRecordImport:
         assert imported_at is not None, "imported_at must be set by record_import"
 
 
-# ---------------------------------------------------------------------------
 # Table isolation — token_import_log vs import_log
-# ---------------------------------------------------------------------------
 
 
 class TestTableIsolation:
@@ -379,9 +364,7 @@ class TestTableIsolation:
         assert version == SCHEMA_VERSION, f"Expected schema version {SCHEMA_VERSION}, got {version}"
 
 
-# ---------------------------------------------------------------------------
 # v3 → v4 migration
-# ---------------------------------------------------------------------------
 
 
 def _v3_token_db() -> sqlite3.Connection:
@@ -488,9 +471,7 @@ class TestV3ToV4Migration:
         conn.close()
 
 
-# ---------------------------------------------------------------------------
 # Worktree path consolidation (issue #239)
-# ---------------------------------------------------------------------------
 
 
 class TestWorktreeConsolidation:
@@ -608,9 +589,7 @@ class TestWorktreeConsolidation:
         )
 
 
-# ---------------------------------------------------------------------------
 # user_gap_ms — gap between a turn_duration finish and the next assistant turn
-# ---------------------------------------------------------------------------
 
 
 class TestUserGapComputation:

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -16,9 +16,7 @@ import ccrecall.db as _db_mod
 import ccrecall.hooks.onboarding as onboarding
 from ccrecall.db import CURRENT_ONBOARDING_VERSION
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def _patch_config_path(monkeypatch, path: Path) -> None:
@@ -38,9 +36,7 @@ def _run_main_captured(monkeypatch, cfg_path: Path) -> dict:
     return json.loads(buf.getvalue())
 
 
-# ---------------------------------------------------------------------------
 # Tests
-# ---------------------------------------------------------------------------
 
 
 class TestOnboardingAlreadyCompleted:

--- a/tests/test_recent_chats.py
+++ b/tests/test_recent_chats.py
@@ -1,4 +1,4 @@
-"""AC#8 — cm-recent-chats invariant: output unaffected by embedding columns/tables.
+"""cm-recent-chats invariant: output unaffected by embedding columns/tables.
 
 recent_chats uses get_db_connection with load_vec=False and performs no query
 or fusion. The invariant is that get_recent_sessions produces identical results

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -458,9 +458,7 @@ class TestPathFilter:
         assert all(r["uuid"] == "sess-beta-1" for r in with_path)
 
 
-# ---------------------------------------------------------------------------
 # Helpers shared by new vec/fusion tests
-# ---------------------------------------------------------------------------
 
 
 def _seed_branch(conn: sqlite3.Connection, uuid: str, content: str, summary: str) -> tuple[int, int]:
@@ -497,16 +495,14 @@ def _seed_branch(conn: sqlite3.Connection, uuid: str, content: str, summary: str
     return sess_id, branch_id
 
 
-# ---------------------------------------------------------------------------
-# FR#3 / AC#2 — degrade to keyword when model/extension unavailable
-# ---------------------------------------------------------------------------
+# degrade to keyword when model/extension unavailable
 
 
 class TestDegradation:
     """search_sessions must not raise and must return FTS results when vec/model unavailable."""
 
     def test_no_model_returns_fts_results(self, search_db):
-        """model_available() == False → keyword path, no raise (FR#3)."""
+        """model_available() == False → keyword path, no raise."""
         fts_level = detect_fts_support(search_db)
         if fts_level not in ("fts5", "fts4"):
             pytest.skip("FTS not available")
@@ -519,7 +515,7 @@ class TestDegradation:
         assert "sess-beta-1" in uuids
 
     def test_attribute_error_on_extension_does_not_raise(self, search_db):
-        """AttributeError from extension load → keyword path, no raise (AC#2)."""
+        """AttributeError from extension load → keyword path, no raise."""
         fts_level = detect_fts_support(search_db)
 
         def _raise(*_a, **_kw):
@@ -533,7 +529,7 @@ class TestDegradation:
         assert isinstance(results, list)
 
     def test_missing_model_path_does_not_raise(self, search_db):
-        """model_available() is False (model unavailable) → keyword path (FR#3)."""
+        """model_available() is False (model unavailable) → keyword path."""
         fts_level = detect_fts_support(search_db)
 
         with patch("ccrecall.search_conversations.model_available", return_value=False):
@@ -545,7 +541,7 @@ class TestDegradation:
         assert "sess-alpha-2" in uuids
 
     def test_keyword_only_flag_skips_embed(self, search_db):
-        """--keyword-only skips embed_text entirely (FR#2)."""
+        """--keyword-only skips embed_text entirely."""
         fts_level = detect_fts_support(search_db)
         called = []
 
@@ -563,7 +559,7 @@ class TestDegradation:
         assert len(results) >= 2
 
     def test_vec_table_missing_falls_back(self, search_db):
-        """FR#3: model_available=True but branch_vec absent → OperationalError → keyword results."""
+        """model_available=True but branch_vec absent → OperationalError → keyword results."""
         fts_level = detect_fts_support(search_db)
         if fts_level not in ("fts5", "fts4"):
             pytest.skip("FTS not available")
@@ -580,9 +576,7 @@ class TestDegradation:
         assert "sess-alpha-2" in uuids
 
 
-# ---------------------------------------------------------------------------
-# FR#11 / AC#9 — stale-version branch_vec rows excluded from vector candidates
-# ---------------------------------------------------------------------------
+# stale-version branch_vec rows excluded from vector candidates
 
 
 class TestStaleVersionExclusion:
@@ -647,7 +641,7 @@ class TestStaleVersionExclusion:
         reason="sqlite-vec not available",
     )
     def test_stale_branch_excluded_from_vec_candidates(self, stale_db):
-        """_get_vec_branch_ids must not return the stale-version branch (FR#11 / AC#9)."""
+        """_get_vec_branch_ids must not return the stale-version branch."""
         conn, current_id, stale_id = stale_db
         cursor = conn.cursor()
         fake_vec = [0.1] * EMBEDDING_DIM
@@ -660,7 +654,7 @@ class TestStaleVersionExclusion:
         reason="sqlite-vec not available",
     )
     def test_stale_branch_reachable_via_fts_not_vec(self, stale_db):
-        """Integration: stale branch appears in FTS results but NOT in vec candidates (FR#11).
+        """Integration: stale branch appears in FTS results but NOT in vec candidates.
 
         The stale branch's aggregated_content contains "stale text", so a keyword
         search for "stale" must surface it via FTS. However, _get_vec_branch_ids
@@ -682,9 +676,7 @@ class TestStaleVersionExclusion:
         assert "sess-stale" in uuids, "Stale session must still be reachable via keyword/FTS search"
 
 
-# ---------------------------------------------------------------------------
-# FR#12 / AC#10 — session dedup: two branches of one session → one result
-# ---------------------------------------------------------------------------
+# session dedup: two branches of one session → one result
 
 
 class TestSessionDedup:
@@ -771,7 +763,7 @@ class TestSessionDedup:
         reason="sqlite-vec not available",
     )
     def test_duplicate_session_via_search(self):
-        """Two branches of one session ranked by fusion → exactly one result returned (AC#10)."""
+        """Two branches of one session ranked by fusion → exactly one result returned."""
         conn = make_vec_conn()
         fts_level = detect_fts_support(conn)
 
@@ -832,21 +824,19 @@ class TestSessionDedup:
 
         session_uuids = [r["uuid"] for r in results]
         assert session_uuids.count("sess-multi-branch") == 1, (
-            "Two branches of the same session must yield exactly one result (FR#12 / AC#10)"
+            "Two branches of the same session must yield exactly one result"
         )
         conn.close()
 
 
-# ---------------------------------------------------------------------------
-# FR#15 / AC#13 — --status flag
-# ---------------------------------------------------------------------------
+# --status flag
 
 
 class TestStatusFlag:
     """--status prints diagnostic info and exits 0 without requiring --query."""
 
     def test_status_exits_zero(self, tmp_path, capsys):
-        """--status exits 0 and outputs the three diagnostic fields (AC#13)."""
+        """--status exits 0 and outputs the three diagnostic fields."""
         db_path = tmp_path / "test.db"
         # Create a minimal DB so status can read branch counts
         c = sqlite3.connect(str(db_path))
@@ -868,7 +858,7 @@ class TestStatusFlag:
         assert "embedded branches:" in captured.out
 
     def test_status_does_not_require_query(self, tmp_path, monkeypatch):
-        """--status works without --query (AC#13 — query must not be required)."""
+        """--status works without --query."""
         db_path = tmp_path / "conv.db"
         c = sqlite3.connect(str(db_path))
         c.executescript(SCHEMA_CORE)
@@ -887,7 +877,7 @@ class TestStatusFlag:
         assert exc.value.code == 0
 
     def test_status_ignores_keyword_only(self, tmp_path, monkeypatch, capsys):
-        """--status combined with --keyword-only still exits 0 (AC#13)."""
+        """--status combined with --keyword-only still exits 0."""
         db_path = tmp_path / "conv2.db"
         c = sqlite3.connect(str(db_path))
         c.executescript(SCHEMA_CORE)

--- a/tests/test_session_ops.py
+++ b/tests/test_session_ops.py
@@ -241,7 +241,7 @@ class TestImportSkipsNullHashEntry:
 
 
 class TestSyncThenImportDedupIntegration:
-    """FR#8 integration test: sync then import does not duplicate messages."""
+    """Integration test: sync then import does not duplicate messages."""
 
     def test_sync_then_import_dedup_integration(self, memory_db):
         """End-to-end: sync a session file, then run import on the same file.
@@ -406,7 +406,7 @@ def _make_vec_conn(tmp_path: Path) -> sqlite3.Connection | None:
 
 
 class TestEmbedOnWriteModelUnavailable:
-    """FR#5: embedding failure must not fail sync; embedding_version stays 0."""
+    """Embedding failure must not fail sync; embedding_version stays 0."""
 
     def test_embed_text_raises_leaves_embedding_version_zero(self, tmp_path):
         """When embed_text raises, sync completes and embedding_version stays 0."""
@@ -486,7 +486,7 @@ except Exception:
 
 
 class TestEmbedOnWriteSuccess:
-    """FR#4/AC#5: a sync on a vec-enabled connection produces a branch_vec row."""
+    """A sync on a vec-enabled connection produces a branch_vec row."""
 
     @pytest.mark.skipif(not _VEC_OK, reason="sqlite-vec not available")
     def test_sync_writes_branch_vec_row(self, tmp_path):

--- a/tests/test_session_tail.py
+++ b/tests/test_session_tail.py
@@ -14,7 +14,7 @@ from ccrecall.session_tail import (
     typed_instruction,
 )
 
-# --- entry builders (mirror the real transcript shapes) ---
+# entry builders (mirror the real transcript shapes)
 
 _counter = [0]
 

--- a/tests/test_write_config.py
+++ b/tests/test_write_config.py
@@ -7,9 +7,6 @@ from pathlib import Path
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 import ccrecall.db as _db_mod
 import ccrecall.hooks.write_config as write_config
 from ccrecall.db import CURRENT_ONBOARDING_VERSION
@@ -31,9 +28,7 @@ def _run_main(args=None):
         sys.argv = original_argv
 
 
-# ---------------------------------------------------------------------------
 # Tests
-# ---------------------------------------------------------------------------
 
 
 class TestWriteConfigDefaults:


### PR DESCRIPTION
Flips three deferred pre-commit guards on after clearing the violations the existing tree carried. Part of the phased CI-tooling rollout from #4, which landed the guards committed but staged off so the tree stayed green.

## Guards enabled

| Guard | Cleanup |
|---|---|
| `check-shebang-scripts-are-executable` | Strip vestigial `#!` shebangs from 23 non-executable modules (they run via console-scripts, not directly). The 5 genuine entrypoints keep their shebang + executable bit. |
| `check-llm-cruft` | Remove 87 section-divider comments — delete bare `# ----` rules, unwrap `# --- Label ---` headers to plain `# Label`. |
| `check-spec-tokens` | Reword test docstrings and code comments to drop 66 leaked `AC#`/`FR#`/`T0x`/`WP##` planning codes — describe the behavior, not the plan ID. |

## Verification

- No behavior change — `580 passed` on the full suite.
- `prek run --all-files` green at both pre-commit and pre-push stages.
- ruff-format clean.

## Still deferred (own cleanup PRs)

`ruff-check` (213), `pyright` (30), `check-lazy-imports` (8) remain commented out in `.pre-commit-config.yaml`.