### PR TITLE
test: cover the token subsystem (parser, output, insights)

### DIFF
--- a/src/ccrecall/token_parser.py
+++ b/src/ccrecall/token_parser.py
@@ -115,6 +115,11 @@ MODEL_PRICING: list[tuple[str, dict[str, float]]] = [
 ]
 
 
+# Fallback rates for unknown/missing models. Resolved by name so reordering
+# MODEL_PRICING can't silently change the default (was a hardcoded [4][1] index).
+DEFAULT_PRICING = next(rates for substr, rates in MODEL_PRICING if substr == "sonnet")
+
+
 def get_pricing(model: str | None) -> dict[str, float]:
     """Return pricing dict for a model ID, falling back to Sonnet rates."""
     if model:
@@ -122,7 +127,7 @@ def get_pricing(model: str | None) -> dict[str, float]:
         for substr, rates in MODEL_PRICING:
             if substr in m:
                 return rates
-    return MODEL_PRICING[4][1]  # default: sonnet
+    return DEFAULT_PRICING
 
 
 def turn_cost(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,12 @@ from pathlib import Path
 
 import pytest
 import sqlite_vec
+from token_helpers import TOKEN_JNL, token_session, token_turn
 
 from ccrecall.db import SCHEMA, _ensure_vec_schema, _migrate_columns
+from ccrecall.token_analytics import import_session
+from ccrecall.token_parser import ToolCall
+from ccrecall.token_schema import ensure_schema
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
 
@@ -49,3 +53,41 @@ def memory_db():
 def jsonl_fixture(request):
     """Parameterized fixture yielding each JSONL file path."""
     return request.param
+
+
+@pytest.fixture
+def token_db():
+    """In-memory DB with the token-ingest schema and no data."""
+    conn = sqlite3.connect(":memory:")
+    ensure_schema(conn)
+    conn.commit()
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def populated_token_db():
+    """Token DB with a known dataset, so read-side aggregates are assertable.
+
+    Two top-level sessions, three turns total:
+      s1: turn1 (in=100, out=50, one Read tool call), turn2 (in=200, out=80)
+      s2: turn1 (in=300, out=120)
+    Totals: sessions=2, turns=3, output=250, input=600, tool calls=1.
+    """
+    conn = sqlite3.connect(":memory:")
+    ensure_schema(conn)
+    import_session(
+        conn,
+        token_session(
+            "s1",
+            [
+                token_turn(1, input_tokens=100, output_tokens=50, tool_calls=[ToolCall("Read", "t1")]),
+                token_turn(2, input_tokens=200, output_tokens=80),
+            ],
+        ),
+        TOKEN_JNL,
+    )
+    import_session(conn, token_session("s2", [token_turn(1, input_tokens=300, output_tokens=120)]), TOKEN_JNL)
+    conn.commit()
+    yield conn
+    conn.close()

--- a/tests/test_ingest_token_data.py
+++ b/tests/test_ingest_token_data.py
@@ -9,6 +9,7 @@ import sqlite3
 from pathlib import Path
 
 import pytest
+from token_helpers import token_session, token_turn
 
 from ccrecall.token_analytics import import_session
 from ccrecall.token_parser import (
@@ -27,11 +28,11 @@ from ccrecall.token_schema import (
     ensure_schema,
 )
 
-# Helpers
+# Helpers — the token_db fixture lives in conftest.py.
 
 
 def _minimal_jnl(tmp_path: Path) -> JnlFile:
-    """A JnlFile pointing at a dummy path (file not actually read in these tests)."""
+    """A JnlFile pointing at a real (empty) file — needed by the mtime/skip tests."""
     fake_path = tmp_path / "fake-session.jsonl"
     fake_path.write_text("")
     return JnlFile(
@@ -43,30 +44,11 @@ def _minimal_jnl(tmp_path: Path) -> JnlFile:
 
 
 def _make_session(session_id: str, turns: list[Turn]) -> ParsedSession:
-    """Build a minimal ParsedSession from an explicit turn list."""
-    s = ParsedSession(session_id=session_id, project_path="/test/project")
-    s.turns = turns
-    return s
+    return token_session(session_id, turns, project_path="/test/project")
 
 
 def _make_turn(index: int, input_tokens: int = 100, output_tokens: int = 50) -> Turn:
-    return Turn(
-        index=index,
-        message_id=f"msg-{index}",
-        timestamp=f"2026-03-01T10:0{index}:00Z",
-        input_tokens=input_tokens,
-        output_tokens=output_tokens,
-    )
-
-
-@pytest.fixture
-def token_db():
-    """In-memory DB with full token ingest schema."""
-    conn = sqlite3.connect(":memory:")
-    ensure_schema(conn)
-    conn.commit()
-    yield conn
-    conn.close()
+    return token_turn(index, input_tokens=input_tokens, output_tokens=output_tokens)
 
 
 # Gap 4a — turns are append-only (skip-if-exists)

--- a/tests/test_token_insights.py
+++ b/tests/test_token_insights.py
@@ -1,0 +1,89 @@
+"""Tests for token_insights: trend windows and insight generation."""
+
+from token_helpers import TOKEN_JNL, token_session, token_turn
+from whenever import Instant
+
+from ccrecall.token_analytics import import_session
+from ccrecall.token_insights import build_insights_and_trends, build_trends
+
+
+def _session_at(sid: str, days_ago: int):
+    """A one-turn session whose timestamp lands `days_ago` before now."""
+    ts = Instant.now().subtract(hours=24 * days_ago).format_iso()
+    return token_session(sid, [token_turn(1, timestamp=ts, input_tokens=100, output_tokens=50)])
+
+
+def _insight_kwargs(**overrides):
+    """A complete kwargs set for build_insights_and_trends, all signals off.
+
+    The count/rate signals below are what fire insights when nonzero; the
+    structural args after the blank line just shape output and never trigger one.
+    """
+    base = dict(
+        total_output=0,
+        total_input=0,
+        cache_cliffs=0,
+        max_token_stops=0,
+        total_bash_antipatterns=0,
+        redundant_reads_count=0,
+        edit_retries_count=0,
+        total_thinking=0,
+        total_tool_errors=0,
+        global_cache_ratio=0.0,
+        total_cost_usd=0.0,
+        total_sessions=10,
+        response_time_dist={},
+        bash_antipattern_projects=[],
+        top_redundant_files=[],
+        edit_retry_projects=[],
+        cost_by_project=[],
+        context_seg_summary={},
+        dominant_cache_tier="5m",
+        model_split=[],
+    )
+    base.update(overrides)
+    return base
+
+
+class TestBuildTrends:
+    def test_no_recent_data_returns_empty(self, populated_token_db):
+        # The shared fixture is dated 2026-03-01, well outside the 7-day rolling
+        # window, so build_trends short-circuits to an empty dict.
+        assert build_trends(populated_token_db) == {}
+
+    def test_empty_db_returns_empty(self, token_db):
+        assert build_trends(token_db) == {}
+
+    def test_structure_with_recent_data(self, token_db):
+        # One session in the current window (1d ago) and one in the prior (9d ago).
+        import_session(token_db, _session_at("cur", days_ago=1), TOKEN_JNL)
+        import_session(token_db, _session_at("pri", days_ago=9), TOKEN_JNL)
+        token_db.commit()
+        t = build_trends(token_db)
+        assert t["window_days"] == 7
+        for key in ("current_window", "prior_window", "metrics", "improved", "regressed"):
+            assert key in t
+
+
+class TestBuildInsights:
+    def test_returns_all_sections(self, token_db):
+        result = build_insights_and_trends(token_db, **_insight_kwargs())
+        for key in ("insights", "findings", "recommendations", "trends"):
+            assert key in result
+        assert isinstance(result["insights"], list)
+
+    def test_cache_cliffs_insight_fires(self, token_db):
+        result = build_insights_and_trends(token_db, **_insight_kwargs(cache_cliffs=5))
+        titles = [i["title"] for i in result["insights"]]
+        assert "Cache Cliffs" in titles
+
+    def test_cache_cliffs_absent_when_zero(self, token_db):
+        result = build_insights_and_trends(token_db, **_insight_kwargs(cache_cliffs=0))
+        titles = [i["title"] for i in result["insights"]]
+        assert "Cache Cliffs" not in titles
+
+    def test_cache_cliffs_insight_has_waste_estimate(self, token_db):
+        result = build_insights_and_trends(token_db, **_insight_kwargs(cache_cliffs=5))
+        cliff = next(i for i in result["insights"] if i["title"] == "Cache Cliffs")
+        assert cliff["waste_tokens"] == 5 * 15000
+        assert cliff["severity"] in ("INFO", "WARNING", "CRITICAL")

--- a/tests/test_token_output.py
+++ b/tests/test_token_output.py
@@ -1,0 +1,65 @@
+"""Tests for token_output.build_output.
+
+build_output runs the full read-side aggregation (and spreads in
+build_insights_and_trends), so these exercise token_output and token_insights
+together against the shared populated_token_db fixture (see conftest).
+"""
+
+from ccrecall.token_output import build_output
+
+
+class TestBuildOutputKpis:
+    def test_kpi_aggregates(self, populated_token_db):
+        kpis = build_output(populated_token_db)["kpis"]
+        assert kpis["total_sessions"] == 2
+        assert kpis["total_turns"] == 3
+        assert kpis["total_output_tokens"] == 50 + 80 + 120
+        assert kpis["total_cost_usd"] >= 0
+
+    def test_top_level_total_sessions(self, populated_token_db):
+        assert build_output(populated_token_db)["total_sessions"] == 2
+
+    def test_date_range_present(self, populated_token_db):
+        dr = build_output(populated_token_db)["date_range"]
+        assert dr["earliest"] == "2026-03-01"
+        assert dr["latest"] == "2026-03-01"
+
+    def test_top_tools_counts_read(self, populated_token_db):
+        tools = {t["tool"]: t["count"] for t in build_output(populated_token_db)["top_tools"]}
+        assert tools.get("Read") == 1
+
+
+class TestBuildOutputStructure:
+    def test_has_expected_sections(self, populated_token_db):
+        out = build_output(populated_token_db)
+        for key in (
+            "kpis",
+            "date_range",
+            "sessions_by_day",
+            "top_tools",
+            "model_split",
+            "cost_by_day",
+            # spread in from build_insights_and_trends:
+            "insights",
+            "findings",
+            "recommendations",
+            "trends",
+        ):
+            assert key in out, f"missing section: {key}"
+
+    def test_insights_and_trends_types(self, populated_token_db):
+        out = build_output(populated_token_db)
+        assert isinstance(out["insights"], list)
+        assert isinstance(out["findings"], list)
+        assert isinstance(out["recommendations"], list)
+        assert isinstance(out["trends"], dict)
+
+
+class TestBuildOutputEmpty:
+    def test_empty_db_zeroed_not_crashed(self, token_db):
+        out = build_output(token_db)
+        assert out["kpis"]["total_sessions"] == 0
+        assert out["kpis"]["total_turns"] == 0
+        assert out["kpis"]["total_cost_usd"] == 0
+        assert out["top_tools"] == []
+        assert out["date_range"]["earliest"] is None

--- a/tests/test_token_parser.py
+++ b/tests/test_token_parser.py
@@ -1,14 +1,19 @@
-"""Tests for token_parser.parse_session.
+"""Tests for token_parser: parse_session, pricing, and cost computation.
 
-The characterization tests here pin parse_session's behavior on realistic JSONL,
-so that boundary-validation changes stay provably behavior-preserving on valid
-input.
+The parse_session characterization tests pin its behavior on realistic JSONL, so
+boundary-validation changes stay provably behavior-preserving on valid input.
 """
 
 import json
 from pathlib import Path
 
-from ccrecall.token_parser import JnlFile, parse_session
+from ccrecall.token_parser import (
+    DEFAULT_PRICING,
+    JnlFile,
+    get_pricing,
+    parse_session,
+    turn_cost,
+)
 
 
 def _jnl(tmp_path: Path, lines: list[dict], name: str = "sess.jsonl") -> JnlFile:
@@ -133,3 +138,59 @@ class TestParseSessionCharacterization:
         assert session is not None
         assert len(session.turns) == 1
         assert session.turns[0].input_tokens == 5
+
+
+# ── Pricing ────────────────────────────────────────────────────────────────
+
+
+class TestGetPricing:
+    def test_opus_46(self):
+        assert get_pricing("claude-opus-4-6-20260101")["input"] == 5.0
+
+    def test_opus_41_distinct_from_46(self):
+        # opus-4-1 is the older, pricier tier — must not collide with opus-4-6.
+        assert get_pricing("claude-opus-4-1-20250805")["input"] == 15.0
+
+    def test_sonnet(self):
+        assert get_pricing("claude-sonnet-4-5")["input"] == 3.0
+
+    def test_haiku_uppercase_matches(self):
+        # get_pricing lowercases the model id before matching.
+        assert get_pricing("CLAUDE-HAIKU-4-5")["input"] == 1.0
+
+    def test_unknown_model_falls_back_to_sonnet(self):
+        # The fallback-by-name fix: an unrecognized model gets Sonnet rates.
+        assert get_pricing("gpt-4-turbo") == DEFAULT_PRICING
+        assert get_pricing("gpt-4-turbo")["input"] == 3.0
+
+    def test_none_falls_back_to_sonnet(self):
+        assert get_pricing(None) == DEFAULT_PRICING
+
+    def test_default_pricing_is_sonnet(self):
+        assert get_pricing("claude-sonnet-4-5") == DEFAULT_PRICING
+
+
+# ── Cost computation ─────────────────────────────────────────────────────────
+
+
+class TestTurnCost:
+    # Exactly 1M tokens of each kind, so cost == the per-million rate from the
+    # pricing dict — derived from the dict so it can't drift if rates change.
+    def test_input_and_output(self):
+        p = get_pricing("claude-sonnet-4-5")
+        assert turn_cost(1_000_000, 0, 0, 0, 0, 0, p) == p["input"]
+        assert turn_cost(0, 1_000_000, 0, 0, 0, 0, p) == p["output"]
+
+    def test_cache_tiers(self):
+        p = get_pricing("claude-sonnet-4-5")
+        assert turn_cost(0, 0, 1_000_000, 0, 0, 0, p) == p["cache_read"]
+        assert turn_cost(0, 0, 0, 0, 1_000_000, 0, p) == p["cache_write_5m"]
+        assert turn_cost(0, 0, 0, 0, 0, 1_000_000, p) == p["cache_write_1h"]
+
+    def test_unclassified_creation_billed_at_5m(self):
+        # cache_creation beyond the classified 5m/1h tiers is attributed to 5m.
+        p = get_pricing("claude-sonnet-4-5")
+        assert turn_cost(0, 0, 0, 1_000_000, 0, 0, p) == p["cache_write_5m"]
+
+    def test_zero_everything(self):
+        assert turn_cost(0, 0, 0, 0, 0, 0, get_pricing(None)) == 0.0

--- a/tests/token_helpers.py
+++ b/tests/token_helpers.py
@@ -1,0 +1,41 @@
+"""Shared builders for token-subsystem tests.
+
+One place to construct token sessions/turns and the dummy JnlFile, so the
+fixtures in conftest and the per-module tests don't drift apart.
+"""
+
+from pathlib import Path
+
+from ccrecall.token_parser import JnlFile, ParsedSession, Turn
+
+# Dummy source file for import_session — not read by the import path itself.
+TOKEN_JNL = JnlFile(path=Path("/x/s.jsonl"), project_cwd="/home/u/proj", is_sidechain=False, parent_session_id=None)
+
+
+def token_turn(
+    index: int,
+    *,
+    timestamp: str | None = None,
+    model: str = "claude-sonnet-4-5",
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_read: int = 0,
+    tool_calls: list | None = None,
+) -> Turn:
+    return Turn(
+        index=index,
+        message_id=f"m{index}",
+        # :02d so multi-turn fixtures (index >= 10) stay valid timestamps.
+        timestamp=timestamp or f"2026-03-01T10:{index:02d}:00Z",
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read,
+        tool_calls=tool_calls or [],
+    )
+
+
+def token_session(sid: str, turns: list[Turn], project_path: str = "/home/u/proj") -> ParsedSession:
+    s = ParsedSession(session_id=sid, project_path=project_path)
+    s.turns = turns
+    return s


### PR DESCRIPTION
## What

The token modules (`token_parser`, `token_output`, `token_insights`, ~39% of source) had **no direct tests** — the audit's Finding #3. Adds:

- **test_token_parser.py** — `get_pricing` (each tier + unknown/None → Sonnet fallback) and `turn_cost` (cost math derived from the pricing dict so the assertions can't drift if rates change). Plus the pre-existing `parse_session` characterization tests.
- **test_token_output.py** — `build_output` KPI aggregates (sessions/turns/output sums I control via the fixture), section structure, and empty-DB zeroing. Exercises `build_insights_and_trends` transitively (it's spread into the output).
- **test_token_insights.py** — `build_trends` (time-relative windows, using recent-relative timestamps via `whenever`) and `build_insights_and_trends` (cache-cliffs insight fires / is absent / waste estimate).

## Shared fixtures (de-duplicated)

Shared token-DB fixtures (`token_db`, `populated_token_db`) live in `conftest.py`; builders (`token_turn`/`token_session`/`TOKEN_JNL`) in new `tests/token_helpers.py`. `test_ingest_token_data.py` was migrated onto them (its local `token_db` fixture deleted, builders now delegate) so there's **one** way to build a token DB in the suite.

## Small src hardening

`get_pricing`'s unknown-model fallback was `return MODEL_PRICING[4][1]` (hardcoded index = Sonnet). Replaced with `DEFAULT_PRICING`, resolved by name. **Behavior-identical today**, but a list reorder can no longer silently change the default. The new `get_pricing` tests pin this.

## Verification

- `pytest`: **643 passed** (token coverage: parser 15, output 7, insights 7)
- `ruff` + `ruff format`: clean
- `pyright`: 0 errors
- custom guards: pass
- code-reviewer + integration-reviewer + wtf-reviewer: **all APPROVE** (integration re-review after consolidating the duplicate fixtures/builders)

From the 2026-06-20 audit (Finding #3).