### PR TITLE
chore(ruff): clear all ruff-check violations and enable the lint guard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,9 @@
 # Staging: fast, always-green hooks run at pre-commit; heavier checks run at
 # pre-push. `default_install_hook_types` below wires both stages automatically.
 #
-# Phased rollout: one guard (ruff lint) is committed but COMMENTED OUT at the
-# bottom of this file. The current tree has
-# pre-existing violations of each; every one gets fixed and flipped on in its own
-# follow-up cleanup PR. Until then, only the green hooks below are active so the
-# hook run and the lint CI stay green.
+# Phased rollout: every guard ported from hassette has been brought to green and
+# flipped on in its own cleanup PR. ruff lint was the last — the tree is now clean
+# under the full guard set, so there are no deferred hooks remaining.
 default_install_hook_types: [pre-commit, pre-push]
 
 repos:
@@ -35,7 +33,9 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.15.17"
     hooks:
-      # Formatter is green today; the linter is staged off below until cleanup.
+      # Linter runs before the formatter so autofixes are reformatted in the same pass.
+      - id: ruff-check
+        args: [--fix]
       - id: ruff-format
 
   - repo: local
@@ -103,16 +103,3 @@ repos:
       - id: pyright
         pass_filenames: false
         stages: [pre-push]
-
-  # ----------------------------------------------------------------------------
-  # DEFERRED — committed but staged off until each guard's cleanup PR brings the
-  # tree to green. Uncomment a block in the PR that fixes its violations.
-  #
-  #   ruff lint            213 violations  (ruff check)
-  # ----------------------------------------------------------------------------
-  #
-  # - repo: https://github.com/astral-sh/ruff-pre-commit
-  #   rev: "v0.15.17"
-  #   hooks:
-  #     - id: ruff-check
-  #       args: [--fix]

--- a/ruff.toml
+++ b/ruff.toml
@@ -66,6 +66,11 @@ ignore = [
     "N801",   # invalid-class-name
     "SIM103", # needless-bool
     "N812",   # lowercase-imported-as-non-lowercase
+    # S608: every dynamic SQL fragment here interpolates an identifier, a
+    # placeholder count (",".join("?" * n)), or a module-level constant
+    # predicate — never user data, which always flows through ? params. The
+    # check is pure false-positive noise for this parameterized-SQLite codebase.
+    "S608",   # hardcoded-sql-expression
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
@@ -77,6 +82,8 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [lint.per-file-ignores]
 "tests/**/*.py" = [
+    "ARG",    # unused-argument — test doubles/fixtures carry signature-matching params they don't use
+    "E501",   # line-too-long — inline SQL/data fixtures are legitimately long
     "S101",   # assert usage
     "S104",   # binding to all interfaces (test fixtures)
     "S105",   # hardcoded passwords (test tokens)
@@ -85,10 +92,9 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
     "S110",   # try-except-pass
     "S603",   # subprocess calls
     "S607",   # partial executable paths
-    "S608",   # SQL string construction (test queries)
 ]
 "tools/*.py" = ["S603", "S607"]
-"scripts/**/*.py" = ["S101", "S105", "S310", "S603", "S607", "S608"]
+"scripts/**/*.py" = ["S101", "S105", "S310", "S603", "S607"]
 
 [format]
 quote-style = "double"

--- a/scripts/embedding_eval/recall_harness.py
+++ b/scripts/embedding_eval/recall_harness.py
@@ -267,7 +267,7 @@ def main() -> int:
         corpus_ids, corpus_docs = load_corpus(conn)
         if args.export_corpus:
             args.export_corpus.write_text(
-                json.dumps([{"id": i, "summary": d} for i, d in zip(corpus_ids, corpus_docs)])
+                json.dumps([{"id": i, "summary": d} for i, d in zip(corpus_ids, corpus_docs, strict=False)])
             )
             print(f"exported {len(corpus_ids)} corpus rows -> {args.export_corpus}")
             return 0

--- a/src/ccrecall/db.py
+++ b/src/ccrecall/db.py
@@ -397,13 +397,13 @@ CURRENT_ONBOARDING_VERSION = 1
 
 def load_config() -> dict:
     """Read ~/.claude-memory/config.json. Returns empty dict on missing/error."""
+    if not CONFIG_PATH.exists():
+        return {}
     try:
-        if CONFIG_PATH.exists():
-            result = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-            return result if isinstance(result, dict) else {}
+        result = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
     except Exception:
-        pass
-    return {}
+        return {}
+    return result if isinstance(result, dict) else {}
 
 
 def load_settings() -> dict:
@@ -831,7 +831,9 @@ def _migrate_v5(conn: sqlite3.Connection, cursor: sqlite3.Cursor) -> None:
 
             # Rename INTERRUPTED → ABANDONED in context_summary (markdown)
             cursor.execute(
-                "UPDATE branches SET context_summary = REPLACE(context_summary, '**Status:** INTERRUPTED', '**Status:** ABANDONED') WHERE id = ? AND context_summary LIKE '%**Status:** INTERRUPTED%'",
+                "UPDATE branches SET context_summary = "
+                "REPLACE(context_summary, '**Status:** INTERRUPTED', '**Status:** ABANDONED') "
+                "WHERE id = ? AND context_summary LIKE '%**Status:** INTERRUPTED%'",
                 (branch_id,),
             )
 
@@ -850,12 +852,11 @@ def _migrate_v5(conn: sqlite3.Connection, cursor: sqlite3.Cursor) -> None:
 
         conn.commit()
 
-    # Single FTS rebuild after all batches — faster than per-row trigger-driven ops
-    try:
+    # Single FTS rebuild after all batches — faster than per-row trigger-driven ops.
+    # FTS table may not exist (e.g., FTS disabled SQLite build), so this is best-effort.
+    with contextlib.suppress(Exception):
         conn.execute("INSERT INTO branches_fts(branches_fts) VALUES('rebuild')")
         conn.commit()
-    except Exception:
-        pass  # FTS table may not exist (e.g., FTS disabled SQLite build)
 
     conn.execute("PRAGMA user_version = 5")
     conn.commit()

--- a/src/ccrecall/embeddings.py
+++ b/src/ccrecall/embeddings.py
@@ -62,7 +62,7 @@ def get_model(threads: int | None = None):
 
     # DEPS_AVAILABLE is True only when the fastembed import bound TextEmbedding; the
     # assert restates that invariant so the type checker sees a non-None constructor.
-    assert TextEmbedding is not None
+    assert TextEmbedding is not None  # noqa: S101 — type-checker narrowing; the real guard is the RuntimeError above
     _model = TextEmbedding(model_name=EMBEDDING_MODEL, threads=resolve_thread_count(threads))
     return _model
 

--- a/src/ccrecall/formatting.py
+++ b/src/ccrecall/formatting.py
@@ -101,16 +101,14 @@ def format_markdown_session(session: dict, verbose: bool = False) -> str:
         files = session.get("files_modified", [])
         if files:
             lines.append("\n### Files Modified")
-            for f in files[-10:]:
-                lines.append(f"- `{f}`")
+            lines.extend(f"- `{f}`" for f in files[-10:])
             if len(files) > 10:
                 lines.append(f"- ...and {len(files) - 10} more")
 
         commits = session.get("commits", [])
         if commits:
             lines.append("\n### Commits")
-            for c in commits:
-                lines.append(f"- {c}")
+            lines.extend(f"- {c}" for c in commits)
 
         tool_counts = session.get("tool_counts", {})
         if tool_counts:
@@ -122,7 +120,7 @@ def format_markdown_session(session: dict, verbose: bool = False) -> str:
     lines.append("\n### Conversation\n")
 
     for msg in session.get("messages", []):
-        if msg.get("is_notification"):
+        if msg.get("is_notification"):  # noqa: SIM108 — nested ternary hurts readability
             role = "Subagent Result"
         else:
             role = "User" if msg["role"] == "user" else "Assistant"

--- a/src/ccrecall/hooks/backfill_embeddings.py
+++ b/src/ccrecall/hooks/backfill_embeddings.py
@@ -18,6 +18,7 @@ non-zero so the scheduler sees the failure.
 """
 
 import argparse
+import contextlib
 import json
 import os
 import sys
@@ -148,7 +149,7 @@ def run_status(args, settings, logger) -> int:
     try:
         conn = get_db_connection(settings, load_vec=True)
     except Exception as e:
-        logger.error(f"Backfill status: failed to connect to DB: {e}")
+        logger.error("Backfill status: failed to connect to DB: %s", e)
         print(f"cm-backfill-embeddings: failed to connect to DB: {e}", file=sys.stderr)
         return EXIT_ABORT
 
@@ -191,10 +192,8 @@ def main():
         code = _main()
     finally:
         if not is_status:
-            try:
+            with contextlib.suppress(OSError):
                 _PID_FILE.unlink(missing_ok=True)
-            except OSError:
-                pass
     sys.exit(code)
 
 
@@ -252,10 +251,8 @@ def _main(argv: list[str] | None = None) -> int:
     # Background CPU job: lower scheduling priority so the bounded inference
     # threads yield to interactive work (machines.md thrash risk). Best-effort —
     # os.nice is POSIX-only and may be denied; either way the run proceeds.
-    try:
+    with contextlib.suppress(AttributeError, OSError):
         os.nice(10)
-    except (AttributeError, OSError):
-        pass
 
     # ABORT level: check model availability before touching any rows.
     # model_available() warms the singleton session on success — no extra cost.
@@ -271,7 +268,7 @@ def _main(argv: list[str] | None = None) -> int:
     try:
         conn = get_db_connection(settings, load_vec=True)
     except Exception as e:
-        logger.error(f"Backfill embeddings: failed to connect to DB: {e}")
+        logger.error("Backfill embeddings: failed to connect to DB: %s", e)
         print(
             f"cm-backfill-embeddings: failed to connect to DB: {e}",
             file=sys.stderr,
@@ -306,7 +303,7 @@ def _main(argv: list[str] | None = None) -> int:
     if args.limit is not None:
         total_eligible = min(total_eligible, args.limit)
 
-    logger.info(f"Backfill embeddings: starting, {total_eligible} branches to embed")
+    logger.info("Backfill embeddings: starting, %s branches to embed", total_eligible)
     print(
         f"cm-backfill-embeddings: starting, {total_eligible} to embed",
         file=sys.stderr,
@@ -361,11 +358,11 @@ def _main(argv: list[str] | None = None) -> int:
                         "UPDATE branches SET embedding_version = ? WHERE id = ?",
                         (CONTENT_ERROR_VERSION, branch_id),
                     )
-                    logger.error(f"Backfill embeddings: branch {branch_id} failed: {e}")
+                    logger.error("Backfill embeddings: branch %s failed: %s", branch_id, e)
         except Exception as e:
             # Infra/session failure (e.g. ONNX session crash, OOM): abort without
             # marking any further rows — they stay eligible for the next run.
-            logger.error(f"Backfill embeddings: session failure, aborting: {e}")
+            logger.error("Backfill embeddings: session failure, aborting: %s", e)
             conn.commit()
             conn.close()
             return EXIT_ABORT
@@ -383,7 +380,7 @@ def _main(argv: list[str] | None = None) -> int:
                 f"{total_updated}/{total_eligible} embedded, {remaining} left, "
                 f"{format_duration(elapsed)} elapsed, ETA {eta}"
             )
-            logger.info(f"Backfill embeddings: {msg}")
+            logger.info("Backfill embeddings: %s", msg)
             print(f"cm-backfill-embeddings: {msg}", file=sys.stderr)
             last_progress = total_updated
 
@@ -392,7 +389,7 @@ def _main(argv: list[str] | None = None) -> int:
     conn.close()
     elapsed = time.monotonic() - started
     remaining = max(0, total_eligible - total_updated)
-    logger.info(f"Backfill embeddings complete: {total_updated} branches embedded in {format_duration(elapsed)}")
+    logger.info("Backfill embeddings complete: %s branches embedded in %s", total_updated, format_duration(elapsed))
     if args.json:
         print(
             json.dumps(

--- a/src/ccrecall/hooks/backfill_summaries.py
+++ b/src/ccrecall/hooks/backfill_summaries.py
@@ -6,6 +6,8 @@ Processes branches in batches, commits between batches, and marks errors
 with summary_version = -1 to avoid infinite retry.
 """
 
+import contextlib
+
 from ccrecall.db import (
     CONTENT_ERROR_VERSION,
     DEFAULT_DB_PATH,
@@ -25,10 +27,8 @@ def main():
         _main()
     finally:
         # Delete PID file so _spawn_background can spawn again next session
-        try:
+        with contextlib.suppress(OSError):
             _PID_FILE.unlink(missing_ok=True)
-        except OSError:
-            pass
 
 
 def _main():
@@ -38,7 +38,7 @@ def _main():
     try:
         conn = get_db_connection(settings)
     except Exception as e:
-        logger.error(f"Backfill: failed to connect to DB: {e}")
+        logger.error("Backfill: failed to connect to DB: %s", e)
         return
 
     cursor = conn.cursor()
@@ -71,7 +71,7 @@ def _main():
                         (summary_md, summary_json, SUMMARY_VERSION, branch_id),
                     )
                     total_updated += 1
-                except (ValueError, TypeError, KeyError) as e:
+                except (ValueError, TypeError, KeyError) as e:  # noqa: PERF203 — per-row error isolation
                     # Per-row content error (malformed summary data): mark the
                     # sentinel so it isn't retried forever. Infra errors fall
                     # through to the outer handler instead of poisoning the row.
@@ -79,11 +79,11 @@ def _main():
                         "UPDATE branches SET summary_version = ? WHERE id = ?",
                         (CONTENT_ERROR_VERSION, branch_id),
                     )
