### PR TITLE
fix: clear pyright errors and enable the pyright guard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,8 @@
 # Staging: fast, always-green hooks run at pre-commit; heavier checks run at
 # pre-push. `default_install_hook_types` below wires both stages automatically.
 #
-# Phased rollout: two guards (ruff lint, pyright) are committed but COMMENTED
-# OUT at the bottom of this file. The current tree has
+# Phased rollout: one guard (ruff lint) is committed but COMMENTED OUT at the
+# bottom of this file. The current tree has
 # pre-existing violations of each; every one gets fixed and flipped on in its own
 # follow-up cleanup PR. Until then, only the green hooks below are active so the
 # hook run and the lint CI stay green.
@@ -92,12 +92,23 @@ repos:
         files: ^(src|tests|scripts|tools)/.*\.py$
         stages: [pre-push]
 
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.408
+    hooks:
+      # pass_filenames: false so pyright runs over its configured include (src/)
+      # via pyrightconfig.json rather than per-file — explicit file args would
+      # override `include` and pull in tests/, which are intentionally unchecked.
+      # Whole-project is also correct for a type-checker: one file's change can
+      # break types in another.
+      - id: pyright
+        pass_filenames: false
+        stages: [pre-push]
+
   # ----------------------------------------------------------------------------
   # DEFERRED — committed but staged off until each guard's cleanup PR brings the
   # tree to green. Uncomment a block in the PR that fixes its violations.
   #
   #   ruff lint            213 violations  (ruff check)
-  #   pyright               30 errors
   # ----------------------------------------------------------------------------
   #
   # - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -105,9 +116,3 @@ repos:
   #   hooks:
   #     - id: ruff-check
   #       args: [--fix]
-  #
-  # - repo: https://github.com/RobertCraigie/pyright-python
-  #   rev: v1.1.408
-  #   hooks:
-  #     - id: pyright
-  #       stages: [pre-push]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -5,7 +5,9 @@
     "ignore": [
         "**/node_modules",
         "**/__pycache__",
-        "**/.venv"
+        "**/.venv",
+        "**/tests",
+        "**/tools"
     ],
     "venvPath": ".",
     "venv": ".venv",

--- a/src/ccrecall/embeddings.py
+++ b/src/ccrecall/embeddings.py
@@ -11,14 +11,13 @@ import numpy as np
 # instead of raising at import time.
 try:
     from fastembed import TextEmbedding
-
-    DEPS_AVAILABLE = True
 except (ImportError, OSError):
     # OSError too: a native wheel that imports but can't load its shared library
     # (ABI mismatch, missing system lib) raises OSError, not ImportError — catch
     # both so import-time degrades instead of crashing.
     TextEmbedding = None
-    DEPS_AVAILABLE = False
+
+DEPS_AVAILABLE = TextEmbedding is not None
 
 EMBEDDING_MODEL = "jinaai/jina-embeddings-v2-small-en"
 EMBEDDING_VERSION = 2  # Bumped from 1 (bge-m3): different model and vector space.
@@ -61,6 +60,9 @@ def get_model(threads: int | None = None):
     if not DEPS_AVAILABLE:
         raise RuntimeError("fastembed not importable")
 
+    # DEPS_AVAILABLE is True only when the fastembed import bound TextEmbedding; the
+    # assert restates that invariant so the type checker sees a non-None constructor.
+    assert TextEmbedding is not None
     _model = TextEmbedding(model_name=EMBEDDING_MODEL, threads=resolve_thread_count(threads))
     return _model
 

--- a/src/ccrecall/hooks/memory_sync.py
+++ b/src/ccrecall/hooks/memory_sync.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import sys
 import tempfile
+from typing import Any
 
 
 def main():
@@ -27,7 +28,9 @@ def main():
             raise
 
         # Background the sync
-        kwargs = {"stdout": subprocess.DEVNULL, "stderr": subprocess.DEVNULL}
+        # Heterogeneous values (DEVNULL ints here, bool/int platform flags added below);
+        # dict[str, Any] lets **kwargs satisfy Popen's individually-typed keyword params.
+        kwargs: dict[str, Any] = {"stdout": subprocess.DEVNULL, "stderr": subprocess.DEVNULL}
         if sys.platform == "win32":
             kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS
         else:

--- a/src/ccrecall/hooks/onboarding.py
+++ b/src/ccrecall/hooks/onboarding.py
@@ -8,11 +8,8 @@ a silent no-op.
 
 import json
 
-from ccrecall.db import (  # noqa: F401 — CONFIG_PATH re-exported for test monkeypatching
-    CONFIG_PATH,
-    CURRENT_ONBOARDING_VERSION,
-    load_config,
-)
+from ccrecall.db import CONFIG_PATH as CONFIG_PATH  # noqa: F401 — re-exported for test monkeypatching
+from ccrecall.db import CURRENT_ONBOARDING_VERSION, load_config
 
 
 def _build_onboarding_context() -> str:

--- a/src/ccrecall/session_ops.py
+++ b/src/ccrecall/session_ops.py
@@ -287,6 +287,9 @@ def sync_session(
                 ),
             )
             branch_db_id = cursor.lastrowid
+        # branch_db_id is set on both paths above: existing_branches[leaf_uuid] (UPDATE) or
+        # lastrowid (INSERT, non-None after a successful insert). Narrow for the type checker.
+        assert branch_db_id is not None
 
         # Ensure only one active branch per session
         if is_active:

--- a/src/ccrecall/session_tail.py
+++ b/src/ccrecall/session_tail.py
@@ -151,8 +151,11 @@ def find_pending_question(entries: list[dict]) -> dict | None:
             continue
         for block in content:
             if isinstance(block, dict) and block.get("type") == "tool_result":
+                tool_use_id = block.get("tool_use_id")
+                if not isinstance(tool_use_id, str):
+                    continue
                 text, _, _, _ = extract_text_content(block.get("content"))
-                results[block.get("tool_use_id")] = text
+                results[tool_use_id] = text
 
     last = None
     for entry in entries:
@@ -168,6 +171,9 @@ def find_pending_question(entries: list[dict]) -> dict | None:
     if not last:
         return None
     tool_id, payload = last
+    # A non-str id can't index results; treat the question as unanswered and surface it.
+    if not isinstance(tool_id, str):
+        return payload
     if ANSWER_MARK in results.get(tool_id, "").lower():
         return None
     return payload
@@ -282,7 +288,8 @@ def emit(path: Path, k: int) -> int:
         print(f"cm-session-tail: transcript is empty: {path}", file=sys.stderr)
         return 1
     meta = extract_session_metadata(entries)
-    sid = next((e.get("sessionId") for e in entries if e.get("sessionId")), path.stem)
+    # sessionId is Any (untyped JSON) and the path.stem fallback is str; str() narrows for the type checker.
+    sid = str(next((e.get("sessionId") for e in entries if e.get("sessionId")), path.stem))
 
     print(f"RESUME — prior session {sid[:8]}")
     print(f"  transcript:  {path}")

--- a/src/ccrecall/summarizer.py
+++ b/src/ccrecall/summarizer.py
@@ -91,7 +91,7 @@ def build_exchange_pairs(messages: list[dict]) -> list[dict]:
     exchanges = []
     current_user = None
     current_user_ts = None
-    current_asst_parts = []  # type: list[str]
+    current_asst_parts: list[str] = []
 
     for m in messages:
         if m["role"] == "user":

--- a/src/ccrecall/token_insights.py
+++ b/src/ccrecall/token_insights.py
@@ -7,9 +7,9 @@ import sqlite3
 
 from ccrecall.token_parser import (
     _BASH_ANTIPATTERN_PREDICATE,
-    _get_pricing,
-    _project_slug,
-    _turn_cost,
+    get_pricing,
+    project_slug,
+    turn_cost,
 )
 
 # ── Public API ─────────────────────────────────────────────────────────
