### PR TITLE
chore: enable check-lazy-imports guard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,8 @@
 # Staging: fast, always-green hooks run at pre-commit; heavier checks run at
 # pre-push. `default_install_hook_types` below wires both stages automatically.
 #
-# Phased rollout: a few guards (ruff lint, pyright, check-lazy-imports) are
-# committed but COMMENTED OUT at the bottom of this file. The current tree has
+# Phased rollout: two guards (ruff lint, pyright) are committed but COMMENTED
+# OUT at the bottom of this file. The current tree has
 # pre-existing violations of each; every one gets fixed and flipped on in its own
 # follow-up cleanup PR. Until then, only the green hooks below are active so the
 # hook run and the lint CI stay green.
@@ -84,13 +84,20 @@ repos:
         files: ^(src|tests|scripts|tools)/.*\.py$
         stages: [pre-push]
 
+      - id: check-lazy-imports
+        name: Ban lazy imports (use '# lazy-import:' to defend circular-import cases)
+        language: system
+        entry: ./tools/check_lazy_imports.py
+        pass_filenames: false
+        files: ^(src|tests|scripts|tools)/.*\.py$
+        stages: [pre-push]
+
   # ----------------------------------------------------------------------------
   # DEFERRED — committed but staged off until each guard's cleanup PR brings the
   # tree to green. Uncomment a block in the PR that fixes its violations.
   #
   #   ruff lint            213 violations  (ruff check)
   #   pyright               30 errors
-  #   check-lazy-imports     8 lazy imports
   # ----------------------------------------------------------------------------
   #
   # - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -103,14 +110,4 @@ repos:
   #   rev: v1.1.408
   #   hooks:
   #     - id: pyright
-  #       stages: [pre-push]
-  #
-  # - repo: local
-  #   hooks:
-  #     - id: check-lazy-imports
-  #       name: Ban lazy imports (use '# lazy-import:' to defend circular-import cases)
-  #       language: system
-  #       entry: ./tools/check_lazy_imports.py
-  #       pass_filenames: false
-  #       files: ^(src|tests|scripts|tools)/.*\.py$
   #       stages: [pre-push]

--- a/scripts/embedding_eval/recall_harness.py
+++ b/scripts/embedding_eval/recall_harness.py
@@ -26,6 +26,10 @@ import time
 from pathlib import Path
 
 import numpy as np
+import sqlite_vec
+from fastembed import TextEmbedding
+
+from ccrecall import embeddings
 
 DB_PATH = Path.home() / ".claude-memory" / "conversations.db"
 OUT_DIR = Path(__file__).resolve().parent
@@ -181,8 +185,6 @@ def embed_with_progress(model, texts: list[str], batch_size: int, label: str) ->
 def embed_fastembed(
     model_cfg: dict, docs: list[str], queries: list[str], batch_size: int, threads: int | None, cuda: bool
 ) -> tuple[np.ndarray, np.ndarray]:
-    from fastembed import TextEmbedding
-
     # batch_size must stay small: attention memory scales as batch * heads * seq^2,
     # and these summaries reach ~3000 tokens, so fastembed's default batch of 256
     # tries to allocate ~73 GB and OOMs. CPU-safe batch is 2; an 8 GB GPU fits ~4.