-                    logger.error(f"Backfill: branch {branch_id} content error: {e}")
+                    logger.error("Backfill: branch %s content error: %s", branch_id, e)
         except Exception as e:
             # Infra/session failure (locked DB, I/O): abort without marking
             # further rows — they stay eligible next run. Commit prior batches.
-            logger.error(f"Backfill: session failure, aborting: {e}")
+            logger.error("Backfill: session failure, aborting: %s", e)
             conn.commit()
             conn.close()
             return
@@ -91,7 +91,7 @@ def _main():
         conn.commit()
 
     conn.close()
-    logger.info(f"Backfill complete: {total_updated} branches summarized")
+    logger.info("Backfill complete: %s branches summarized", total_updated)
 
 
 if __name__ == "__main__":

--- a/src/ccrecall/hooks/clear_handoff.py
+++ b/src/ccrecall/hooks/clear_handoff.py
@@ -1,5 +1,6 @@
 """SessionEnd hook (matcher: clear) — writes handoff file for SessionStart to link sessions."""
 
+import contextlib
 import json
 import sys
 
@@ -23,7 +24,8 @@ def main():
     if not session_id or not cwd:
         return
 
-    try:
+    # Best-effort: a failed handoff write must not surface an error on session clear.
+    with contextlib.suppress(Exception):
         settings = load_settings()
         db_path = get_db_path(settings)
         handoff_path = db_path.parent / "clear-handoff.json"
@@ -37,8 +39,6 @@ def main():
             ),
             encoding="utf-8",
         )
-    except Exception:
-        pass
 
 
 if __name__ == "__main__":

--- a/src/ccrecall/hooks/import_conversations.py
+++ b/src/ccrecall/hooks/import_conversations.py
@@ -9,6 +9,7 @@ v3 schema: messages stored once per session, branches as separate index.
 """
 
 import argparse
+import contextlib
 import hashlib
 import sqlite3
 import sys
@@ -31,7 +32,7 @@ from ccrecall.session_ops import sync_session
 
 def get_file_hash(filepath: Path) -> str:
     """Get MD5 hash of file for change detection."""
-    h = hashlib.md5()
+    h = hashlib.md5(usedforsecurity=False)
     with open(filepath, "rb") as f:
         for chunk in iter(lambda: f.read(8192), b""):
             h.update(chunk)
@@ -106,7 +107,8 @@ def import_session(
         return -1, 0
 
     cursor.execute(
-        "SELECT COUNT(*) FROM branches WHERE session_id = ? AND aggregated_content IS NOT NULL AND aggregated_content != ''",
+        "SELECT COUNT(*) FROM branches "
+        "WHERE session_id = ? AND aggregated_content IS NOT NULL AND aggregated_content != ''",
         (session_id,),
     )
     branches_imported = cursor.fetchone()[0]
@@ -168,10 +170,8 @@ def main():
         _main()
     finally:
         # Delete PID file so _spawn_background can spawn again next session
-        try:
+        with contextlib.suppress(OSError):
             _PID_FILE.unlink(missing_ok=True)
-        except OSError:
-            pass
 
 
 def _main():
@@ -356,7 +356,7 @@ def _main():
 
     conn.close()
 
-    logger.info(f"Import complete: {total_sessions} branches, {total_messages} messages")
+    logger.info("Import complete: %s branches, %s messages", total_sessions, total_messages)
     print(f"\nTotal: {total_sessions} branches, {total_messages} messages imported ({total_skipped} unchanged)")
 
     if db_path.exists():

--- a/src/ccrecall/hooks/memory_context.py
+++ b/src/ccrecall/hooks/memory_context.py
@@ -15,6 +15,7 @@ Selection Algorithm (clear):
 Output: JSON with hookSpecificOutput for context injection
 """
 
+import contextlib
 import json
 import sqlite3
 import sys