@@ -49,7 +49,7 @@ def build_insights_and_trends(
         FROM session_metrics WHERE is_sidechain = 0 AND cache_cliff_count > 0
         GROUP BY project_path ORDER BY cliffs DESC LIMIT 5
     """):
-        cache_cliff_projects.append({"project": _project_slug(row[0]), "cliffs": row[1], "sessions": row[2]})
+        cache_cliff_projects.append({"project": project_slug(row[0]), "cliffs": row[1], "sessions": row[2]})
 
     # Root-cause detail: top antipattern commands
     top_bash_cmds = []
@@ -66,8 +66,8 @@ def build_insights_and_trends(
     avg_input_cpm = 5.0
     avg_output_cpm = 25.0
     if model_split:
-        weighted_in = sum(m["input_tokens"] * _get_pricing(m["model"])["input"] for m in model_split)
-        weighted_out = sum(m["output_tokens"] * _get_pricing(m["model"])["output"] for m in model_split)
+        weighted_in = sum(m["input_tokens"] * get_pricing(m["model"])["input"] for m in model_split)
+        weighted_out = sum(m["output_tokens"] * get_pricing(m["model"])["output"] for m in model_split)
         total_in = sum(m["input_tokens"] for m in model_split) or 1
         total_out = sum(m["output_tokens"] for m in model_split) or 1
         avg_input_cpm = weighted_in / total_in
@@ -176,8 +176,8 @@ def build_trends(conn: sqlite3.Connection) -> dict:
             WHERE sm.is_sidechain = 0 AND {where_clause}
             GROUP BY t.model
         """):
-            pricing = _get_pricing(crow[0])
-            window_cost += _turn_cost(
+            pricing = get_pricing(crow[0])
+            window_cost += turn_cost(
                 crow[1] or 0,
                 crow[2] or 0,
                 crow[3] or 0,

--- a/src/ccrecall/token_output.py
+++ b/src/ccrecall/token_output.py
@@ -12,9 +12,9 @@ from whenever import Instant
 from ccrecall.token_insights import build_insights_and_trends
 from ccrecall.token_parser import (
     _BASH_ANTIPATTERN_PREDICATE,
-    _get_pricing,
-    _project_slug,
-    _turn_cost,
+    get_pricing,
+    project_slug,
+    turn_cost,
 )
 
 # ── Build Output ──────────────────────────────────────────────────────
@@ -110,8 +110,8 @@ def build_output(conn: sqlite3.Connection) -> dict:
         WHERE model IS NOT NULL
         GROUP BY model ORDER BY inp + out DESC
     """):
-        pricing = _get_pricing(row[0])
-        cost = _turn_cost(row[1], row[2], row[4], row[5], row[6], row[7], pricing)
+        pricing = get_pricing(row[0])
+        cost = turn_cost(row[1], row[2], row[4], row[5], row[6], row[7], pricing)
         model_split.append(
             {
                 "model": row[0],
@@ -137,8 +137,8 @@ def build_output(conn: sqlite3.Connection) -> dict:
         GROUP BY day, t.model
     """):
         day = row[0]
-        pricing = _get_pricing(row[1])
-        day_cost = _turn_cost(row[2], row[3], row[4], row[5], row[6], row[7], pricing)
+        pricing = get_pricing(row[1])
+        day_cost = turn_cost(row[2], row[3], row[4], row[5], row[6], row[7], pricing)
         cost_by_day[day] = cost_by_day.get(day, 0.0) + day_cost
 
     cost_by_day_list = [{"date": d, "cost_usd": round(c, 4)} for d, c in sorted(cost_by_day.items())]
@@ -153,9 +153,9 @@ def build_output(conn: sqlite3.Connection) -> dict:
         JOIN session_metrics sm ON t.session_id = sm.session_id AND sm.is_sidechain = 0
         GROUP BY sm.project_path, t.model
     """):
-        slug = _project_slug(row[0])
-        pricing = _get_pricing(row[1])
-        proj_cost = _turn_cost(row[2], row[3], row[4], row[5], row[6], row[7], pricing)
+        slug = project_slug(row[0])
+        pricing = get_pricing(row[1])
+        proj_cost = turn_cost(row[2], row[3], row[4], row[5], row[6], row[7], pricing)
         cost_by_project[slug] = cost_by_project.get(slug, 0.0) + proj_cost
 
     cost_by_project_list = sorted(
@@ -193,7 +193,7 @@ def build_output(conn: sqlite3.Connection) -> dict:
         cache_trajectory.append(
             {
                 "session_id": tsid[:8],
-                "project": _project_slug(proj[0] if proj else None),
+                "project": project_slug(proj[0] if proj else None),
                 "turns": turns_data,
             }
         )
@@ -216,7 +216,7 @@ def build_output(conn: sqlite3.Connection) -> dict:
         ).fetchall()
 
         buckets: dict[int, dict[str, list[float]]] = {}
-        for sid, session_turns in groupby(all_turns, key=lambda r: r[0]):
+        for _sid, session_turns in groupby(all_turns, key=lambda r: r[0]):
             rows = list(session_turns)
             if not rows or rows[0][2] <= 0:
                 continue
@@ -331,7 +331,7 @@ def build_output(conn: sqlite3.Connection) -> dict:
         HAVING e5 + e1 > 0
         ORDER BY e5 + e1 DESC LIMIT 8
     """):