@@ -208,8 +210,6 @@ def load_stored_bge_vectors(conn: sqlite3.Connection, corpus_ids: list[int]) -> 
     single-threaded pass that thrashed the VPS overnight). Only queries are
     embedded live.
     """
-    import sqlite_vec
-
     conn.enable_load_extension(True)
     sqlite_vec.load(conn)
     rows = conn.execute("SELECT branch_id, embedding FROM branch_vec").fetchall()
@@ -221,8 +221,6 @@ def load_stored_bge_vectors(conn: sqlite3.Connection, corpus_ids: list[int]) -> 
 
 
 def embed_bge_m3(conn: sqlite3.Connection, corpus_ids: list[int], queries: list[str]) -> tuple[np.ndarray, np.ndarray]:
-    from ccrecall import embeddings
-
     if not embeddings.model_available():
         raise RuntimeError("bge-m3 weights not in HF cache; baseline unavailable")
     doc_emb = load_stored_bge_vectors(conn, corpus_ids)

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1,5 +1,7 @@
 """Tests for ccrecall.content — message content extraction and tool detection."""
 
+import json
+
 from ccrecall.content import (
     extract_commits,
     extract_files_modified,
@@ -64,8 +66,6 @@ class TestExtractTextContent:
         assert text == "Let me check."
         assert has_tool is True
         assert summary is not None
-        import json
-
         counts = json.loads(summary)
         assert counts == {"Read": 2, "Bash": 1}
 
@@ -90,8 +90,6 @@ class TestExtractTextContent:
         assert text == "Here's what I found."
         assert has_tool is True
         assert has_think is True
-        import json
-
         assert json.loads(summary) == {"Grep": 1}
 
     def test_list_with_tool_use_no_name(self):

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,6 +1,7 @@
 """Tests for ccrecall.formatting — time formatting, project paths, session rendering."""
 
 import re
+from pathlib import Path
 
 from ccrecall.formatting import (
     extract_project_name,
@@ -132,8 +133,6 @@ class TestProjectKey:
 
     def test_normalize_cwd_project_name_is_base(self):
         """After normalize_cwd, Path().name should be the base repo name, not the worktree name."""
-        from pathlib import Path
-
         wt = "/Users/sam/repos/myproject/.claude/worktrees/feat"
         assert Path(normalize_cwd(wt)).name == "myproject"
 

--- a/tests/test_import_pipeline.py
+++ b/tests/test_import_pipeline.py
@@ -1,5 +1,6 @@
 """Integration tests for the import pipeline with v3 schema guards."""
 
+import shutil
 import tempfile
 from pathlib import Path
 
@@ -361,8 +362,6 @@ class TestImportProject:
 
             # Copy a fixture into it; the fixture has cwd="/Users/samarthgupta/repos/forks/node-banana"
             # so project_name will be "node-banana" (derived from real cwd, not directory key)
-            import shutil
-
             shutil.copy(FIXTURE_DIR / "linear_3_exchange.jsonl", project_dir / "session1.jsonl")
 
             sessions, messages, skipped = import_project(memory_db, project_dir, exclude_projects=["node-banana"])
@@ -376,8 +375,6 @@ class TestImportProject:
         with tempfile.TemporaryDirectory() as tmpdir:
             project_dir = Path(tmpdir) / "-Users-sam-project"
             project_dir.mkdir()
-
-            import shutil
 
             shutil.copy(FIXTURE_DIR / "linear_3_exchange.jsonl", project_dir / "session1.jsonl")
 


### PR DESCRIPTION
Hoists all 8 lazy imports (imports inside function bodies) to module top-level and flips the `check-lazy-imports` guard on. Continues the phased CI-tooling rollout from #4.

## Changes

| File | Imports hoisted |
|---|---|
| `scripts/embedding_eval/recall_harness.py` | `fastembed`, `sqlite_vec`, `ccrecall.embeddings` |
| `tests/test_content.py` | `json` (×2) |
| `tests/test_formatting.py` | `pathlib.Path` |
| `tests/test_import_pipeline.py` | `shutil` (×2) |

The harness imports were vestigial: both `fastembed` and `sqlite-vec` are **core declared dependencies** (`db.py` already imports `sqlite_vec` at top level), so the lazy form dated from when fastembed was injected ad-hoc via `uv run --with fastembed`. Hoisting is house-rule-compliant — no `# lazy-import:` annotation exception needed (those are reserved for circular-import breaks).

The hoisted `from fastembed import TextEmbedding` is left as a bare import (no `try/except` guard like `embeddings.py` has): the harness is a dev eval script that *requires* fastembed, so fail-fast at import is correct; `embeddings.py` guards because it's shipped code that must degrade gracefully.

## Verification

- `580 passed` on the full suite.
- `recall_harness.py` imports cleanly (verified — it has no test coverage).
- `prek run --all-files` green at both stages; ruff-format clean.

## Still deferred (own cleanup PRs)

`ruff-check` (213) and `pyright` (30) remain commented out in `.pre-commit-config.yaml`.