@@ -182,10 +183,8 @@ def _find_cleared_from_session_uuid(db_path: Path, cwd: str) -> str | None:
     try:
         data = json.loads(handoff_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        try:
+        with contextlib.suppress(OSError):
             handoff_path.unlink()
-        except OSError:
-            pass
         return None
 
     session_id = data.get("session_id")
@@ -204,24 +203,18 @@ def _find_cleared_from_session_uuid(db_path: Path, cwd: str) -> str | None:
             # TimeDelta.total() takes a unit string; this is age in seconds.
             age = (Instant.now() - written).total("seconds")
             if age > 30:
-                try:
+                with contextlib.suppress(OSError):
                     handoff_path.unlink()
-                except OSError:
-                    pass
                 return None
         except Exception:
             # Unparseable timestamp — treat as invalid; delete and reject
-            try:
+            with contextlib.suppress(OSError):
                 handoff_path.unlink()
-            except OSError:
-                pass
             return None
 
     # Consume the file only after validation passes
-    try:
+    with contextlib.suppress(OSError):
         handoff_path.unlink()
-    except OSError:
-        pass
 
     return session_id
 
@@ -303,7 +296,7 @@ def select_sessions(
     # remaining slots go to short sessions that are more recent
     if substantive:
         recent_shorts = short_sessions[: max_sessions - 1]
-        filtered = recent_shorts + [substantive]
+        filtered = [*recent_shorts, substantive]
     else:
         filtered = short_sessions[:max_sessions]
 
@@ -367,10 +360,7 @@ def build_origin_block(source: str, sessions: list[dict]) -> str:
     branch = primary.get("git_branch", "unknown")
     exchanges = primary.get("exchange_count", 0)
 
-    if source == "clear":
-        source_label = "clear (continuing same session)"
-    else:
-        source_label = "startup (new session)"
+    source_label = "clear (continuing same session)" if source == "clear" else "startup (new session)"
 
     uuid = primary.get("uuid", "")
     lines = [
@@ -480,7 +470,7 @@ def main():
             print(json.dumps({}))
             return
 
-        logger.info(f"Injecting context from {len(sessions)} session(s) for project {project_key}")
+        logger.info("Injecting context from %s session(s) for project %s", len(sessions), project_key)
 
         # Top-of-context directive: placed first because the hook's inline
         # preview may be truncated by the harness, and because earlier tokens
@@ -514,7 +504,7 @@ def main():
         print(json.dumps(output))
 
     except Exception as e:
-        logger.error(f"Context injection error: {e}")
+        logger.error("Context injection error: %s", e)
         # Don't block session start on errors
         print(json.dumps({}))
         sys.exit(0)

--- a/src/ccrecall/hooks/memory_setup.py
+++ b/src/ccrecall/hooks/memory_setup.py
@@ -1,6 +1,6 @@
 """SessionStart hook - setup memory directory and trigger initial import."""
 
-import glob
+import contextlib
 import json
 import os
 import subprocess
@@ -39,7 +39,7 @@ def _spawn_background(cmd: str) -> None:
         try:
             # Atomic create — fails with FileExistsError if file already exists
             fd = os.open(str(pid_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-        except FileExistsError:
+        except FileExistsError:  # noqa: PERF203 — the try/except IS the retry mechanism for atomic PID-file creation
             # File exists — check if the owning process is alive
             try:
                 existing_pid = int(pid_path.read_text().strip())
@@ -48,10 +48,8 @@ def _spawn_background(cmd: str) -> None:
                 return
             except (ValueError, OSError):
                 # Dead process (OSError ESRCH) or unreadable PID — reap and retry
-                try:
+                with contextlib.suppress(OSError):
                     pid_path.unlink()
-                except OSError:
-                    pass
                 continue
         else:
             break
@@ -63,7 +61,7 @@ def _spawn_background(cmd: str) -> None:
     else:
         kwargs["start_new_session"] = True
     try:
-        proc = subprocess.Popen([cmd], **kwargs)
+        proc = subprocess.Popen([cmd], **kwargs)  # noqa: S603 — spawns a trusted internal command, not untrusted input
         # Write child PID so the child process can clean up the file on exit
         os.write(fd, str(proc.pid).encode())
     finally:
@@ -72,11 +70,9 @@ def _spawn_background(cmd: str) -> None:
 
 def _ensure_schema(settings: dict | None = None) -> None:
     """Open DB connection to trigger _migrate_columns (creates token_snapshots if missing)."""
-    try:
+    with contextlib.suppress(Exception):
         conn = get_db_connection(settings)
         conn.close()
-    except Exception:
-        pass
 
 
 def _needs_reimport(settings: dict | None = None) -> bool:
@@ -120,14 +116,12 @@ def _reap_stale_temp_files() -> None:
     These are left behind when cm-sync-current crashes or is killed before it
     can clean up its own input file.
     """
-    pattern = os.path.join(tempfile.gettempdir(), "claude-memory-sync-*.json")
+    tmp_dir = Path(tempfile.gettempdir())
     one_hour_ago = time.time() - 3600
-    for path in glob.glob(pattern):
-        try:
-            if os.path.getmtime(path) < one_hour_ago:
-                os.unlink(path)
-        except OSError:
-            pass
+    for path in tmp_dir.glob("claude-memory-sync-*.json"):
+        with contextlib.suppress(OSError):
+            if path.stat().st_mtime < one_hour_ago:
+                path.unlink()
 
 
 def main():
@@ -155,7 +149,7 @@ def main():
         # forward by embed-on-write (active leaves only); historical seeding is
         # opt-in via `cm-backfill-embeddings [--days N] [--limit N]` so embedding
         # the full history never fires unbidden (machines.md thrash risk).
-    except Exception:
+    except Exception:  # noqa: S110 — top-level hook guard: must never crash the session start
         pass
 
     print(json.dumps({"continue": True}))

--- a/src/ccrecall/hooks/memory_sync.py
+++ b/src/ccrecall/hooks/memory_sync.py
@@ -1,10 +1,12 @@
 """Stop hook - background sync for current session."""
 
+import contextlib
 import json
 import os
 import subprocess
 import sys
 import tempfile
+from pathlib import Path
 from typing import Any
 
 
@@ -21,10 +23,8 @@ def main():
                 f.write(hook_input)
         except Exception:
             # fd is closed by os.fdopen even on error; clean up the file
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
+            with contextlib.suppress(OSError):
+                Path(tmp_path).unlink()
             raise
 
         # Background the sync
@@ -36,18 +36,16 @@ def main():
         else:
             kwargs["start_new_session"] = True
         try:
-            subprocess.Popen(
-                ["cm-sync-current", "--input-file", tmp_path],
+            subprocess.Popen(  # noqa: S603 — spawns the project's own installed CLI, not untrusted input
+                ["cm-sync-current", "--input-file", tmp_path],  # noqa: S607 — entrypoint resolved via PATH by design
                 **kwargs,
             )
         except Exception:
             # Popen failed — clean up the temp file (cm-sync-current won't run to do it)
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
+            with contextlib.suppress(OSError):
+                Path(tmp_path).unlink()
             raise
-    except Exception:
+    except Exception:  # noqa: S110 — top-level hook guard: must never crash the session stop
         pass
 
     print(json.dumps({"continue": True}))

--- a/src/ccrecall/hooks/onboarding.py
+++ b/src/ccrecall/hooks/onboarding.py
@@ -8,7 +8,7 @@ a silent no-op.
 
 import json
 
-from ccrecall.db import CONFIG_PATH as CONFIG_PATH  # noqa: F401 — re-exported for test monkeypatching
+from ccrecall.db import CONFIG_PATH as CONFIG_PATH
 from ccrecall.db import CURRENT_ONBOARDING_VERSION, load_config
 
 

--- a/src/ccrecall/hooks/sync_current.py
+++ b/src/ccrecall/hooks/sync_current.py
@@ -10,8 +10,8 @@ v3 schema: messages stored once per session, branches as a separate index.
 """
 
 import argparse
+import contextlib
 import json
-import os
 import re
 import sys
 from pathlib import Path
@@ -94,10 +94,8 @@ def main():
             hook_input = {}
         finally:
             # Clean up temp file
-            try:
-                os.unlink(args.input_file)
-            except OSError:
-                pass
+            with contextlib.suppress(OSError):
+                args.input_file.unlink()
     else:
         try:
             hook_input = json.load(sys.stdin)
@@ -139,7 +137,7 @@ def main():
         conn.close()
 
         if new_messages > 0:
-            logger.info(f"Synced {new_messages} new message(s) from session {session_id[:8]}")
+            logger.info("Synced %s new message(s) from session %s", new_messages, session_id[:8])
 
         # Output for hook (continue = True means don't block)
         output = {"continue": True}
@@ -149,7 +147,7 @@ def main():
         print(json.dumps(output))
 
     except Exception as e:
-        logger.error(f"Sync error: {e}")
+        logger.error("Sync error: %s", e)
         # Don't block Claude on sync errors
         print(json.dumps({"continue": True}))
         sys.exit(0)

--- a/src/ccrecall/hooks/write_config.py
+++ b/src/ccrecall/hooks/write_config.py
@@ -5,6 +5,7 @@ Atomic write via tmp+replace to prevent partial writes.
 """
 
 import argparse
+import contextlib
 import json
 import os
 import tempfile
@@ -36,12 +37,10 @@ def main():
     }
     config = _write_config_defaults.copy()
     if CONFIG_PATH.exists() and not args.defaults:
-        try:
+        with contextlib.suppress(Exception):
             existing = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
             if isinstance(existing, dict):
                 config.update(existing)
-        except Exception:
-            pass
 
     # Apply CLI arguments (only reached when --defaults is not set)
     if not args.defaults:

--- a/src/ccrecall/parsing.py
+++ b/src/ccrecall/parsing.py
@@ -141,10 +141,7 @@ def find_all_branches(all_entries: list[dict]) -> list[dict]:
         entry = uuid_to_entry.get(uuid)
         if entry and entry.get("type") == "user":
             return True
-        for kid in children.get(uuid, []):
-            if has_user_descendant(kid, depth + 1):
-                return True
-        return False
+        return any(has_user_descendant(kid, depth + 1) for kid in children.get(uuid, []))
 
     def collect_subtree(uuid: str) -> set[str]:
         result: set[str] = set()

--- a/src/ccrecall/project_ops.py
+++ b/src/ccrecall/project_ops.py
@@ -9,6 +9,7 @@ into the projects table. Two path strategies are supported:
     extract cwd metadata when no direct cwd is available
 """
 
+import contextlib
 import sqlite3
 from pathlib import Path
 
@@ -98,11 +99,9 @@ def _probe_project_dir(project_dir: Path) -> str | None:
     Returns the cwd string if found, or None if no JSONL exists or has no cwd.
     """
     for jsonl_file in sorted(project_dir.glob("*.jsonl"))[:1]:
-        try:
+        with contextlib.suppress(Exception):
             entries = list(parse_all_with_uuids(jsonl_file))
             meta = extract_session_metadata(entries)
             if meta.get("cwd"):
                 return meta["cwd"]
-        except Exception:
-            pass
     return None

--- a/src/ccrecall/recent_chats.py
+++ b/src/ccrecall/recent_chats.py
@@ -154,8 +154,7 @@ def format_markdown(sessions: list[dict], verbose: bool = False) -> str:
         return "No sessions found."
 
     lines = [f"# Recent Conversations ({len(sessions)} sessions)\n"]
-    for session in sessions:
-        lines.append(format_markdown_session(session, verbose=verbose))
+    lines.extend(format_markdown_session(session, verbose=verbose) for session in sessions)
 
     return "\n".join(lines)
 

--- a/src/ccrecall/search_conversations.py
+++ b/src/ccrecall/search_conversations.py
@@ -170,7 +170,7 @@ def _get_vec_branch_ids(
           AND b.embedding_version = ?
           AND b.embedding_model = ?
     """
-    filter_params: list = list(candidate_ids) + [EMBEDDING_VERSION, EMBEDDING_MODEL]
+    filter_params: list = [*list(candidate_ids), EMBEDDING_VERSION, EMBEDDING_MODEL]
 
     if projects:
         ph2 = ",".join("?" * len(projects))
@@ -376,13 +376,12 @@ def format_markdown(sessions: list[dict], query: str, verbose: bool = False) -> 
         return f"No sessions found for query: {query}"
 
     lines = [f'# Search Results: "{query}" ({len(sessions)} sessions)\n']
-    for session in sessions:
-        lines.append(format_markdown_session(session, verbose=verbose))
+    lines.extend(format_markdown_session(session, verbose=verbose) for session in sessions)
 
     return "\n".join(lines)
 
 
-def print_status(args: argparse.Namespace, settings: dict | None) -> None:
+def print_status(settings: dict | None) -> None:
     """Print diagnostic status and exit 0."""
     # Open one connection with vec loaded; branch_vec_queryable probes whether
     # the vec table is usable — get_db_connection already loaded the extension
@@ -484,7 +483,7 @@ def main():
     settings = {"db_path": str(args.db)} if args.db != DEFAULT_DB_PATH else None
 
     if args.status:
-        print_status(args, settings)
+        print_status(settings)
         return  # print_status calls sys.exit(0), but be explicit
 
     try:

--- a/src/ccrecall/session_ops.py
+++ b/src/ccrecall/session_ops.py
@@ -16,6 +16,7 @@ A ``NULL``-hash import_log entry is treated as stale: when the import path sees
 the file and updates the row.
 """
 
+import contextlib
 import json
 import sqlite3
 from pathlib import Path
@@ -289,7 +290,7 @@ def sync_session(
             branch_db_id = cursor.lastrowid
         # branch_db_id is set on both paths above: existing_branches[leaf_uuid] (UPDATE) or
         # lastrowid (INSERT, non-None after a successful insert). Narrow for the type checker.
-        assert branch_db_id is not None
+        assert branch_db_id is not None  # noqa: S101 — type-checker narrowing; set on both branches above
 
         # Ensure only one active branch per session
         if is_active:
@@ -358,11 +359,10 @@ def sync_session(
         # If the upsert raises and is swallowed, version columns stay at 0
         # so the branch remains eligible for backfill (no "version done, no vector").
         if summary_md and is_active and vec_writable:
-            try:
+            # Don't fail sync/import on embedding errors — the branch stays eligible for backfill.
+            with contextlib.suppress(Exception):
                 vec = embed_text(summary_md)
                 write_branch_embedding(cursor, branch_db_id, vec, SUMMARY_VERSION)
-            except Exception:
-                pass  # Don't fail sync/import on embedding errors
 
     # Update import_log
     if write_import_log:

--- a/src/ccrecall/session_tail.py
+++ b/src/ccrecall/session_tail.py
@@ -20,7 +20,6 @@ for locating files. So we encode the raw cwd here.
 """
 
 import argparse
-import os
 import sys
 from collections import deque
 from pathlib import Path
@@ -216,9 +215,11 @@ def build_tail(entries: list[dict], k: int) -> list[tuple[str, str]]:
             if text:
                 events.append(("assistant", clip(text)))
             if isinstance(content, list):
-                for block in content:
-                    if isinstance(block, dict) and block.get("type") == "tool_use":
-                        events.append(("tool", block.get("name", "?")))
+                events.extend(
+                    ("tool", block.get("name", "?"))
+                    for block in content
+                    if isinstance(block, dict) and block.get("type") == "tool_use"
+                )
     return events[-k:]
 
 
@@ -234,8 +235,9 @@ def format_pending_block(payload: dict, *, for_injection: bool = False) -> str:
         )
         for q in payload.get("questions", []):
             lines.append(f"- **Q:** {q.get('question', '')}")
-            for opt in q.get("options", []):
-                lines.append(f"  - {opt.get('label', '')}: {clip(opt.get('description', ''), 160)}")
+            lines.extend(
+                f"  - {opt.get('label', '')}: {clip(opt.get('description', ''), 160)}" for opt in q.get("options", [])
+            )
     else:
         lines.append("⚠ PENDING QUESTION — prior session stopped at an UNANSWERED AskUserQuestion.")
         lines.append("  Surface this to the user. Do NOT answer it or act on it yourself.")
@@ -331,7 +333,7 @@ def main() -> int:
     )
     ap.add_argument("selector", nargs="?", help="session id or substring to target")
     ap.add_argument("--list", action="store_true", help="list sessions and exit")
-    ap.add_argument("--cwd", default=os.getcwd(), help="derive project dir from this path")
+    ap.add_argument("--cwd", default=str(Path.cwd()), help="derive project dir from this path")
     ap.add_argument(
         "-n",
         type=int,

--- a/src/ccrecall/token_insights.py
+++ b/src/ccrecall/token_insights.py
@@ -43,24 +43,26 @@ def build_insights_and_trends(
     cur = conn.cursor()
 
     # Root-cause detail: cache cliffs by project
-    cache_cliff_projects = []
-    for row in cur.execute("""
+    cache_cliff_projects = [
+        {"project": project_slug(row[0]), "cliffs": row[1], "sessions": row[2]}
+        for row in cur.execute("""
         SELECT project_path, SUM(cache_cliff_count) as cliffs, COUNT(*) as sessions
         FROM session_metrics WHERE is_sidechain = 0 AND cache_cliff_count > 0
         GROUP BY project_path ORDER BY cliffs DESC LIMIT 5
-    """):
-        cache_cliff_projects.append({"project": project_slug(row[0]), "cliffs": row[1], "sessions": row[2]})
+    """)
+    ]
 
     # Root-cause detail: top antipattern commands
-    top_bash_cmds = []
-    for row in cur.execute(f"""
+    top_bash_cmds = [
+        {"command": row[0], "count": row[1]}
+        for row in cur.execute(f"""
         SELECT SUBSTR(tc.command, 1, 60) as cmd, COUNT(*) as cnt
         FROM turn_tool_calls tc
         JOIN session_metrics sm ON tc.session_id = sm.session_id AND sm.is_sidechain = 0
         WHERE {_BASH_ANTIPATTERN_PREDICATE}
         GROUP BY cmd ORDER BY cnt DESC LIMIT 5
-    """):
-        top_bash_cmds.append({"command": row[0], "count": row[1]})
+    """)
+    ]
 
     # Weighted average cost rates for waste-to-dollar conversion
     avg_input_cpm = 5.0
@@ -201,7 +203,8 @@ def build_trends(conn: sqlite3.Connection) -> dict:
 
     current = _window_kpis("datetime(sm.first_turn_ts) >= datetime('now', '-7 days')")
     prior = _window_kpis(
-        "datetime(sm.first_turn_ts) >= datetime('now', '-14 days') AND datetime(sm.first_turn_ts) < datetime('now', '-7 days')"
+        "datetime(sm.first_turn_ts) >= datetime('now', '-14 days') "
+        "AND datetime(sm.first_turn_ts) < datetime('now', '-7 days')"
     )
 
     if not current:
@@ -479,7 +482,8 @@ def _build_insights(**kw) -> list[dict]:
                     "CLAUDE.md guidance is sufficient for standalone cases.",
                     "claudemd_rule": "\n".join(suggested_rules)
                     if suggested_rules
-                    else "Use Read instead of standalone cat/head/tail. Use Grep instead of standalone grep. Use Glob instead of standalone find/ls.",
+                    else "Use Read instead of standalone cat/head/tail. Use Grep instead of standalone grep. "
+                    "Use Glob instead of standalone find/ls.",
                     "estimated_savings_usd": round(waste_dollars * 0.7, 2),
                 },
             }
@@ -507,10 +511,13 @@ def _build_insights(**kw) -> list[dict]:
                 "waste_tokens": waste_tok,
                 "waste_usd": waste_dollars,
                 "solution": {
-                    "action": "Add a CLAUDE.md rule: 'After reading a file, reference it from context — do not re-read unless the file was modified since last read'",
+                    "action": "Add a CLAUDE.md rule: 'After reading a file, reference it from context — "
+                    "do not re-read unless the file was modified since last read'",
                     "detail": "Each redundant read re-ingests the file as input tokens. For large files (1K+ lines) "
-                    "this adds significant cost. The Read tool output note already says 'content unchanged since last read' but Claude sometimes ignores it.",
-                    "claudemd_rule": "After reading a file, reference it from context. Only re-read if the file was modified since last read.",
+                    "this adds significant cost. The Read tool output note already says 'content unchanged "
+                    "since last read' but Claude sometimes ignores it.",
+                    "claudemd_rule": "After reading a file, reference it from context. "
+                    "Only re-read if the file was modified since last read.",
                     "estimated_savings_usd": round(waste_dollars * 0.5, 2),
                 },
             }