-        ephem_split.append({"project": _project_slug(row[0]), "ephem_5m": row[1], "ephem_1h": row[2]})
+        ephem_split.append({"project": project_slug(row[0]), "ephem_5m": row[1], "ephem_1h": row[2]})
 
     # ── Chart 7: Bash antipattern rate by project (computed at query time) ──
     bash_antipatterns = []
@@ -347,7 +347,7 @@ def build_output(conn: sqlite3.Connection) -> dict:
     """):
         bash_antipatterns.append(
             {
-                "project": _project_slug(row[0]),
+                "project": project_slug(row[0]),
                 "antipatterns": row[1],
                 "total_bash": row[2],
             }
@@ -429,7 +429,7 @@ def build_output(conn: sqlite3.Connection) -> dict:
         HAVING retries > 0
         ORDER BY retries DESC LIMIT 10
     """):
-        edit_retries.append({"project": _project_slug(row[0]), "retries": row[1]})
+        edit_retries.append({"project": project_slug(row[0]), "retries": row[1]})
     total_edit_retries = (
         cur.execute("""
         SELECT COUNT(*)
@@ -460,7 +460,7 @@ def build_output(conn: sqlite3.Connection) -> dict:
     """):
         agent_cost.append(
             {
-                "project": _project_slug(row[0]),
+                "project": project_slug(row[0]),
                 "parent_cost": row[1],
                 "agent_cost": row[2],
             }
@@ -536,7 +536,7 @@ def build_output(conn: sqlite3.Connection) -> dict:
     """):
         hook_overhead.append(
             {
-                "project": _project_slug(row[0]),
+                "project": project_slug(row[0]),
                 "hook_ms": row[1],
                 "sessions": row[2],
                 "avg_hook_ms": round(row[1] / row[2]) if row[2] else 0,
@@ -558,7 +558,7 @@ def build_output(conn: sqlite3.Connection) -> dict:
     """):
         project_spend.append(
             {
-                "project": _project_slug(row[0]),
+                "project": project_slug(row[0]),
                 "input_tokens": row[1],
                 "output_tokens": row[2],
                 "cache_creation": row[3],
@@ -577,7 +577,7 @@ def build_output(conn: sqlite3.Connection) -> dict:
             FROM session_metrics WHERE is_sidechain = 0
             GROUP BY project_path ORDER BY cost DESC LIMIT 5
         """):
-            project_paths[_project_slug(row[0])] = row[0]
+            project_paths[project_slug(row[0])] = row[0]
 
         for proj_slug, proj_path in project_paths.items():
             tools = {}

--- a/src/ccrecall/token_parser.py
+++ b/src/ccrecall/token_parser.py
@@ -113,7 +113,7 @@ MODEL_PRICING: list[tuple[str, dict[str, float]]] = [
 ]
 
 
-def _get_pricing(model: str | None) -> dict[str, float]:
+def get_pricing(model: str | None) -> dict[str, float]:
     """Return pricing dict for a model ID, falling back to Sonnet rates."""
     if model:
         m = model.lower()
@@ -123,7 +123,7 @@ def _get_pricing(model: str | None) -> dict[str, float]:
     return MODEL_PRICING[4][1]  # default: sonnet
 
 
-def _turn_cost(
+def turn_cost(
     input_tok: int,
     output_tok: int,
     cache_read: int,
@@ -586,7 +586,7 @@ def _normalize_worktree_path(path: str) -> str:
     return path
 
 
-def _project_slug(path: str | None) -> str:
+def project_slug(path: str | None) -> str:
     """Build a short but unique project label from the full path.
 
     Uses the last 2-3 meaningful path segments, skipping common prefixes

--- a/tests/test_ingest_token_data.py
+++ b/tests/test_ingest_token_data.py
@@ -16,7 +16,7 @@ from ccrecall.token_parser import (
     ParsedSession,
     Turn,
     _normalize_worktree_path,
-    _project_slug,
+    project_slug,
     parse_session,
     record_import,
     should_skip_file,
@@ -478,21 +478,21 @@ class TestWorktreeConsolidation:
     """Worktree sessions must be grouped under their parent repo, not as separate projects."""
 
     def test_project_slug_normalizes_worktree_path(self):
-        """_project_slug must produce the same slug for worktree and parent repo paths."""
+        """project_slug must produce the same slug for worktree and parent repo paths."""
         parent = "/home/jessica/source/hassette"
         worktree = "/home/jessica/source/hassette/.claude/worktrees/65-66"
-        assert _project_slug(worktree) == _project_slug(parent)
+        assert project_slug(worktree) == project_slug(parent)
 
     def test_project_slug_preserves_non_worktree_paths(self):
-        """_project_slug must not alter paths that don't contain worktree segments."""
+        """project_slug must not alter paths that don't contain worktree segments."""
         path = "/home/jessica/source/hassette"
-        assert _project_slug(path) == "source-hassette"
+        assert project_slug(path) == "source-hassette"
 
     def test_project_slug_handles_deep_worktree_branch_names(self):
         """Worktree branch names with slashes (e.g. feature/foo) must still normalize."""
         parent = "/home/jessica/source/myapp"
         worktree = "/home/jessica/source/myapp/.claude/worktrees/feature/fix-bug"
-        assert _project_slug(worktree) == _project_slug(parent)
+        assert project_slug(worktree) == project_slug(parent)
 
     def test_normalize_worktree_path_strips_suffix(self):
         """_normalize_worktree_path must strip /.claude/worktrees/<branch>."""


### PR DESCRIPTION
Resolves all 30 pyright errors (src-scoped, `basic` mode) and flips the `pyright` pre-commit guard on. Continues the phased CI-tooling rollout from #4. These are type-correctness fixes with **no behavior change**.

## Fixes

| File | Error | Fix |
|---|---|---|
| `embeddings.py` | `reportConstantRedefinition` + `reportOptionalCall` | Assign `DEPS_AVAILABLE = TextEmbedding is not None` once (not in both try/except arms); `assert TextEmbedding is not None` before constructing. Both guards still gate on `DEPS_AVAILABLE` (one idiom). |
| `memory_sync.py` | `reportCallIssue` (×14, one call) | Annotate `kwargs: dict[str, Any]` so `**kwargs` satisfies `subprocess.Popen`'s typed keyword params. |
| `session_ops.py` | `reportArgumentType` (×3) | `assert branch_db_id is not None` after the INSERT/UPDATE branches (`lastrowid` is `int | None`). |
| `session_tail.py` | optional key / subscript (×4) | `isinstance(str)` guards for `tool_use_id`/`tool_id` dict keys; `str()` narrowing for `sid`. |
| `summarizer.py` | `reportTypeCommentUsage` | `# type:` comment → annotation. |
| `token_output.py` | `reportUnusedVariable` | Rename unused loop var `sid` → `_sid`. |
| `onboarding.py` | `reportUnusedImport` | Re-export `CONFIG_PATH` via redundant-alias form (pyright-aware). |
| `token_parser.py` | `reportUnusedFunction` (×3) | Rename `_get_pricing`/`_turn_cost`/`_project_slug` to drop the `_` prefix — they were flagged because `_` marks them module-private yet they're imported cross-module. **Folds the no-underscore house rule.** Call sites in `token_output`/`token_insights`/tests updated via serena rename. |

## Hook wiring

The pyright hook uses `pass_filenames: false` so it runs over `pyrightconfig.json`'s `include` (`src/`) rather than per-file — explicit file args would override `include` and pull in `tests/`, which are intentionally unchecked. Whole-project is also the correct mode for a type-checker (one file's change can break types in another). Verified: `prek run pyright` matches `uvx pyright` (0 errors).

## Verification

- `580 passed` on the full suite.
- `prek run --all-files` green at both stages (incl. pyright); ruff-format clean.
- Reviewed: code + integration + readability. The one HIGH (a `DEPS_AVAILABLE`/`TextEmbedding` guard divergence) was fixed by converging both guards on `DEPS_AVAILABLE`.

## Note (pre-existing, out of scope)

`tests/test_ingest_token_data.py` imports `_normalize_worktree_path` by its private name across a module boundary. pyright doesn't check `tests/`, so it's not an error today — but it's the logical next candidate if `tests/` is ever brought under pyright.

## Still deferred

`ruff-check` (213) remains commented out in `.pre-commit-config.yaml` — the last guard, its own PR.