### PR TITLE
refactor: extract shared session-uuid and json-column decode helpers

### DIFF
--- a/src/ccrecall/db.py
+++ b/src/ccrecall/db.py
@@ -14,7 +14,7 @@ import sqlite_vec
 
 from ccrecall.content import parse_origin
 from ccrecall.embeddings import EMBEDDING_DIM, EMBEDDING_MODEL, EMBEDDING_VERSION
-from ccrecall.parsing import build_aggregated_content
+from ccrecall.parsing import build_aggregated_content, extract_session_uuid
 from ccrecall.summarizer import truncate_mid
 
 # Default paths
@@ -655,14 +655,10 @@ def _backfill_origin(conn: sqlite3.Connection, cursor: sqlite3.Cursor) -> None:
         return
 
     # Build file_path -> session mapping from import_log + sessions
-    # The file stem (minus .jsonl and optional agent- prefix) is the session uuid
     file_session_map = {}
     all_import_rows = cursor.execute("SELECT file_path FROM import_log").fetchall()
     for (file_path,) in all_import_rows:
-        p = Path(file_path)
-        stem = p.stem
-        if stem.startswith("agent-"):
-            stem = stem[6:]
+        stem = extract_session_uuid(Path(file_path))
         row = cursor.execute("SELECT id FROM sessions WHERE uuid = ?", (stem,)).fetchone()
         if row:
             file_session_map[file_path] = row[0]

--- a/src/ccrecall/hooks/import_conversations.py
+++ b/src/ccrecall/hooks/import_conversations.py
@@ -26,6 +26,7 @@ from ccrecall.db import (
     setup_logging,
 )
 from ccrecall.formatting import extract_project_name, normalize_project_key
+from ccrecall.parsing import extract_session_uuid
 from ccrecall.project_ops import upsert_project
 from ccrecall.session_ops import sync_session
 