@@ -538,11 +545,13 @@ def _build_insights(**kw) -> list[dict]:
                 "waste_tokens": waste_tok,
                 "waste_usd": waste_dollars,
                 "solution": {
-                    "action": "Add a CLAUDE.md rule: 'Always read a file before editing if more than 2 turns have passed since last read'",
+                    "action": "Add a CLAUDE.md rule: 'Always read a file before editing "
+                    "if more than 2 turns have passed since last read'",
                     "detail": "The root cause is stale context. Claude edits based on what it remembers, not "
                     "the current file state. A fresh read before each edit is cheap (~500 input tokens) "
                     "compared to the cost of a failed edit + retry (~300 output tokens wasted).",
-                    "claudemd_rule": "Read file before editing if >2 turns since last read, to avoid stale-context edit failures.",
+                    "claudemd_rule": "Read file before editing if >2 turns since last read, "
+                    "to avoid stale-context edit failures.",
                     "estimated_savings_usd": round(waste_dollars * 0.7, 2),
                 },
             }
@@ -556,15 +565,16 @@ def _build_insights(**kw) -> list[dict]:
             {
                 "title": "Thinking Token Overhead",
                 "severity": "INFO",
-                "finding": f"~{pct}% of output tokens went to extended thinking ({kw['total_thinking'] // 1000}K tokens, "
-                f"~${thinking_dollars}).",
+                "finding": f"~{pct}% of output tokens went to extended thinking "
+                f"({kw['total_thinking'] // 1000}K tokens, ~${thinking_dollars}).",
                 "root_cause": "Extended thinking is Opus's reasoning mode — it produces internal chain-of-thought "
                 "tokens that are billed as output but not visible to you. This is expected for complex "
                 "tasks but can be excessive for simple ones.",
                 "waste_tokens": 0,
                 "waste_usd": 0,
                 "solution": {
-                    "action": "Use Sonnet for routine tasks (file reads, simple edits, git operations) and reserve Opus for complex reasoning",
+                    "action": "Use Sonnet for routine tasks (file reads, simple edits, git operations) "
+                    "and reserve Opus for complex reasoning",
                     "detail": f"Thinking tokens cost ${thinking_dollars} at output rates. If you're using Opus for "
                     f"everything, switching routine tasks to Sonnet (which doesn't use extended thinking) "
                     f"could save 50-70% of this cost.",
@@ -619,7 +629,8 @@ def _build_insights(**kw) -> list[dict]:
                 {
                     "title": "Cost Concentration",
                     "severity": "INFO",
-                    "finding": f"{top['project']} accounts for {top_pct}% of total spend (${top['cost_usd']:.2f} of ${total_cost:.2f}).",
+                    "finding": f"{top['project']} accounts for {top_pct}% of total spend "
+                    f"(${top['cost_usd']:.2f} of ${total_cost:.2f}).",
                     "root_cause": "This project dominates your usage. Either it has the most sessions, uses "
                     "the most expensive model, or both. Review whether all work in this project "
                     "requires the current model tier.",
@@ -656,8 +667,10 @@ def _build_insights(**kw) -> list[dict]:
                 "waste_tokens": waste_tok,
                 "waste_usd": waste_dollars,
                 "solution": {
-                    "action": "Enable ENABLE_TOOL_SEARCH to defer tool schemas, trim CLAUDE.md, and disable unused skills",
-                    "detail": f"Your avg base is {avg_base:,} tokens. Tool schemas typically account for 14-20K of that. "
+                    "action": "Enable ENABLE_TOOL_SEARCH to defer tool schemas, trim CLAUDE.md, "
+                    "and disable unused skills",
+                    "detail": f"Your avg base is {avg_base:,} tokens. "
+                    "Tool schemas typically account for 14-20K of that. "
                     f"With deferred loading + pruning unused skills, base can drop to ~20K. "
                     f"Every 1K tokens trimmed from base saves that amount on every turn of every session.",
                     "claudemd_rule": None,

--- a/src/ccrecall/token_output.py
+++ b/src/ccrecall/token_output.py
@@ -69,34 +69,34 @@ def build_output(conn: sqlite3.Connection) -> dict:
     """).fetchone()
 
     # ── Chart 1: Sessions by day ──
-    sessions_by_day = []
-    for row in cur.execute("""
+    sessions_by_day = [
+        {
+            "date": row[0],
+            "session_count": row[1],
+            "input_tokens": row[2],
+            "output_tokens": row[3],
+            "cache_read": row[4],
+            "cache_creation": row[5],
+        }
+        for row in cur.execute("""
         SELECT DATE(first_turn_ts) as day, COUNT(*),
                SUM(total_input_tokens), SUM(total_output_tokens),
                SUM(total_cache_read), SUM(total_cache_creation)
         FROM session_metrics WHERE is_sidechain = 0 AND first_turn_ts IS NOT NULL
         GROUP BY day ORDER BY day
-    """):
-        sessions_by_day.append(
-            {
-                "date": row[0],
-                "session_count": row[1],
-                "input_tokens": row[2],
-                "output_tokens": row[3],
-                "cache_read": row[4],
-                "cache_creation": row[5],
-            }
-        )
+    """)
+    ]
 
     # ── Chart 3: Top 10 tools ──
-    top_tools = []
-    for row in cur.execute("""
+    top_tools = [
+        {"tool": row[0], "count": row[1]}
+        for row in cur.execute("""
         SELECT tool_name, COUNT(*) as cnt
         FROM turn_tool_calls tc
         JOIN session_metrics sm ON tc.session_id = sm.session_id AND sm.is_sidechain = 0
         GROUP BY tool_name ORDER BY cnt DESC LIMIT 15
-    """):
-        top_tools.append({"tool": row[0], "count": row[1]})
+    """)
+    ]
 
     # ── Chart 4: Model cost split (with dollar costs) ──
     model_split = []
@@ -172,23 +172,22 @@ def build_output(conn: sqlite3.Connection) -> dict:
         ORDER BY total_cache_read + total_cache_creation DESC LIMIT 5
     """).fetchall()
     for (tsid,) in trajectory_sessions:
-        turns_data = []
-        for row in cur.execute(
-            """
+        turns_data = [
+            {
+                "turn": row[0],
+                "ratio": row[1],
+                "read": row[2],
+                "creation": row[3],
+                "gap_ms": row[4],
+            }
+            for row in cur.execute(
+                """
             SELECT turn_index, cache_read_ratio, cache_read_tokens, cache_creation_tokens, user_gap_ms
             FROM turns WHERE session_id = ? ORDER BY turn_index LIMIT 30
         """,
-            (tsid,),
-        ):
-            turns_data.append(
-                {
-                    "turn": row[0],
-                    "ratio": row[1],
-                    "read": row[2],
-                    "creation": row[3],
-                    "gap_ms": row[4],
-                }
+                (tsid,),
             )
+        ]
         proj = cur.execute("SELECT project_path FROM session_metrics WHERE session_id = ?", (tsid,)).fetchone()
         cache_trajectory.append(
             {
@@ -271,8 +270,9 @@ def build_output(conn: sqlite3.Connection) -> dict:
     context_segments_recent = _compute_seg_curve(recent_seg_sids, min_sessions=2)
 
     # ── Tool context footprint (avg tokens added per call by tool type) ──
-    tool_footprint = []
-    for row in cur.execute("""
+    tool_footprint = [
+        {"tool": row[0], "calls": row[1], "avg_tokens": int(row[2])}
+        for row in cur.execute("""
         WITH single_tool_turns AS (
             SELECT tc.turn_id, tc.tool_name, tc.session_id
             FROM turn_tool_calls tc
@@ -292,8 +292,8 @@ def build_output(conn: sqlite3.Connection) -> dict:
         GROUP BY stt.tool_name
         HAVING cnt >= 10 AND avg_footprint > 0
         ORDER BY avg_footprint DESC LIMIT 12
-    """):
-        tool_footprint.append({"tool": row[0], "calls": row[1], "avg_tokens": int(row[2])})
+    """)
+    ]
 
     seg_agg = cur.execute("""
         SELECT
@@ -322,20 +322,26 @@ def build_output(conn: sqlite3.Connection) -> dict:
     }
 
     # ── Chart 6: Ephemeral cache tier split by project ──
-    ephem_split = []
-    for row in cur.execute("""
+    ephem_split = [
+        {"project": project_slug(row[0]), "ephem_5m": row[1], "ephem_1h": row[2]}
+        for row in cur.execute("""
         SELECT sm.project_path, SUM(t.ephem_5m_tokens) as e5, SUM(t.ephem_1h_tokens) as e1
         FROM turns t
         JOIN session_metrics sm ON t.session_id = sm.session_id AND sm.is_sidechain = 0
         GROUP BY sm.project_path
         HAVING e5 + e1 > 0
         ORDER BY e5 + e1 DESC LIMIT 8
-    """):
-        ephem_split.append({"project": project_slug(row[0]), "ephem_5m": row[1], "ephem_1h": row[2]})
+    """)
+    ]
 
     # ── Chart 7: Bash antipattern rate by project (computed at query time) ──
-    bash_antipatterns = []
-    for row in cur.execute(f"""
+    bash_antipatterns = [
+        {
+            "project": project_slug(row[0]),
+            "antipatterns": row[1],
+            "total_bash": row[2],
+        }
+        for row in cur.execute(f"""
         SELECT sm.project_path,
                SUM(CASE WHEN {_BASH_ANTIPATTERN_PREDICATE} THEN 1 ELSE 0 END) as antipatterns,
                SUM(CASE WHEN tc.tool_name = 'Bash' THEN 1 ELSE 0 END) as total_bash
@@ -344,14 +350,8 @@ def build_output(conn: sqlite3.Connection) -> dict:
         GROUP BY sm.project_path
         HAVING antipatterns > 0
         ORDER BY antipatterns DESC LIMIT 10
-    """):
-        bash_antipatterns.append(
-            {
-                "project": project_slug(row[0]),
-                "antipatterns": row[1],
-                "total_bash": row[2],
-            }
-        )
+    """)
+    ]
     total_bash_antipatterns = (
         cur.execute(f"""
         SELECT SUM(CASE WHEN {_BASH_ANTIPATTERN_PREDICATE} THEN 1 ELSE 0 END)
@@ -362,27 +362,31 @@ def build_output(conn: sqlite3.Connection) -> dict:
     )
 
     # ── Chart 8: Tool error rate by tool ──
-    tool_errors_by_tool = []
-    for row in cur.execute("""
+    tool_errors_by_tool = [
+        {
+            "tool": row[0],
+            "errors": row[1],
+            "total": row[2],
+            "rate": round(row[1] / row[2], 4) if row[2] else 0,
+        }
+        for row in cur.execute("""
         SELECT tool_name, SUM(is_error) as errors, COUNT(*) as total
         FROM turn_tool_calls tc
         JOIN session_metrics sm ON tc.session_id = sm.session_id AND sm.is_sidechain = 0
         GROUP BY tool_name
         HAVING errors > 0
         ORDER BY errors DESC LIMIT 10
-    """):
-        tool_errors_by_tool.append(
-            {
-                "tool": row[0],
-                "errors": row[1],
-                "total": row[2],
-                "rate": round(row[1] / row[2], 4) if row[2] else 0,
-            }
-        )
+    """)
+    ]
 
     # ── Chart 9: Redundant read hotspots (computed at query time) ──
-    redundant_reads = []
-    for row in cur.execute("""
+    redundant_reads = [
+        {
+            "session_id": row[0][:8],
+            "file": row[1].rsplit("/", 1)[-1] if row[1] else "?",
+            "count": row[2],
+        }
+        for row in cur.execute("""
         SELECT tc.session_id, tc.file_path, COUNT(*) as cnt
         FROM turn_tool_calls tc
         JOIN session_metrics sm ON tc.session_id = sm.session_id AND sm.is_sidechain = 0
@@ -390,14 +394,8 @@ def build_output(conn: sqlite3.Connection) -> dict:
         GROUP BY tc.session_id, tc.file_path
         HAVING cnt > 2
         ORDER BY cnt DESC LIMIT 20
-    """):
-        redundant_reads.append(
-            {
-                "session_id": row[0][:8],
-                "file": row[1].rsplit("/", 1)[-1] if row[1] else "?",
-                "count": row[2],
-            }
-        )
+    """)
+    ]
     total_redundant_reads = (
         cur.execute("""
         SELECT SUM(cnt - 1) FROM (
@@ -413,8 +411,9 @@ def build_output(conn: sqlite3.Connection) -> dict:
     )
 
     # ── Chart 10: Edit retry chains by project ──
-    edit_retries = []
-    for row in cur.execute("""
+    edit_retries = [
+        {"project": project_slug(row[0]), "retries": row[1]}
+        for row in cur.execute("""
         SELECT sm.project_path, COUNT(*) as retries
         FROM turn_tool_calls tc1
         JOIN turns t1 ON tc1.turn_id = t1.id
@@ -428,8 +427,8 @@ def build_output(conn: sqlite3.Connection) -> dict:
         GROUP BY sm.project_path
         HAVING retries > 0
         ORDER BY retries DESC LIMIT 10
-    """):
-        edit_retries.append({"project": project_slug(row[0]), "retries": row[1]})
+    """)
+    ]
     total_edit_retries = (
         cur.execute("""
         SELECT COUNT(*)
@@ -447,24 +446,26 @@ def build_output(conn: sqlite3.Connection) -> dict:
     )
 
     # ── Chart 11: Agent cost attribution ──
-    agent_cost = []
-    for row in cur.execute("""
+    agent_cost = [
+        {
+            "project": project_slug(row[0]),
+            "parent_cost": row[1],
+            "agent_cost": row[2],
+        }
+        for row in cur.execute("""
         SELECT parent.project_path,
-               SUM(CASE WHEN child.is_sidechain = 0 THEN child.total_input_tokens + child.total_cache_creation ELSE 0 END) as parent_cost,
-               SUM(CASE WHEN child.is_sidechain = 1 THEN child.total_input_tokens + child.total_cache_creation ELSE 0 END) as agent_cost
+               SUM(CASE WHEN child.is_sidechain = 0
+                        THEN child.total_input_tokens + child.total_cache_creation ELSE 0 END) as parent_cost,
+               SUM(CASE WHEN child.is_sidechain = 1
+                        THEN child.total_input_tokens + child.total_cache_creation ELSE 0 END) as agent_cost
         FROM session_metrics parent
-        JOIN session_metrics child ON child.parent_session_id = parent.session_id OR child.session_id = parent.session_id
+        JOIN session_metrics child
+          ON child.parent_session_id = parent.session_id OR child.session_id = parent.session_id
         WHERE parent.is_sidechain = 0 AND parent.uses_agent = 1
         GROUP BY parent.project_path
         ORDER BY agent_cost DESC LIMIT 10
-    """):
-        agent_cost.append(
-            {
-                "project": project_slug(row[0]),
-                "parent_cost": row[1],
-                "agent_cost": row[2],
-            }
-        )
+    """)
+    ]
 
     # ── Chart 12: Turn complexity distribution ──
     turn_complexity = {"minimal": 0, "light": 0, "medium": 0, "heavy": 0, "runaway": 0}
@@ -527,25 +528,32 @@ def build_output(conn: sqlite3.Connection) -> dict:
             response_time_dist["over_1h"] += 1
 
     # ── Chart 14: Hook overhead top 10 ──
-    hook_overhead = []
-    for row in cur.execute("""
+    hook_overhead = [
+        {
+            "project": project_slug(row[0]),
+            "hook_ms": row[1],
+            "sessions": row[2],
+            "avg_hook_ms": round(row[1] / row[2]) if row[2] else 0,
+        }
+        for row in cur.execute("""
         SELECT project_path, SUM(total_hook_ms) as hook_ms, COUNT(*) as sessions
         FROM session_metrics WHERE is_sidechain = 0 AND total_hook_ms > 0
         GROUP BY project_path
         ORDER BY hook_ms DESC LIMIT 10
-    """):
-        hook_overhead.append(
-            {
-                "project": project_slug(row[0]),
-                "hook_ms": row[1],
-                "sessions": row[2],
-                "avg_hook_ms": round(row[1] / row[2]) if row[2] else 0,
-            }
-        )
+    """)
+    ]
 
     # ── Chart 15: Per-project token spend ──
-    project_spend = []
-    for row in cur.execute("""
+    project_spend = [
+        {
+            "project": project_slug(row[0]),
+            "input_tokens": row[1],
+            "output_tokens": row[2],
+            "cache_creation": row[3],
+            "cache_read": row[4],
+            "sessions": row[5],
+        }
+        for row in cur.execute("""
         SELECT project_path,
                SUM(total_input_tokens) as inp,
                SUM(total_output_tokens) as out,
@@ -555,17 +563,8 @@ def build_output(conn: sqlite3.Connection) -> dict:
         FROM session_metrics WHERE is_sidechain = 0
         GROUP BY project_path
         ORDER BY inp + cc DESC LIMIT 10
-    """):
-        project_spend.append(
-            {
-                "project": project_slug(row[0]),
-                "input_tokens": row[1],
-                "output_tokens": row[2],
-                "cache_creation": row[3],
-                "cache_read": row[4],
-                "sessions": row[5],
-            }
-        )
+    """)
+    ]
 
     # ── Chart 16: Per-project tool profile ──
     project_tool_profile = []
@@ -596,49 +595,60 @@ def build_output(conn: sqlite3.Connection) -> dict:
             project_tool_profile.append({"project": proj_slug, "tools": tools})
 
     # ── Chart 17: Skill usage ──
-    skill_usage = []
-    for row in cur.execute("""
+    skill_usage = [
+        {"skill": row[0], "count": row[1], "errors": row[2]}
+        for row in cur.execute("""
         SELECT skill_name, COUNT(*) as cnt, SUM(is_error) as errs
         FROM turn_tool_calls
         WHERE skill_name IS NOT NULL
         GROUP BY skill_name ORDER BY cnt DESC
-    """):
-        skill_usage.append({"skill": row[0], "count": row[1], "errors": row[2]})
+    """)
+    ]
 
-    skill_usage_by_day = []
-    for row in cur.execute("""
+    skill_usage_by_day = [
+        {"date": row[0], "skill": row[1], "count": row[2]}
+        for row in cur.execute("""
         SELECT DATE(t.timestamp) as day, tc.skill_name, COUNT(*) as cnt
         FROM turn_tool_calls tc
         JOIN turns t ON tc.turn_id = t.id
         WHERE tc.skill_name IS NOT NULL
         GROUP BY day, tc.skill_name ORDER BY day
-    """):
-        skill_usage_by_day.append({"date": row[0], "skill": row[1], "count": row[2]})
+    """)
+    ]
 
     # ── Chart 18: Agent delegation ──
-    agent_delegation = []
-    for row in cur.execute("""
+    agent_delegation = [
+        {"subagent_type": row[0], "count": row[1], "errors": row[2]}
+        for row in cur.execute("""
         SELECT tc.subagent_type, COUNT(*) as cnt, SUM(tc.is_error) as errs
         FROM turn_tool_calls tc
         JOIN session_metrics sm ON tc.session_id = sm.session_id AND sm.is_sidechain = 0
         WHERE tc.subagent_type IS NOT NULL
         GROUP BY tc.subagent_type ORDER BY cnt DESC
-    """):
-        agent_delegation.append({"subagent_type": row[0], "count": row[1], "errors": row[2]})
+    """)
+    ]
 
-    agent_model_dist = []
-    for row in cur.execute("""
+    agent_model_dist = [
+        {"model": row[0], "count": row[1]}
+        for row in cur.execute("""
         SELECT tc.agent_model, COUNT(*) as cnt
         FROM turn_tool_calls tc
         JOIN session_metrics sm ON tc.session_id = sm.session_id AND sm.is_sidechain = 0
         WHERE tc.agent_model IS NOT NULL
         GROUP BY tc.agent_model ORDER BY cnt DESC
-    """):
-        agent_model_dist.append({"model": row[0], "count": row[1]})
+    """)
+    ]
 
     # ── Chart 19: Hook performance ──
-    hook_performance = []
-    for row in cur.execute("""
+    hook_performance = [
+        {
+            "hook_command": row[0],
+            "runs": row[1],
+            "total_ms": row[2],
+            "avg_ms": row[3],
+            "errors": row[4],
+        }
+        for row in cur.execute("""
         SELECT he.hook_command, COUNT(*) as runs,
                SUM(he.duration_ms) as total_ms,
                ROUND(AVG(he.duration_ms)) as avg_ms,
@@ -646,16 +656,8 @@ def build_output(conn: sqlite3.Connection) -> dict:
         FROM hook_executions he
         JOIN session_metrics sm ON he.session_id = sm.session_id AND sm.is_sidechain = 0
         GROUP BY he.hook_command ORDER BY total_ms DESC
-    """):
-        hook_performance.append(
-            {
-                "hook_command": row[0],
-                "runs": row[1],
-                "total_ms": row[2],
-                "avg_ms": row[3],
-                "errors": row[4],
-            }
-        )
+    """)
+    ]
 
     # ── Insights, findings, recommendations, trends ──
     insight_data = build_insights_and_trends(

--- a/src/ccrecall/token_parser.py
+++ b/src/ccrecall/token_parser.py
@@ -178,8 +178,7 @@ def discover_jsonl_files() -> list[JnlFile]:
             continue
         project_cwd = _decode_project_cwd(proj_dir.name)
         # Top-level session files
-        for jf in proj_dir.glob("*.jsonl"):
-            results.append(JnlFile(jf, project_cwd, False, None))
+        results.extend(JnlFile(jf, project_cwd, False, None) for jf in proj_dir.glob("*.jsonl"))
         # Subagent files
         for jf in proj_dir.glob("*/subagents/*.jsonl"):
             parent_id = jf.parent.parent.name  # the session UUID directory
@@ -612,7 +611,7 @@ def project_slug(path: str | None) -> str:
                 continue
         meaningful.append(p)
     # Take last 2-3 segments depending on length
-    if len(meaningful) <= 2:
+    if len(meaningful) <= 2:  # noqa: SIM108 — nested ternary hurts readability
         slug = "-".join(meaningful) if meaningful else "unknown"
     else:
         slug = "-".join(meaningful[-3:])

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -62,7 +62,7 @@ class TestExtractTextContent:
             {"type": "tool_use", "name": "Read", "input": {"file": "other.py"}},
             {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}},
         ]
-        text, has_tool, has_think, summary = extract_text_content(content)
+        text, has_tool, _has_think, summary = extract_text_content(content)
         assert text == "Let me check."
         assert has_tool is True
         assert summary is not None
@@ -100,7 +100,7 @@ class TestExtractTextContent:
         assert summary is None  # No tool name -> no counts -> None
 
     def test_empty_string(self):
-        text, has_tool, has_think, summary = extract_text_content("")
+        text, _has_tool, _has_think, summary = extract_text_content("")
         assert text == ""
         assert summary is None
 
@@ -112,12 +112,12 @@ class TestExtractTextContent:
         assert summary is None
 
     def test_unexpected_type(self):
-        text, has_tool, has_think, summary = extract_text_content(42)
+        text, has_tool, _has_think, _summary = extract_text_content(42)
         assert text == ""
         assert has_tool is False
 
     def test_empty_list(self):
-        text, has_tool, has_think, summary = extract_text_content([])
+        text, has_tool, _has_think, summary = extract_text_content([])
         assert text == ""
         assert has_tool is False
         assert summary is None

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,5 +1,6 @@
 """Tests for ccrecall.db — schema creation, migration, settings."""
 
+import contextlib
 import inspect
 import json
 import sqlite3
@@ -959,8 +960,8 @@ def _v4_db_for_v5_tests():
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP
         )
     """)
-    # FTS5 branches table (for FTS rebuild test)
-    try:
+    # FTS5 branches table (for FTS rebuild test). FTS5 may not be available in all test environments.
+    with contextlib.suppress(Exception):
         conn.execute("""
             CREATE VIRTUAL TABLE IF NOT EXISTS branches_fts USING fts5(
               aggregated_content,
@@ -969,8 +970,6 @@ def _v4_db_for_v5_tests():
               tokenize='porter unicode61'
             )
         """)
-    except Exception:
-        pass  # FTS5 may not be available in all test environments
     conn.execute("PRAGMA user_version = 4")
     conn.commit()
     return conn

--- a/tests/test_import_pipeline.py
+++ b/tests/test_import_pipeline.py
@@ -158,7 +158,7 @@ class TestEmptyBranchGuard:
             )
 
         try:
-            branches_imported, total_messages = import_session(memory_db, temp_path, project_id)
+            branches_imported, _total_messages = import_session(memory_db, temp_path, project_id)
 
             # Guard 2 fires because after excluding notifications, the branch
             # has only assistant text — but the notification user message IS
@@ -259,7 +259,7 @@ class TestImportLogTracking:
         memory_db.commit()
 
         # Reimport — should restore correct hash
-        branches, msg_count = import_session(memory_db, fixture_file, project_id)
+        branches, _msg_count = import_session(memory_db, fixture_file, project_id)
         assert branches > 0, "Forced reimport should succeed"
 
         cursor.execute(
@@ -313,7 +313,7 @@ class TestFKSafeReimport:
         )
         memory_db.commit()
 
-        branches2, messages2 = import_session(memory_db, fixture_file, project_id)
+        branches2, _messages2 = import_session(memory_db, fixture_file, project_id)
         assert branches2 == 3, "Reimport should produce same branch count"
         memory_db.commit()
 
@@ -378,7 +378,7 @@ class TestImportProject:
 
             shutil.copy(FIXTURE_DIR / "linear_3_exchange.jsonl", project_dir / "session1.jsonl")
 
-            sessions, messages, skipped = import_project(memory_db, project_dir)
+            sessions, _messages, skipped = import_project(memory_db, project_dir)
             assert sessions > 0 or skipped > 0, "Should process the JSONL file"
 
     def test_dotfiles_skipped(self, memory_db):
@@ -390,7 +390,7 @@ class TestImportProject:
             # Create a dotfile
             (project_dir / ".hidden.jsonl").write_text('{"type":"progress"}\n')
 
-            sessions, messages, skipped = import_project(memory_db, project_dir)
+            sessions, messages, _skipped = import_project(memory_db, project_dir)
             assert sessions == 0
             assert messages == 0
 
@@ -426,7 +426,7 @@ class TestAppendOnlyReimport:
         )
         memory_db.commit()
 
-        branches2, messages2 = import_session(memory_db, fixture_file, project_id)
+        branches2, _messages2 = import_session(memory_db, fixture_file, project_id)
         assert branches2 > 0, "Forced reimport must succeed"
 
         # Same number of message rows — append-only, no duplicates
@@ -560,7 +560,7 @@ class TestSessionWithMessagesButNoBranches:
             )
 
         try:
-            branches_imported, total_messages = import_session(memory_db, temp_path, project_id)
+            branches_imported, _total_messages = import_session(memory_db, temp_path, project_id)
 
             cursor = memory_db.cursor()
             # Session must still exist (messages present — conservative cleanup)
@@ -609,7 +609,7 @@ class TestSessionWithMessagesButNoBranches:
             )
 
         try:
-            branches_imported, total_messages = import_session(memory_db, temp_path, project_id)
+            branches_imported, _total_messages = import_session(memory_db, temp_path, project_id)
 
             # Guard 1 fires: no extractable text, session must be cleaned up
             assert branches_imported == -1, "Should trigger guard 1 (no extractable content)"

--- a/tests/test_ingest_token_data.py
+++ b/tests/test_ingest_token_data.py
@@ -16,8 +16,8 @@ from ccrecall.token_parser import (
     ParsedSession,
     Turn,
     _normalize_worktree_path,
-    project_slug,
     parse_session,
+    project_slug,
     record_import,
     should_skip_file,
 )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -92,7 +92,7 @@ def _setup_db_and_import(filepath: Path) -> sqlite3.Connection:
     for branch in branches:
         branch_msgs = [m for m in messages if m.get("uuid") in branch["uuids"]]
         branch_msgs.sort(key=lambda e: e.get("timestamp") or "")
-        exchange_count, files, commits, _tool_counts = compute_branch_metadata(branch_msgs)
+        exchange_count, _files, _commits, _tool_counts = compute_branch_metadata(branch_msgs)
 
         cursor.execute(
             """

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -231,7 +231,7 @@ class TestComputeBranchMetadata:
             {"type": "user", "message": {"content": "How?"}},
             {"type": "assistant", "message": {"content": "Like this."}},
         ]
-        count, files, commits, _ = compute_branch_metadata(entries)
+        count, _files, _commits, _ = compute_branch_metadata(entries)
         assert count == 2
 
     def test_notifications_not_counted_as_exchanges(self):

--- a/tests/test_recent_chats.py
+++ b/tests/test_recent_chats.py
@@ -108,7 +108,7 @@ class TestRecentChatsInvariant:
         assert len(plain_results) == len(vec_results)
 
         # Same ordered list — compare element by element
-        for plain, vec in zip(plain_results, vec_results):
+        for plain, vec in zip(plain_results, vec_results, strict=False):
             assert plain["uuid"] == vec["uuid"], f"UUID mismatch at same position: {plain['uuid']!r} vs {vec['uuid']!r}"
             assert plain["project"] == vec["project"]
             assert plain.get("started_at") == vec.get("started_at")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,6 +1,5 @@
 """Tests for search_conversations.py and recent_chats.py — search and retrieval."""
 
-import argparse
 import sqlite3
 import sys
 from unittest.mock import patch
@@ -521,9 +520,11 @@ class TestDegradation:
         def _raise(*_a, **_kw):
             raise AttributeError("no load_extension")
 
-        with patch("ccrecall.search_conversations.model_available", return_value=True):
-            with patch("ccrecall.search_conversations.embed_text", side_effect=_raise):
-                results = search_sessions(search_db, "pytest", fts_level, max_results=10)
+        with (
+            patch("ccrecall.search_conversations.model_available", return_value=True),
+            patch("ccrecall.search_conversations.embed_text", side_effect=_raise),
+        ):
+            results = search_sessions(search_db, "pytest", fts_level, max_results=10)
 
         # Should return results via keyword fallback, not raise
         assert isinstance(results, list)
@@ -845,11 +846,10 @@ class TestStatusFlag:
         _migrate_columns(c)
         c.close()
 
-        args = argparse.Namespace(db=db_path, keyword_only=False, status=True, query=None)
         settings = {"db_path": str(db_path)}
 
         with pytest.raises(SystemExit) as exc:
-            print_status(args, settings)
+            print_status(settings)
 
         assert exc.value.code == 0
         captured = capsys.readouterr()

--- a/tests/test_session_ops.py
+++ b/tests/test_session_ops.py
@@ -150,7 +150,7 @@ class TestImportSessionWritesRealHashImportLog:
         """When write_import_log=True with a real hash, import_log stores that hash."""
 
         fixture_path = FIXTURE_DIR / "linear_3_exchange.jsonl"
-        h = hashlib.md5()
+        h = hashlib.md5(usedforsecurity=False)
         with open(fixture_path, "rb") as fh:
             for chunk in iter(lambda: fh.read(8192), b""):
                 h.update(chunk)
@@ -210,7 +210,7 @@ class TestImportSkipsNullHashEntry:
         assert cursor.fetchone()[0] is None, "Setup: hash should be NULL"
 
         # Now simulate import path: compute real hash and call sync_session again
-        h = hashlib.md5()
+        h = hashlib.md5(usedforsecurity=False)
         with open(fixture_path, "rb") as fh:
             for chunk in iter(lambda: fh.read(8192), b""):
                 h.update(chunk)
@@ -273,7 +273,7 @@ class TestSyncThenImportDedupIntegration:
         assert messages_after_sync > 0
 
         # Step 2: import path computes hash and re-syncs
-        h = hashlib.md5()
+        h = hashlib.md5(usedforsecurity=False)
         with open(fixture_path, "rb") as fh:
             for chunk in iter(lambda: fh.read(8192), b""):
                 h.update(chunk)
@@ -417,10 +417,12 @@ class TestEmbedOnWriteModelUnavailable:
         conn.commit()
         _migrate_columns(conn)
 
-        with patch("ccrecall.session_ops.embed_text", side_effect=RuntimeError("no model")):
-            with tempfile.TemporaryDirectory() as tmpdir:
-                result = sync_session(conn, fixture_path, Path(tmpdir))
-                conn.commit()
+        with (
+            patch("ccrecall.session_ops.embed_text", side_effect=RuntimeError("no model")),
+            tempfile.TemporaryDirectory() as tmpdir,
+        ):
+            result = sync_session(conn, fixture_path, Path(tmpdir))
+            conn.commit()
 
         # sync must succeed
         assert result >= 0
@@ -459,10 +461,12 @@ class TestEmbedOnWriteOrderingInvariant:
 
         fake_vec = [0.1] * EMBEDDING_DIM
 
-        with patch("ccrecall.session_ops.embed_text", return_value=fake_vec):
-            with tempfile.TemporaryDirectory() as tmpdir:
-                result = sync_session(conn, fixture_path, Path(tmpdir))
-                conn.commit()
+        with (
+            patch("ccrecall.session_ops.embed_text", return_value=fake_vec),
+            tempfile.TemporaryDirectory() as tmpdir,
+        ):
+            result = sync_session(conn, fixture_path, Path(tmpdir))
+            conn.commit()
 
         # sync must succeed
         assert result >= 0
@@ -499,10 +503,12 @@ class TestEmbedOnWriteSuccess:
 
         fake_vec = [0.1] * EMBEDDING_DIM
 
-        with patch("ccrecall.session_ops.embed_text", return_value=fake_vec):
-            with tempfile.TemporaryDirectory() as tmpdir:
-                result = sync_session(conn, fixture_path, Path(tmpdir))
-                conn.commit()
+        with (
+            patch("ccrecall.session_ops.embed_text", return_value=fake_vec),
+            tempfile.TemporaryDirectory() as tmpdir,
+        ):
+            result = sync_session(conn, fixture_path, Path(tmpdir))
+            conn.commit()
 
         assert result >= 0
 

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -423,9 +423,7 @@ class TestDetectDispositionWithCommits:
     """Tests for the improved detect_disposition() with commits parameter."""
 
     def _make_exchanges(self, count: int, last_user: str = "ok") -> list[dict]:
-        exchanges = []
-        for i in range(count - 1):
-            exchanges.append({"user": f"Q{i}", "assistant": f"A{i}", "timestamp": f"t{i}"})
+        exchanges = [{"user": f"Q{i}", "assistant": f"A{i}", "timestamp": f"t{i}"} for i in range(count - 1)]
         exchanges.append({"user": last_user, "assistant": "Done.", "timestamp": "t_last"})
         return exchanges
 
@@ -483,7 +481,7 @@ class TestDetectDispositionWithCommits:
         ]
         # Simulate: last exchange has assistant content but no user reply after
         # We can test this by checking disposition of a last exchange where user="" and assistant is non-empty
-        exchanges_with_no_reply = exchanges[:2] + [{"user": "", "assistant": "No followup.", "timestamp": "t3"}]
+        exchanges_with_no_reply = [*exchanges[:2], {"user": "", "assistant": "No followup.", "timestamp": "t3"}]
         result = detect_disposition(exchanges_with_no_reply)
         assert result == "ABANDONED"
 

--- a/tests/test_sync_hook.py
+++ b/tests/test_sync_hook.py
@@ -4,6 +4,8 @@ import contextlib
 import io
 import os
 import sqlite3
+import subprocess
+import sys
 import tempfile
 import time
 from pathlib import Path
@@ -370,17 +372,17 @@ class TestPidGuard:
         pid_path = tmp_path / ".pid-cm-test-cmd"
         monkeypatch.setattr(memory_setup, "_PID_DIR", tmp_path)
 
-        # Use PID 1 for kernel (always alive) — we need a truly dead PID.
-        # os.fork() gives us a real dead PID safely.
-        child_pid = os.fork()
-        if child_pid == 0:
-            # Child exits immediately
-            os._exit(0)
-        # Wait for child to die
-        os.waitpid(child_pid, 0)
+        # We need a real PID that is guaranteed dead. Spawn a trivial subprocess
+        # and reap it. Deliberately NOT os.fork(): by the time this test runs the
+        # process has usually started threads (the embedding model's onnxruntime
+        # pool), and forking a multi-threaded process can deadlock the child — an
+        # intermittent CI hang. Popen+wait gives the same dead PID with no fork.
+        proc = subprocess.Popen([sys.executable, "-c", ""])
+        proc.wait()
+        dead_pid = proc.pid
 
-        # Write the dead child's PID to the file
-        pid_path.write_text(str(child_pid))
+        # Write the dead PID to the file
+        pid_path.write_text(str(dead_pid))
 
         mock_proc = MagicMock()
         mock_proc.pid = 99999

--- a/tests/test_sync_hook.py
+++ b/tests/test_sync_hook.py
@@ -1,5 +1,6 @@
 """Integration tests for sync_current.py hook."""
 
+import contextlib
 import io
 import os
 import sqlite3
@@ -46,7 +47,7 @@ class TestSyncSessionCreatesBranches:
 
     def test_sync_session_creates_branches(self, memory_db_with_project):
         """sync_session should create branches from a fixture with rewinding."""
-        conn, project_id = memory_db_with_project
+        conn, _project_id = memory_db_with_project
         fixture_path = FIXTURE_DIR / "single_rewind.jsonl"
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -79,7 +80,7 @@ class TestSyncSessionCreatesBranches:
 
     def test_sync_session_populates_branch_content(self, memory_db_with_project):
         """Aggregated content should be populated after sync."""
-        conn, project_id = memory_db_with_project
+        conn, _project_id = memory_db_with_project
         fixture_path = FIXTURE_DIR / "single_rewind.jsonl"
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -95,7 +96,7 @@ class TestSyncSessionCreatesBranches:
 
     def test_sync_session_populates_context_summary(self, memory_db_with_project):
         """Context summary and summary_version should be populated after sync."""
-        conn, project_id = memory_db_with_project
+        conn, _project_id = memory_db_with_project
         fixture_path = FIXTURE_DIR / "single_rewind.jsonl"
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -123,7 +124,7 @@ class TestSyncSessionUpdatesExisting:
         Verifies both the Python-level dedup (existing_uuids set check)
         and the overall idempotency of sync_session.
         """
-        conn, project_id = memory_db_with_project
+        conn, _project_id = memory_db_with_project
         fixture_path = FIXTURE_DIR / "single_rewind.jsonl"
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -409,10 +410,13 @@ class TestPidGuard:
         mock_proc = MagicMock()
         mock_proc.pid = 12345
 
-        with patch("os.open", side_effect=capturing_open), patch("subprocess.Popen", return_value=mock_proc):
-            with patch("os.write"):
-                with patch("os.close"):
-                    memory_setup._spawn_background("cm-test-cmd")
+        with (
+            patch("os.open", side_effect=capturing_open),
+            patch("subprocess.Popen", return_value=mock_proc),
+            patch("os.write"),
+            patch("os.close"),
+        ):
+            memory_setup._spawn_background("cm-test-cmd")
 
         assert created_flags, "os.open must have been called for the PID file"
         flags = created_flags[0]
@@ -436,17 +440,17 @@ class TestMemorySyncTempCleanup:
             mock_file = MagicMock()
             mock_fdopen.return_value.__enter__ = MagicMock(return_value=mock_file)
             mock_fdopen.return_value.__exit__ = MagicMock(return_value=False)
-            with patch("subprocess.Popen", side_effect=OSError("no such file")):
-                with patch("os.unlink") as mock_unlink:
-                    # Run with a stdin that returns empty content
-                    with patch("sys.stdin") as mock_stdin:
-                        mock_stdin.read.return_value = '{"session": "test"}'
-                        try:
-                            memory_sync.main()
-                        except Exception:
-                            pass
-                    # Verify unlink was called with our tmp path
-                    mock_unlink.assert_any_call(tmp_path_str)
+            with (
+                patch("subprocess.Popen", side_effect=OSError("no such file")),
+                patch("sys.stdin") as mock_stdin,
+            ):
+                # Run with a stdin that returns empty content
+                mock_stdin.read.return_value = '{"session": "test"}'
+                with contextlib.suppress(Exception):
+                    memory_sync.main()
+
+        # Popen failed, so the cleanup path must have deleted the real temp file
+        assert not tmp_file.exists(), "temp file should be unlinked when Popen fails"
 
 
 class TestReapStaleTempFiles:

--- a/tests/test_write_config.py
+++ b/tests/test_write_config.py
@@ -133,7 +133,7 @@ class TestWriteConfigAtomicWrite:
 
         monkeypatch.setattr(os, "fdopen", exploding_fdopen)
 
-        with pytest.raises(OSError):
+        with pytest.raises(OSError, match="simulated write failure"):
             _run_main(["--defaults"])
 
         tmp_files = list(tmp_path.glob("*.tmp"))
@@ -152,7 +152,7 @@ class TestWriteConfigAtomicWrite:
 
         monkeypatch.setattr(os, "fdopen", exploding_fdopen)
 
-        with pytest.raises(OSError):
+        with pytest.raises(OSError, match="simulated write failure"):
             _run_main(["--defaults"])
 
         surviving = json.loads(cfg.read_text())


### PR DESCRIPTION
Final guard in the phased CI-tooling rollout ported from hassette. Brings the tree to green under `ruff check` and flips the last deferred guard (`ruff-check`) on.

## What changed

**`.pre-commit-config.yaml`** — moved `ruff-check` from the commented "DEFERRED" block into the active ruff-pre-commit repo (linter before formatter, `args: [--fix]`); removed the now-empty deferred section and refreshed the header comment (no deferred guards remain).

**Code fixes** — all behavior-preserving, **580 tests pass**, verified green via `prek run --all-files` (both stages) and pyright:
- **PERF401**: `for`/`append` loops → list comprehensions / `list.extend`
- **SIM105 / S110**: `try/except: pass` → `contextlib.suppress` where intentional; `noqa` for top-level hook guards that must never crash the session
- **PTH**: `os.unlink` / `os.getcwd` / `os.path.getmtime` / `glob.glob` → pathlib
- **G004**: f-string logging → lazy `%`-formatting
- **E501**: wrapped long SQL / insight strings via implicit concatenation
- **SIM117**: combined nested `with` statements
- **S324**: `hashlib.md5(usedforsecurity=False)` for content-identity hashing
- **B905 / RUF005 / RUF059**: `zip(strict=…)`, unpacking, unused-var prefixes
- dropped the unused `print_status(args)` parameter and updated its call sites

**`ruff.toml`** config decisions:
- **S608** ignored globally — every dynamic SQL fragment interpolates an identifier, a placeholder count (`",".join("?" * n)`), or a constant predicate; user data always flows through `?` params, so the check is pure false-positive noise here
- **tests/\*\***: ignore **E501** (inline SQL/data fixtures are legitimately long) and **ARG** (test doubles/fixtures carry signature-matching params they don't use)
- targeted `noqa` with rationale for trusted-subprocess (S603/S607), type-narrowing asserts (S101), loop-essential try/except (PERF203), and two deliberately-unflattened ternaries (SIM108)

## Review

code-reviewer (APPROVE), integration-reviewer + wtf-reviewer (WARN, none blocking). Three real findings they surfaced were fixed in this branch:
- a test assertion that had been pulled inside a `contextlib.suppress` (vacuous) — moved out, which also exposed that it mocked `os.unlink` where the code now calls `Path.unlink`; rewrote it to observe the real temp-file deletion
- a stale `ruff.toml` comment referencing a per-file ignore removed in the same change
- `load_config`'s `return`-inside-`suppress` → clearer early-return + explicit except