@@ -79,9 +80,7 @@ def import_session(
         return -1, 0
 
     # Gather branch and message counts for the return value
-    session_uuid = filepath.stem
-    if session_uuid.startswith("agent-"):
-        session_uuid = session_uuid[6:]
+    session_uuid = extract_session_uuid(filepath)
 
     cursor.execute("SELECT id FROM sessions WHERE uuid = ?", (session_uuid,))
     row = cursor.fetchone()

--- a/src/ccrecall/hooks/memory_context.py
+++ b/src/ccrecall/hooks/memory_context.py
@@ -38,6 +38,7 @@ from ccrecall.formatting import (
     normalize_cwd,
 )
 from ccrecall.models import HookInput
+from ccrecall.serialization import decode_json_column
 from ccrecall.session_tail import (
     find_pending_question,
     format_pending_block,
@@ -91,8 +92,8 @@ def _row_to_entry(row) -> dict:
         "started_at": started_at,
         "ended_at": ended_at,
         "exchange_count": exchange_count,
-        "files_modified": json.loads(files_json) if files_json else [],
-        "commits": json.loads(commits_json) if commits_json else [],
+        "files_modified": decode_json_column(files_json, []),
+        "commits": decode_json_column(commits_json, []),
         "git_branch": git_branch,
         "branch_db_id": branch_db_id,
         "context_summary": context_summary,

--- a/src/ccrecall/parsing.py
+++ b/src/ccrecall/parsing.py
@@ -27,6 +27,16 @@ def is_valid_entry(obj: object) -> bool:
     return is_valid(TranscriptEntry, obj, "transcript entry")
 
 
+def extract_session_uuid(filepath: Path) -> str:
+    """Session UUID from a transcript filename.
+
+    The stem minus an optional ``agent-`` prefix — subagent transcripts are named
+    ``agent-<uuid>.jsonl`` and resolve to the same session UUID as the parent.
+    """
+    stem = filepath.stem
+    return stem.removeprefix("agent-")
+
+
 def parse_jsonl_file(filepath: Path) -> Generator[dict, None, None]:
     """Parse JSONL file, yielding user/assistant entries for import."""
     with open(filepath, encoding="utf-8", errors="replace") as f:

--- a/src/ccrecall/recent_chats.py
+++ b/src/ccrecall/recent_chats.py
@@ -14,6 +14,7 @@ from pathlib import Path
 # Local imports
 from ccrecall.db import DEFAULT_DB_PATH, get_db_connection
 from ccrecall.formatting import format_json_sessions, format_markdown_session
+from ccrecall.serialization import decode_json_column
 
 
 def get_recent_sessions(
@@ -139,9 +140,9 @@ def get_recent_sessions(
         }
 
         if verbose:
-            session_data["files_modified"] = json.loads(files_json) if files_json else []
-            session_data["commits"] = json.loads(commits_json) if commits_json else []
-            session_data["tool_counts"] = json.loads(tool_counts_json) if tool_counts_json else {}
+            session_data["files_modified"] = decode_json_column(files_json, [])
+            session_data["commits"] = decode_json_column(commits_json, [])
+            session_data["tool_counts"] = decode_json_column(tool_counts_json, {})
 
         results.append(session_data)
 

--- a/src/ccrecall/search_conversations.py
+++ b/src/ccrecall/search_conversations.py
@@ -33,6 +33,7 @@ from ccrecall.embeddings import (
 )
 from ccrecall.formatting import format_json_sessions, format_markdown_session
 from ccrecall.fusion import rrf
+from ccrecall.serialization import decode_json_column
 
 
 def _get_fts_branch_ids(
@@ -294,8 +295,8 @@ def _hydrate_branches(
         }
 
         if verbose:
-            session_data["files_modified"] = json.loads(files_json) if files_json else []
-            session_data["commits"] = json.loads(commits_json) if commits_json else []
+            session_data["files_modified"] = decode_json_column(files_json, [])
+            session_data["commits"] = decode_json_column(commits_json, [])
 
         results.append(session_data)
 

--- a/src/ccrecall/serialization.py
+++ b/src/ccrecall/serialization.py
@@ -1,0 +1,41 @@
+"""Helpers for decoding JSON stored in SQLite TEXT columns.
+
+The branch/session rows store ``files_modified``, ``commits``, and ``tool_counts``
+as JSON text. Read paths previously decoded these inline, in two slightly
+different shapes — these helpers give each shape one home:
+
+- ``decode_json_column`` when the value comes straight from a cursor row (raw str).
+- ``decode_json_field`` when an intermediate layer may already have decoded it.
+"""
+
+import json
+from typing import Any
+
+
+def decode_json_column(raw: str | None, default: Any) -> Any:
+    """Decode a raw JSON column value, returning ``default`` when NULL/empty.
+
+    For read paths that hold the raw column string. Assumes well-formed JSON
+    (the columns only ever store json.dumps output), so a corrupt value raises —
+    same as the inline ``json.loads(raw) if raw else default`` it replaces.
+    """
+    return json.loads(raw) if raw else default
+
+
+def decode_json_field(value: object, default: Any) -> Any:
+    """Decode a JSON field that may be a raw string OR already decoded.
+
+    Some callers hand back the raw column string; others (e.g. memory_context)
+    pre-decode it before passing the row on. Returns ``default`` for None/empty,
+    the value unchanged if already decoded, or the parsed JSON if it's a string;
+    a malformed string falls back to ``default``.
+    """
+    # Falsy (None, "", empty list/dict) -> default, mirroring the old `value or default`.
+    if not value:
+        return default
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return default

--- a/src/ccrecall/session_ops.py
+++ b/src/ccrecall/session_ops.py
@@ -35,6 +35,7 @@ from ccrecall.parsing import (
     build_aggregated_content,
     compute_branch_metadata,
     extract_session_metadata,
+    extract_session_uuid,
     find_all_branches,
     parse_all_with_uuids,
     parse_jsonl_file,
@@ -112,10 +113,7 @@ def sync_session(
     # Extract session-level metadata
     meta = extract_session_metadata(all_entries)
 
-    # Session UUID
-    session_uuid = filepath.stem
-    if session_uuid.startswith("agent-"):
-        session_uuid = session_uuid[6:]
+    session_uuid = extract_session_uuid(filepath)
 
     # Project upsert (skip when caller pre-resolved project_id)
     if _project_id is not None:

--- a/src/ccrecall/session_tail.py
+++ b/src/ccrecall/session_tail.py
@@ -33,6 +33,7 @@ from ccrecall.content import (
 from ccrecall.db import DEFAULT_PROJECTS_DIR
 from ccrecall.parsing import (
     extract_session_metadata,
+    extract_session_uuid,
     parse_all_with_uuids,
     parse_lines_with_uuids,
 )
@@ -290,8 +291,10 @@ def emit(path: Path, k: int) -> int:
         print(f"cm-session-tail: transcript is empty: {path}", file=sys.stderr)
         return 1
     meta = extract_session_metadata(entries)
-    # sessionId is Any (untyped JSON) and the path.stem fallback is str; str() narrows for the type checker.
-    sid = str(next((e.get("sessionId") for e in entries if e.get("sessionId")), path.stem))
+    # Prefer an entry's sessionId; fall back to the filename UUID (agent- prefix
+    # stripped so it matches the session record). sessionId is Any (untyped JSON)
+    # and the fallback is str, so str() narrows for the type checker.
+    sid = str(next((e.get("sessionId") for e in entries if e.get("sessionId")), extract_session_uuid(path)))
 
     print(f"RESUME — prior session {sid[:8]}")
     print(f"  transcript:  {path}")

--- a/src/ccrecall/summarizer.py
+++ b/src/ccrecall/summarizer.py
@@ -11,6 +11,7 @@ import re
 import sqlite3
 
 from ccrecall.formatting import format_time, format_time_full
+from ccrecall.serialization import decode_json_field
 
 # Truncation limits
 _FRONT_CHARS = 300
@@ -151,27 +152,10 @@ def build_context_summary_json(branch_row: dict, messages: list[dict]) -> dict:
     if len(topic) > 120:
         topic = topic[:120] + "..."
 
-    # Parse JSON fields from branch_row
-    files = branch_row.get("files_modified") or "[]"
-    if isinstance(files, str):
-        try:
-            files = json.loads(files)
-        except (json.JSONDecodeError, TypeError):
-            files = []
-
-    commits = branch_row.get("commits") or "[]"
-    if isinstance(commits, str):
-        try:
-            commits = json.loads(commits)
-        except (json.JSONDecodeError, TypeError):
-            commits = []
-
-    tool_counts = branch_row.get("tool_counts") or "{}"
-    if isinstance(tool_counts, str):
-        try:
-            tool_counts = json.loads(tool_counts)
-        except (json.JSONDecodeError, TypeError):
-            tool_counts = {}
+    # Parse JSON fields from branch_row (raw column strings or already decoded)
+    files = decode_json_field(branch_row.get("files_modified"), [])
+    commits = decode_json_field(branch_row.get("commits"), [])
+    tool_counts = decode_json_field(branch_row.get("tool_counts"), {})
 
     disposition = detect_disposition(exchanges, commits=commits)
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -9,10 +9,31 @@ from hypothesis import strategies as st
 from ccrecall.parsing import (
     compute_branch_metadata,
     extract_session_metadata,
+    extract_session_uuid,
     find_all_branches,
     parse_all_with_uuids,
     parse_jsonl_file,
 )
+
+
+class TestExtractSessionUuid:
+    def test_plain_session_file(self):
+        assert extract_session_uuid(Path("/x/abc-123.jsonl")) == "abc-123"
+
+    def test_agent_prefix_stripped(self):
+        assert extract_session_uuid(Path("/x/agent-abc-123.jsonl")) == "abc-123"
+
+    def test_no_double_strip(self):
+        # only the leading prefix is removed
+        assert extract_session_uuid(Path("/x/agent-agent-1.jsonl")) == "agent-1"
+
+    def test_uuid_containing_agent_substring_untouched(self):
+        assert extract_session_uuid(Path("/x/myagent-1.jsonl")) == "myagent-1"
+
+    def test_extensionless_path(self):
+        # Works regardless of extension — stem handles it.
+        assert extract_session_uuid(Path("/x/agent-abc")) == "abc"
+
 
 # Verified expected values from real fixture analysis
 EXPECTED = {

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,58 @@
+"""Tests for the shared JSON-column decode helpers."""
+
+import json
+
+import pytest
+
+from ccrecall.serialization import decode_json_column, decode_json_field
+
+
+class TestDecodeJsonColumn:
+    """Strict decode: raw column string or NULL only."""
+
+    def test_none_returns_default(self):
+        assert decode_json_column(None, []) == []
+        assert decode_json_column(None, {}) == {}
+
+    def test_empty_string_returns_default(self):
+        assert decode_json_column("", []) == []
+
+    def test_valid_list(self):
+        assert decode_json_column('["a", "b"]', []) == ["a", "b"]
+
+    def test_valid_dict(self):
+        assert decode_json_column('{"Read": 2}', {}) == {"Read": 2}
+
+    def test_default_identity_preserved(self):
+        sentinel = ["unchanged"]
+        assert decode_json_column(None, sentinel) is sentinel
+
+    def test_malformed_raises(self):
+        # Contract: columns only ever hold json.dumps output, so a corrupt value
+        # raises rather than masking DB corruption — same as the inline code.
+        with pytest.raises(json.JSONDecodeError):
+            decode_json_column("{not json", [])
+
+
+class TestDecodeJsonField:
+    """Lenient decode: raw string, already-decoded value, or empty."""
+
+    def test_none_returns_default(self):
+        assert decode_json_field(None, []) == []
+
+    def test_empty_string_returns_default(self):
+        assert decode_json_field("", []) == []
+
+    def test_raw_string_parsed(self):
+        assert decode_json_field('["x"]', []) == ["x"]
+
+    def test_already_decoded_passthrough(self):
+        already = ["a", "b"]
+        assert decode_json_field(already, []) is already
+
+    def test_already_decoded_dict_passthrough(self):
+        already = {"Read": 1}
+        assert decode_json_field(already, {}) is already
+
+    def test_malformed_string_returns_default(self):
+        assert decode_json_field("{not json", []) == []


### PR DESCRIPTION
## What

De-duplicates three inline ingest patterns the audit flagged (Finding #2):

| Helper | Replaces | Sites |
|---|---|---|
| `parsing.extract_session_uuid(path)` | `stem.startswith("agent-") -> stem[6:]` | session_ops, db._backfill_origin, import_conversations (+ session_tail fallback) |
| `serialization.decode_json_column(raw, default)` (strict) | `json.loads(x) if x else default` | recent_chats ×3, search_conversations ×2, memory_context ×2 |
| `serialization.decode_json_field(value, default)` (lenient) | summarizer's 3 polymorphic decode blocks | summarizer |

`decode_json_field` is separate from `decode_json_column` because `build_context_summary_json` is fed from two paths — one passing a raw SQL column string, one passing an already-decoded list (`memory_context._row_to_entry`) — so it must accept either. The two helpers are documented with a "which to use" rule in the module docstring.

## Behavior

Behavior-preserving except **one intended fix**: `session_tail`'s display-fallback previously used bare `path.stem` (the inconsistent 4th `agent-` site), so for a subagent transcript with no `sessionId` it showed `agent-<uuid>`. It now strips the prefix, matching the session record everywhere else.

## Deferred (with reason)

The audit also mentioned unifying "two non-converging path/project-key strategies." **Deferred** — `session_tail`'s raw-cwd slug is *intentional* (its docstring explains it needs the raw slug to locate worktree transcripts on disk; `get_project_key` normalizes for DB grouping; `db._migrate_project_paths` heals legacy rows). These are three distinct operations, not a mechanical dup. Integration reviewer concurred.

## Verification

- `pytest`: **618 passed** (17 new)
- `ruff` + `ruff format`: clean
- `pyright`: 0 errors
- custom guards: pass
- code-reviewer + integration-reviewer + wtf-reviewer: **all APPROVE**

From the 2026-06-20 audit (Finding #2).