### PR TITLE
refactor: full clean-code pass across ccrecall (#15)

### DIFF
--- a/src/ccrecall/cli/__init__.py
+++ b/src/ccrecall/cli/__init__.py
@@ -92,9 +92,7 @@ def main() -> None:
 
 # Importing the commands module registers every subcommand on ``app`` /
 # ``backfill_app`` via the @app.command decorators it defines. Kept at the
-# bottom so ``app`` and ``backfill_app`` exist before the decorators run.
-from ccrecall.cli import commands  # noqa: E402
-
-# Reference the side-effect import so ruff and pyright see it as used; the real
-# effect is the subcommand registration that ran at import time.
-_ = commands
+# bottom so ``app`` and ``backfill_app`` exist before the decorators run. The
+# redundant ``as commands`` alias marks it as an intentional side-effect import,
+# so ruff and pyright don't flag it unused without needing a separate sentinel.
+from ccrecall.cli import commands as commands  # noqa: E402

--- a/src/ccrecall/content.py
+++ b/src/ccrecall/content.py
@@ -1,9 +1,16 @@
-"""
-Message content extraction and tool detection utilities.
-"""
+"""Message content extraction and tool detection utilities."""
 
 import json
 import re
+
+# Commit messages are stored truncated — they're for at-a-glance session context,
+# not full reconstruction.
+MAX_COMMIT_MESSAGE_LEN = 100
+
+
+def escape_like(value: str) -> str:
+    """Escape SQLite LIKE wildcards so a user value matches literally (pair with ESCAPE '\\')."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
 def sanitize_fts_term(term: str) -> str:
@@ -91,28 +98,26 @@ def parse_origin(entry: dict) -> str | None:
     return None
 
 
-def is_task_notification(content) -> bool:
-    """Check if content is a task-notification message (subagent result)."""
+def extract_plain_text(content) -> str | None:
+    """Join text blocks (or a bare string) into stripped plain text; None if neither shape."""
     if isinstance(content, list):
         texts = [item.get("text", "") for item in content if isinstance(item, dict) and item.get("type") == "text"]
-        text = "\n".join(texts).strip()
-    elif isinstance(content, str):
-        text = content.strip()
-    else:
-        return False
-    return text.startswith("<task-notification>")
+        return "\n".join(texts).strip()
+    if isinstance(content, str):
+        return content.strip()
+    return None
+
+
+def is_task_notification(content) -> bool:
+    """Check if content is a task-notification message (subagent result)."""
+    text = extract_plain_text(content)
+    return text is not None and text.startswith("<task-notification>")
 
 
 def is_teammate_message(content) -> bool:
     """Detect teammate coordination messages (team reports, idle notifications, shutdown)."""
-    if isinstance(content, list):
-        texts = [item.get("text", "") for item in content if isinstance(item, dict) and item.get("type") == "text"]
-        text = "\n".join(texts).strip()
-    elif isinstance(content, str):
-        text = content.strip()
-    else:
-        return False
-    return text.startswith("<teammate-message")
+    text = extract_plain_text(content)
+    return text is not None and text.startswith("<teammate-message")
 
 
 def is_tool_result(content) -> bool:
@@ -146,7 +151,7 @@ def extract_commits(content) -> list[str]:
                 if item.get("name") == "Bash":
                     cmd = item.get("input", {}).get("command", "")
                     if "git commit" in cmd:
-                        m = re.search(r'-m\s+["\']([^"\']+)["\']', cmd)
-                        if m:
-                            commits.append(m.group(1)[:100])
+                        match = re.search(r'-m\s+["\']([^"\']+)["\']', cmd)
+                        if match:
+                            commits.append(match.group(1)[:MAX_COMMIT_MESSAGE_LEN])
     return commits

--- a/src/ccrecall/content.py
+++ b/src/ccrecall/content.py
@@ -8,11 +8,6 @@ import re
 MAX_COMMIT_MESSAGE_LEN = 100
 
 
-def escape_like(value: str) -> str:
-    """Escape SQLite LIKE wildcards so a user value matches literally (pair with ESCAPE '\\')."""
-    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-
-
 def sanitize_fts_term(term: str) -> str:
     """Remove FTS special characters from search term.
 

--- a/src/ccrecall/db.py
+++ b/src/ccrecall/db.py
@@ -23,6 +23,10 @@ DEFAULT_PROJECTS_DIR = Path.home() / ".claude" / "projects"
 DEFAULT_LOG_PATH = Path.home() / ".claude-memory" / "memory.log"
 CONFIG_PATH = Path.home() / ".claude-memory" / "config.json"
 
+# Hook filenames/prefixes — writer and reader live in different modules and must agree.
+CLEAR_HANDOFF_FILENAME = "clear-handoff.json"
+SYNC_TEMP_PREFIX = "claude-memory-sync-"
+
 # Shared SQL predicate for "branches that are candidates to embed": active
 # leaves (the query path only returns is_active=1) with a usable summary. This
 # is the single source of truth for the embedding universe — build_selection()
@@ -73,6 +77,17 @@ def apply_base_pragmas(conn: sqlite3.Connection) -> None:
     conn.execute("PRAGMA journal_mode = WAL")
     conn.execute(f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS}")
     conn.execute("PRAGMA foreign_keys = ON")
+
+
+def pid_file_path(pid_key: str) -> Path:
+    """Path to a background job's PID sentinel (lives beside the DB)."""
+    return DEFAULT_DB_PATH.parent / f".pid-{pid_key}"
+
+
+def remove_pid_file(pid_key: str) -> None:
+    """Delete a job's PID sentinel so the next session can spawn again (best-effort)."""
+    with contextlib.suppress(OSError):
+        pid_file_path(pid_key).unlink(missing_ok=True)
 
 
 def vec_available(conn: sqlite3.Connection) -> bool:

--- a/src/ccrecall/db.py
+++ b/src/ccrecall/db.py
@@ -14,7 +14,7 @@ import sqlite_vec
 
 from ccrecall.embeddings import EMBEDDING_DIM, EMBEDDING_MODEL, EMBEDDING_VERSION
 from ccrecall.migrations import migrate_columns, migrate_db
-from ccrecall.models import LOGGER_NAME
+from ccrecall.models import BUSY_TIMEOUT_MS, LOGGER_NAME
 from ccrecall.schema import SCHEMA_CORE, SCHEMA_FTS4, SCHEMA_FTS5, detect_fts_support
 
 # Default paths
@@ -57,9 +57,8 @@ _CONFIG_KEYS = {
 
 CURRENT_ONBOARDING_VERSION = 1
 
-# Base connections wait this long on a writer-writer collision; vec-loaded
-# connections (concurrent embedding writers) get a longer window.
-BUSY_TIMEOUT_MS = 5000
+# Vec-loaded connections (concurrent embedding writers) wait longer than the
+# base BUSY_TIMEOUT_MS on a collision.
 VEC_BUSY_TIMEOUT_MS = 30000
 
 # Rotating memory-log handler sizing.
@@ -88,6 +87,11 @@ def remove_pid_file(pid_key: str) -> None:
     """Delete a job's PID sentinel so the next session can spawn again (best-effort)."""
     with contextlib.suppress(OSError):
         pid_file_path(pid_key).unlink(missing_ok=True)
+
+
+def escape_like(value: str) -> str:
+    """Escape SQLite LIKE wildcards so a user value matches literally (pair with ESCAPE '\\')."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
 def vec_available(conn: sqlite3.Connection) -> bool:

--- a/src/ccrecall/db.py
+++ b/src/ccrecall/db.py
@@ -1,5 +1,4 @@
-"""
-Database connection, config/settings, vec (embedding) operations, and logging.
+"""Database connection, config/settings, vec (embedding) operations, and logging.
 
 Schema constants live in ccrecall.schema; migrations in ccrecall.migrations.
 """
@@ -15,6 +14,7 @@ import sqlite_vec
 
 from ccrecall.embeddings import EMBEDDING_DIM, EMBEDDING_MODEL, EMBEDDING_VERSION
 from ccrecall.migrations import migrate_columns, migrate_db
+from ccrecall.models import LOGGER_NAME
 from ccrecall.schema import SCHEMA_CORE, SCHEMA_FTS4, SCHEMA_FTS5, detect_fts_support
 
 # Default paths
@@ -52,6 +52,27 @@ _CONFIG_KEYS = {
 }
 
 CURRENT_ONBOARDING_VERSION = 1
+
+# Base connections wait this long on a writer-writer collision; vec-loaded
+# connections (concurrent embedding writers) get a longer window.
+BUSY_TIMEOUT_MS = 5000
+VEC_BUSY_TIMEOUT_MS = 30000
+
+# Rotating memory-log handler sizing.
+LOG_MAX_BYTES = 1_000_000
+LOG_BACKUP_COUNT = 2
+
+
+def apply_base_pragmas(conn: sqlite3.Connection) -> None:
+    """Set WAL mode, busy_timeout, and foreign-key enforcement for concurrent-safe access.
+
+    WAL lets readers and writers proceed without blocking each other; busy_timeout
+    waits instead of failing on a writer-writer collision; foreign_keys=ON prevents
+    orphaned rows.
+    """
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute(f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS}")
+    conn.execute("PRAGMA foreign_keys = ON")
 
 
 def vec_available(conn: sqlite3.Connection) -> bool:
@@ -116,6 +137,22 @@ def write_branch_embedding(
         "UPDATE branches SET embedding_version = ?, embedding_model = ?, summary_version_at_embed = ? WHERE id = ?",
         (EMBEDDING_VERSION, EMBEDDING_MODEL, summary_version, branch_id),
     )
+
+
+def fetch_branch_messages(cursor: sqlite3.Cursor, branch_id: int, include_notifications: bool) -> list[dict]:
+    """Return a branch's messages ordered by timestamp; notifications included only when asked."""
+    cursor.execute(
+        """
+        SELECT m.role, m.content, m.timestamp, COALESCE(m.is_notification, 0) as is_notification
+        FROM branch_messages bm
+        JOIN messages m ON bm.message_id = m.id
+        WHERE bm.branch_id = ?
+          AND (? OR COALESCE(m.is_notification, 0) = 0)
+        ORDER BY m.timestamp ASC
+        """,
+        (branch_id, include_notifications),
+    )
+    return [{"role": r, "content": c, "timestamp": t, "is_notification": notif} for r, c, t, notif in cursor.fetchall()]
 
 
 def _ensure_vec_schema(conn: sqlite3.Connection) -> None:
@@ -185,37 +222,24 @@ def get_db_path(settings: dict | None = None) -> Path:
 def get_db_connection(settings: dict | None = None, load_vec: bool = False) -> sqlite3.Connection:
     """Get database connection, initializing schema and running migrations if needed.
 
-    Uses settings-based path if provided.
-    Sets WAL mode and busy_timeout for concurrent access safety.
-
-    Args:
-        settings: Optional settings dict (for db_path override).
-        load_vec: When True, load the sqlite-vec extension on the returned
-            connection and raise busy_timeout to 30000. Use this for
-            connections that query or write branch_vec (search, write path,
-            backfill). Default False keeps the extension unloaded — cheaper
-            for recent-chats, token analytics, and setup paths that never
-            touch branch_vec.
+    Uses the settings-based db_path when provided and applies the base pragmas for
+    concurrent-safe access. When ``load_vec`` is True, loads the sqlite-vec extension
+    and raises busy_timeout to VEC_BUSY_TIMEOUT_MS — use it for connections that query
+    or write branch_vec (search, write path, backfill). Default False keeps the
+    extension unloaded, cheaper for recent-chats, token analytics, and setup paths
+    that never touch branch_vec.
     """
     db_path = get_db_path(settings)
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(db_path)
-
-    # WAL mode: readers never block writers, writers never block readers
-    conn.execute("PRAGMA journal_mode = WAL")
-    # busy_timeout: wait up to 5s on writer-writer collisions instead of failing
-    conn.execute("PRAGMA busy_timeout = 5000")
-    # Enforce foreign key constraints to prevent orphaned data
-    conn.execute("PRAGMA foreign_keys = ON")
+    apply_base_pragmas(conn)
 
     # Check if migration needed (old schema -> v3)
     migrated = migrate_db(conn)
     if migrated:
         # Connection was closed during migration, reconnect
         conn = sqlite3.connect(db_path)
-        conn.execute("PRAGMA journal_mode = WAL")
-        conn.execute("PRAGMA busy_timeout = 5000")
-        conn.execute("PRAGMA foreign_keys = ON")
+        apply_base_pragmas(conn)
 
     if not migrated:
         # Apply schema (handles fresh databases, idempotent)
@@ -236,17 +260,14 @@ def get_db_connection(settings: dict | None = None, load_vec: bool = False) -> s
         # raise busy_timeout for concurrent vec writers.
         _ensure_vec_schema(conn)
         conn.commit()
-        conn.execute("PRAGMA busy_timeout = 30000")
+        conn.execute(f"PRAGMA busy_timeout = {VEC_BUSY_TIMEOUT_MS}")
 
     return conn
 
 
 def setup_logging(settings: dict | None = None) -> logging.Logger:
-    """
-    Set up logging with rotation.
-    Returns a null logger if logging is disabled.
-    """
-    logger = logging.getLogger("claude-memory")
+    """Set up logging with rotation. Returns a null logger if logging is disabled."""
+    logger = logging.getLogger(LOGGER_NAME)
     logger.handlers.clear()
 
     if not settings or not settings.get("logging_enabled", False):
@@ -258,8 +279,8 @@ def setup_logging(settings: dict | None = None) -> logging.Logger:
 
     handler = RotatingFileHandler(
         log_path,
-        maxBytes=1_000_000,  # 1MB
-        backupCount=2,
+        maxBytes=LOG_MAX_BYTES,
+        backupCount=LOG_BACKUP_COUNT,
     )
     formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
     handler.setFormatter(formatter)

--- a/src/ccrecall/formatting.py
+++ b/src/ccrecall/formatting.py
@@ -1,11 +1,12 @@
-"""
-Session formatting, time utilities, and project path helpers.
-"""
+"""Session formatting, time utilities, and project path helpers."""
 
 import json
 from pathlib import Path
 
 from whenever import Instant
+
+# Verbose output lists at most this many modified files before collapsing to a count.
+MAX_FILES_DISPLAYED = 10
 
 
 def format_time(ts_str: str | None, fmt: str = "%H:%M") -> str:
@@ -101,9 +102,9 @@ def format_markdown_session(session: dict, verbose: bool = False) -> str:
         files = session.get("files_modified", [])
         if files:
             lines.append("\n### Files Modified")
-            lines.extend(f"- `{f}`" for f in files[-10:])
-            if len(files) > 10:
-                lines.append(f"- ...and {len(files) - 10} more")
+            lines.extend(f"- `{f}`" for f in files[-MAX_FILES_DISPLAYED:])
+            if len(files) > MAX_FILES_DISPLAYED:
+                lines.append(f"- ...and {len(files) - MAX_FILES_DISPLAYED} more")
 
         commits = session.get("commits", [])
         if commits:
@@ -112,7 +113,7 @@ def format_markdown_session(session: dict, verbose: bool = False) -> str:
 
         tool_counts = session.get("tool_counts", {})
         if tool_counts:
-            sorted_tools = sorted(tool_counts.items(), key=lambda x: x[1], reverse=True)
+            sorted_tools = sorted(tool_counts.items(), key=lambda kv: kv[1], reverse=True)
             tools_str = ", ".join(f"{name}: {count}" for name, count in sorted_tools)
             lines.append("\n### Tools Used")
             lines.append(tools_str)

--- a/src/ccrecall/hooks/backfill_embeddings.py
+++ b/src/ccrecall/hooks/backfill_embeddings.py
@@ -1,5 +1,4 @@
-"""
-Backfill embeddings for existing active-leaf branches.
+"""Backfill embeddings for existing active-leaf branches.
 
 Opt-in: invoke manually via `ccrecall backfill embeddings` to seed historical
 embeddings. NOT auto-spawned on SessionStart (embedding inference is CPU-bound);
@@ -26,11 +25,11 @@ import time
 
 from ccrecall.db import (
     CONTENT_ERROR_VERSION,
-    DEFAULT_DB_PATH,
     EMBEDDABLE_BRANCH_FILTER,
     branch_vec_queryable,
     get_db_connection,
     load_settings,
+    remove_pid_file,
     setup_logging,
     write_branch_embedding,
 )
@@ -47,19 +46,20 @@ BATCH_SIZE = 20
 BACKFILL_BATCH_DELAY_SECONDS = 0.05
 DEFAULT_PROGRESS_EVERY = BATCH_SIZE
 
+# Lower scheduling priority for this background CPU job so interactive work wins.
+BACKFILL_NICE_LEVEL = 10
+
 EXIT_OK = 0
 EXIT_ABORT = 1
 
 # PID key for the self-concurrency guard (this command is manual-only, never
 # auto-spawned; the marker is cleaned up by the CLI command on exit).
 PID_KEY = "ccrecall-backfill-embeddings"
-_PID_FILE = DEFAULT_DB_PATH.parent / f".pid-{PID_KEY}"
 
 
 def cleanup_pid() -> None:
     """Remove the self-concurrency PID marker (no-op if absent)."""
-    with contextlib.suppress(OSError):
-        _PID_FILE.unlink(missing_ok=True)
+    remove_pid_file(PID_KEY)
 
 
 def build_selection(days: int | None) -> tuple[str, list]:
@@ -217,7 +217,7 @@ def run(
     # threads yield to interactive work (machines.md thrash risk). Best-effort —
     # os.nice is POSIX-only and may be denied; either way the run proceeds.
     with contextlib.suppress(AttributeError, OSError):
-        os.nice(10)
+        os.nice(BACKFILL_NICE_LEVEL)
 
     # ABORT level: check model availability before touching any rows.
     # model_available() warms the singleton session on success — no extra cost.

--- a/src/ccrecall/hooks/backfill_summaries.py
+++ b/src/ccrecall/hooks/backfill_summaries.py
@@ -1,19 +1,17 @@
-"""
-Backfill context summaries for existing branches.
+"""Backfill context summaries for existing branches.
 
 Runs as a background process spawned by memory-setup.py on SessionStart.
 Processes branches in batches, commits between batches, and marks errors
 with summary_version = -1 to avoid infinite retry.
 """
 
-import contextlib
 import sqlite3
 
 from ccrecall.db import (
     CONTENT_ERROR_VERSION,
-    DEFAULT_DB_PATH,
     get_db_connection,
     load_settings,
+    remove_pid_file,
     setup_logging,
 )
 from ccrecall.summarizer import SUMMARY_VERSION, compute_context_summary
@@ -23,7 +21,6 @@ BATCH_SIZE = 50
 # PID key — must stay in sync with the spawn in memory_setup
 # (`ccrecall backfill summaries`).
 PID_KEY = "ccrecall-backfill-summaries"
-_PID_FILE = DEFAULT_DB_PATH.parent / f".pid-{PID_KEY}"
 
 
 def run():
@@ -36,8 +33,7 @@ def run():
         _main()
     finally:
         # Delete PID file so _spawn_background can spawn again next session
-        with contextlib.suppress(OSError):
-            _PID_FILE.unlink(missing_ok=True)
+        remove_pid_file(PID_KEY)
 
 
 def _main():

--- a/src/ccrecall/hooks/clear_handoff.py
+++ b/src/ccrecall/hooks/clear_handoff.py
@@ -7,7 +7,7 @@ import sys
 from pydantic import ValidationError
 from whenever import Instant
 
-from ccrecall.db import get_db_path, load_settings
+from ccrecall.db import CLEAR_HANDOFF_FILENAME, get_db_path, load_settings
 from ccrecall.models import HookInput
 
 
@@ -32,7 +32,7 @@ def main():
     with contextlib.suppress(Exception):
         settings = load_settings()
         db_path = get_db_path(settings)
-        handoff_path = db_path.parent / "clear-handoff.json"
+        handoff_path = db_path.parent / CLEAR_HANDOFF_FILENAME
         handoff_path.write_text(
             json.dumps(
                 {

--- a/src/ccrecall/hooks/import_conversations.py
+++ b/src/ccrecall/hooks/import_conversations.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python3
-"""
-Import Claude Code JSONL conversations into SQLite memory database.
+"""Import Claude Code JSONL conversations into the SQLite memory database.
 
 Extracts only searchable text content, skipping progress entries (90% of file size).
 Detects conversation branches (from rewind) and stores each branch separately.
@@ -26,12 +24,20 @@ from ccrecall.parsing import extract_session_uuid
 from ccrecall.project_ops import upsert_project
 from ccrecall.session_ops import sync_session
 
+# Chunk size for streaming a file through the change-detection hash (bounded memory).
+HASH_CHUNK_SIZE = 8192
+BYTES_PER_MB = 1024 * 1024
+
+# PID key — must stay in sync with the spawn in memory_setup (`ccrecall import`).
+PID_KEY = "ccrecall-import"
+_PID_FILE = DEFAULT_DB_PATH.parent / f".pid-{PID_KEY}"
+
 
 def get_file_hash(filepath: Path) -> str:
     """Get MD5 hash of file for change detection."""
     h = hashlib.md5(usedforsecurity=False)
     with open(filepath, "rb") as f:
-        for chunk in iter(lambda: f.read(8192), b""):
+        for chunk in iter(lambda: f.read(HASH_CHUNK_SIZE), b""):
             h.update(chunk)
     return h.hexdigest()
 
@@ -79,10 +85,10 @@ def import_session(
     session_uuid = extract_session_uuid(filepath)
 
     cursor.execute("SELECT id FROM sessions WHERE uuid = ?", (session_uuid,))
-    row = cursor.fetchone()
-    if not row:
+    session_row = cursor.fetchone()
+    if not session_row:
         return -1, 0
-    session_id = row[0]
+    session_id = session_row[0]
 
     cursor.execute("SELECT COUNT(*) FROM messages WHERE session_id = ?", (session_id,))
     total_messages = cursor.fetchone()[0]
@@ -133,8 +139,8 @@ def import_project(
 
     # Check exclusion after we know the real project name
     cursor.execute("SELECT name FROM projects WHERE id = ?", (project_id,))
-    row = cursor.fetchone()
-    project_name = row[0] if row else extract_project_name(str(project_dir))
+    project_row = cursor.fetchone()
+    project_name = project_row[0] if project_row else extract_project_name(str(project_dir))
 
     if exclude_projects and project_name in exclude_projects:
         return 0, 0, 0
@@ -155,11 +161,6 @@ def import_project(
             messages_imported += msg_count
 
     return sessions_imported, messages_imported, sessions_skipped
-
-
-# PID key — must stay in sync with the spawn in memory_setup (`ccrecall import`).
-PID_KEY = "ccrecall-import"
-_PID_FILE = DEFAULT_DB_PATH.parent / f".pid-{PID_KEY}"
 
 
 def print_stats(db: Path = DEFAULT_DB_PATH) -> None:
@@ -194,7 +195,7 @@ def print_stats(db: Path = DEFAULT_DB_PATH) -> None:
     db_size = db_path.stat().st_size if db_path.exists() else 0
 
     print(f"Database: {db_path}")
-    print(f"Size: {db_size / 1024 / 1024:.2f} MB")
+    print(f"Size: {db_size / BYTES_PER_MB:.2f} MB")
     print(f"Projects: {projects}")
     print(f"Sessions: {sessions}")
     print(f"Branches: {total_branches} ({active} active, {abandoned} abandoned)")
@@ -268,4 +269,4 @@ def _run(
 
     if db_path.exists():
         db_size = db_path.stat().st_size
-        print(f"Database size: {db_size / 1024 / 1024:.2f} MB")
+        print(f"Database size: {db_size / BYTES_PER_MB:.2f} MB")

--- a/src/ccrecall/hooks/import_conversations.py
+++ b/src/ccrecall/hooks/import_conversations.py
@@ -17,6 +17,7 @@ from ccrecall.db import (
     get_db_connection,
     get_db_path,
     load_settings,
+    remove_pid_file,
     setup_logging,
 )
 from ccrecall.formatting import extract_project_name, normalize_project_key
@@ -30,7 +31,6 @@ BYTES_PER_MB = 1024 * 1024
 
 # PID key — must stay in sync with the spawn in memory_setup (`ccrecall import`).
 PID_KEY = "ccrecall-import"
-_PID_FILE = DEFAULT_DB_PATH.parent / f".pid-{PID_KEY}"
 
 
 def get_file_hash(filepath: Path) -> str:
@@ -213,8 +213,7 @@ def run(
         _run(db=db, projects_dir=projects_dir, project=project)
     finally:
         # Delete PID file so _spawn_background can spawn again next session
-        with contextlib.suppress(OSError):
-            _PID_FILE.unlink(missing_ok=True)
+        remove_pid_file(PID_KEY)
 
 
 def _run(

--- a/src/ccrecall/hooks/memory_context.py
+++ b/src/ccrecall/hooks/memory_context.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-Load previous session context from memory database for SessionStart hook.
+"""Load previous session context from the memory database for the SessionStart hook.
 
 Selection Algorithm (startup):
   Exclude current session, find most recent substantive (>2 exchanges)
@@ -25,8 +24,8 @@ from pathlib import Path
 from pydantic import ValidationError
 from whenever import Instant
 
-# Add path to shared utils
 from ccrecall.db import (
+    CLEAR_HANDOFF_FILENAME,
     get_db_connection,
     get_db_path,
     load_config,
@@ -38,7 +37,7 @@ from ccrecall.formatting import (
     get_project_key,
     normalize_cwd,
 )
-from ccrecall.models import HookInput
+from ccrecall.models import LOGGER_NAME, HookInput
 from ccrecall.serialization import decode_json_column
 from ccrecall.session_tail import (
     find_pending_question,
@@ -50,6 +49,18 @@ from ccrecall.summarizer import (
     build_context_summary_json,
     render_context_summary,
 )
+
+# Reject a clear-handoff written more than this many seconds ago (stale guard).
+HANDOFF_STALE_SECONDS = 30
+# Uncached topic fallback truncates the first user message to this many chars.
+TOPIC_PREVIEW_MAX_CHARS = 120
+# Most recent prior branches scanned when picking sessions to inject.
+_CANDIDATE_LIMIT = 20
+
+
+def _emit_empty() -> None:
+    """Print the empty SessionStart response (inject no context)."""
+    print(json.dumps({}))
 
 
 def _pending_question_block(sessions: list[dict], cwd: str) -> str:
@@ -74,7 +85,7 @@ def _pending_question_block(sessions: list[dict], cwd: str) -> str:
         # Deliberately broad: this optional warning must never break the
         # SessionStart hook or drop the main context injection. Log best-effort
         # (no-op unless logging_enabled) so the failure isn't silently lost.
-        logging.getLogger("claude-memory").exception("pending-question block failed")
+        logging.getLogger(LOGGER_NAME).exception("pending-question block failed")
         return ""
 
 
@@ -105,7 +116,7 @@ def _row_to_entry(row) -> dict:
     }
 
 
-_CANDIDATE_QUERY = """
+_CANDIDATE_QUERY = f"""
     SELECT s.id, s.uuid, b.started_at, b.ended_at, b.exchange_count,
            b.files_modified, b.commits, s.git_branch, b.id as branch_db_id,
            b.context_summary
@@ -115,7 +126,7 @@ _CANDIDATE_QUERY = """
       AND s.uuid != ?
       AND s.parent_session_id IS NULL
     ORDER BY b.ended_at DESC
-    LIMIT 20
+    LIMIT {_CANDIDATE_LIMIT}
 """
 
 _SESSION_BY_UUID_QUERY = """
@@ -178,14 +189,13 @@ def _finalize(entries: list[dict]) -> list[dict]:
 
 
 def _find_cleared_from_session_uuid(db_path: Path, cwd: str) -> str | None:
-    """
-    Read and consume the clear-handoff.json file written by the SessionEnd hook.
+    """Read and consume the clear-handoff file written by the SessionEnd hook.
+
     Returns the previous session_id if valid (recent, same cwd), otherwise None.
     Deletes on: valid consumption, stale timestamp, corrupt JSON.
     Preserves on: cwd mismatch (another session may claim it).
     """
-
-    handoff_path = db_path.parent / "clear-handoff.json"
+    handoff_path = db_path.parent / CLEAR_HANDOFF_FILENAME
     if not handoff_path.exists():
         return None
     try:
@@ -204,13 +214,13 @@ def _find_cleared_from_session_uuid(db_path: Path, cwd: str) -> str | None:
     if not session_id or normalize_cwd(handoff_cwd or "") != normalize_cwd(cwd):
         return None
 
-    # Stale guard: reject handoffs older than 30 seconds
+    # Stale guard: reject handoffs older than HANDOFF_STALE_SECONDS
     if timestamp_str:
         try:
             written = Instant.parse_iso(timestamp_str)
             # TimeDelta.total() takes a unit string; this is age in seconds.
             age = (Instant.now() - written).total("seconds")
-            if age > 30:
+            if age > HANDOFF_STALE_SECONDS:
                 with contextlib.suppress(OSError):
                     handoff_path.unlink()
                 return None
@@ -225,6 +235,30 @@ def _find_cleared_from_session_uuid(db_path: Path, cwd: str) -> str | None:
         handoff_path.unlink()
 
     return session_id
+
+
+def _select_cleared_sessions(cursor, project_id: int, prev_session_uuid: str, max_sessions: int) -> list[dict] | None:
+    """Hard-link to the cleared-from session, plus an optional supplementary substantive one.
+
+    Returns the session list, or None to fall through to startup selection (session not
+    in the DB, or it had zero exchanges).
+    """
+    cursor.execute(_SESSION_BY_UUID_QUERY, (project_id, prev_session_uuid))
+    prev_row = cursor.fetchone()
+    if not prev_row:
+        return None
+
+    cleared_from = _row_to_entry(prev_row)
+    if cleared_from["exchange_count"] <= 0:
+        return None
+
+    filtered = [cleared_from]
+    # If cleared-from is not substantive, add the most recent substantive session.
+    if cleared_from["exchange_count"] <= 2 and max_sessions > 1:
+        supplementary = _find_first_substantive(cursor, project_id, prev_session_uuid)
+        if supplementary:
+            filtered.append(supplementary)
+    return filtered
 
 
 def select_sessions(
@@ -248,7 +282,6 @@ def select_sessions(
     """
     cursor = conn.cursor()
 
-    # Get project ID
     cursor.execute("SELECT id FROM projects WHERE key = ?", (project_key,))
     row = cursor.fetchone()
     if not row:
@@ -258,26 +291,11 @@ def select_sessions(
     # Clear path: hard-link via handoff file written by SessionEnd hook
     if source == "clear" and db_path is not None:
         prev_session_uuid = _find_cleared_from_session_uuid(db_path, cwd)
-
         if prev_session_uuid:
-            cursor.execute(_SESSION_BY_UUID_QUERY, (project_id, prev_session_uuid))
-            prev_row = cursor.fetchone()
-
-            if prev_row:
-                cleared_from = _row_to_entry(prev_row)
-
-                if cleared_from["exchange_count"] > 0:
-                    filtered = [cleared_from]
-
-                    # If cleared-from is not substantive, add supplementary
-                    if cleared_from["exchange_count"] <= 2 and max_sessions > 1:
-                        supplementary = _find_first_substantive(cursor, project_id, prev_session_uuid)
-                        if supplementary:
-                            filtered.append(supplementary)
-
-                    _load_messages_for(cursor, filtered)
-                    return _finalize(filtered)
-
+            cleared = _select_cleared_sessions(cursor, project_id, prev_session_uuid, max_sessions)
+            if cleared is not None:
+                _load_messages_for(cursor, cleared)
+                return _finalize(cleared)
         # Session not found in DB or no recent /clear — fall through to startup logic
 
     # Startup path (also fallback for clear with no handoff)
@@ -353,7 +371,7 @@ def _extract_topic(session: dict) -> str:
     for msg in session.get("messages", []):
         if msg.get("role") == "user":
             content = msg.get("content", "")
-            return (content[:120] + "...") if len(content) > 120 else content
+            return (content[:TOPIC_PREVIEW_MAX_CHARS] + "...") if len(content) > TOPIC_PREVIEW_MAX_CHARS else content
     return ""
 
 
@@ -413,11 +431,9 @@ def build_context(sessions: list[dict]) -> str:
 
 
 def main():
-    # Load settings
     settings = load_settings()
     logger = setup_logging(settings)
 
-    # Read hook input from stdin
     raw = sys.stdin.read()
     try:
         hook_input = HookInput.model_validate_json(raw) if raw else HookInput()
@@ -432,29 +448,27 @@ def main():
 
     # Only inject on fresh sessions
     if source not in ("startup", "clear"):
-        print(json.dumps({}))
+        _emit_empty()
         return
 
     # Gate: require onboarding to be completed before injecting context
     config = load_config()
     if not config.get("onboarding_completed"):
-        print(json.dumps({}))
+        _emit_empty()
         return
 
-    # Check if auto-inject is disabled
     if not settings.get("auto_inject_context", True):
         logger.info("Context injection disabled by settings")
-        print(json.dumps({}))
+        _emit_empty()
         return
 
     if not cwd or not session_id:
-        print(json.dumps({}))
+        _emit_empty()
         return
 
-    # Check if database exists
     db_path = get_db_path(settings)
     if not db_path.exists():
-        print(json.dumps({}))
+        _emit_empty()
         return
 
     try:
@@ -473,12 +487,12 @@ def main():
         conn.close()
 
         if not sessions:
-            print(json.dumps({}))
+            _emit_empty()
             return
 
         context = build_context(sessions)
         if not context:
-            print(json.dumps({}))
+            _emit_empty()
             return
 
         logger.info("Injecting context from %s session(s) for project %s", len(sessions), project_key)
@@ -517,7 +531,7 @@ def main():
     except Exception as e:
         logger.error("Context injection error: %s", e)
         # Don't block session start on errors
-        print(json.dumps({}))
+        _emit_empty()
         sys.exit(0)
 
 

--- a/src/ccrecall/hooks/memory_setup.py
+++ b/src/ccrecall/hooks/memory_setup.py
@@ -13,20 +13,17 @@ from pathlib import Path
 from ccrecall.db import (
     CONTENT_ERROR_VERSION,
     DEFAULT_DB_PATH,
+    SYNC_TEMP_PREFIX,
     get_db_connection,
     load_settings,
     log_hook_exception,
+    pid_file_path,
 )
 from ccrecall.hooks import backfill_summaries, import_conversations
 from ccrecall.summarizer import SUMMARY_VERSION
 
-# PID files live in the same directory as the DB
-_PID_DIR = DEFAULT_DB_PATH.parent
-
-
-def _pid_file_path(pid_key: str) -> Path:
-    """Return the PID file path for a given spawn pid_key."""
-    return _PID_DIR / f".pid-{pid_key}"
+# Stale sync temp files older than this (seconds) are reaped on SessionStart.
+STALE_TEMP_FILE_MAX_AGE_SECONDS = 3600
 
 
 def _spawn_background(argv: list[str], pid_key: str) -> None:
@@ -40,7 +37,7 @@ def _spawn_background(argv: list[str], pid_key: str) -> None:
     concurrent instance of the given command is running.  If a stale PID file
     exists (dead process), it is reaped and the new process is spawned.
     """
-    pid_path = _pid_file_path(pid_key)
+    pid_path = pid_file_path(pid_key)
 
     while True:
         try:
@@ -124,16 +121,15 @@ def _reap_stale_temp_files() -> None:
     before it can clean up its own input file.
     """
     tmp_dir = Path(tempfile.gettempdir())
-    one_hour_ago = time.time() - 3600
-    for path in tmp_dir.glob("claude-memory-sync-*.json"):
+    cutoff = time.time() - STALE_TEMP_FILE_MAX_AGE_SECONDS
+    for path in tmp_dir.glob(f"{SYNC_TEMP_PREFIX}*.json"):
         with contextlib.suppress(OSError):
-            if path.stat().st_mtime < one_hour_ago:
+            if path.stat().st_mtime < cutoff:
                 path.unlink()
 
 
 def main():
     try:
-        # Create directory
         DEFAULT_DB_PATH.parent.mkdir(parents=True, exist_ok=True)
 
         # Clean up stale temp files from crashed/killed sync processes

--- a/src/ccrecall/hooks/memory_sync.py
+++ b/src/ccrecall/hooks/memory_sync.py
@@ -9,17 +9,16 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-from ccrecall.db import log_hook_exception
+from ccrecall.db import SYNC_TEMP_PREFIX, log_hook_exception
 
 
 def main():
     try:
-        # Read hook input from stdin
         hook_input = sys.stdin.read()
 
         # Write to temp file (cross-platform stdin piping to detached process is unreliable)
         # Use os.fdopen on the fd directly to avoid TOCTOU race; mkstemp already sets 0o600
-        fd, tmp_path = tempfile.mkstemp(prefix="claude-memory-sync-", suffix=".json")
+        fd, tmp_path = tempfile.mkstemp(prefix=SYNC_TEMP_PREFIX, suffix=".json")
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(hook_input)
@@ -29,7 +28,6 @@ def main():
                 Path(tmp_path).unlink()
             raise
 
-        # Background the sync
         # Heterogeneous values (DEVNULL ints here, bool/int platform flags added below);
         # dict[str, Any] lets **kwargs satisfy Popen's individually-typed keyword params.
         kwargs: dict[str, Any] = {"stdout": subprocess.DEVNULL, "stderr": subprocess.DEVNULL}

--- a/src/ccrecall/hooks/onboarding.py
+++ b/src/ccrecall/hooks/onboarding.py
@@ -8,7 +8,6 @@ a silent no-op.
 
 import json
 
-from ccrecall.db import CONFIG_PATH as CONFIG_PATH
 from ccrecall.db import CURRENT_ONBOARDING_VERSION, load_config, log_hook_exception
 
 

--- a/src/ccrecall/hooks/sync_current.py
+++ b/src/ccrecall/hooks/sync_current.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python3
-"""
-Incremental sync for current session only.
-Designed to be called from a Stop hook - fast and lightweight.
+"""Incremental sync for the current session only (Stop-hook helper — fast and lightweight).
 
 Reads session_id from stdin (or --input-file) and only syncs that session file.
 Detects conversation branches (from rewind) and stores each branch separately.
@@ -35,7 +32,7 @@ def validate_session_id(session_id: str) -> bool:
 
 
 def _is_under(path: Path, base: Path) -> bool:
-    """Check if resolved path is under base directory (Python 3.7+ compatible)."""
+    """Check whether path resolves to a location under base (symlink-escape guard)."""
     try:
         path.resolve().relative_to(base.resolve())
         return True
@@ -71,11 +68,9 @@ def get_session_file(projects_dir: Path, session_id: str) -> Path | None:
 
 def run(input_file: Path | None = None) -> None:
     """Sync only the current session into the memory DB (Stop-hook helper)."""
-    # Load settings
     settings = load_settings()
     logger = setup_logging(settings)
 
-    # Check if sync is disabled
     if not settings.get("sync_on_stop", True):
         logger.info("Sync disabled by settings")
         print(json.dumps({"continue": True}))
@@ -106,14 +101,12 @@ def run(input_file: Path | None = None) -> None:
         print(json.dumps({"continue": True}))
         return
 
-    # Find session file
     session_file = get_session_file(DEFAULT_PROJECTS_DIR, session_id)
 
     if not session_file:
         print(json.dumps({"continue": True}))
         return
 
-    # Sync
     try:
         conn = get_db_connection(settings, load_vec=True)
         project_dir = session_file.parent

--- a/src/ccrecall/hooks/write_config.py
+++ b/src/ccrecall/hooks/write_config.py
@@ -17,12 +17,12 @@ def run(*, defaults: bool = False, auto_inject_context: bool | None = None) -> N
     """Write or update ~/.claude-memory/config.json from onboarding choices."""
     # Build initial config from DEFAULT_SETTINGS (plus write_config-specific keys).
     # Skip merge when --defaults is set so it always writes fresh defaults.
-    write_config_defaults = {
+    initial_config = {
         "onboarding_completed": False,
         "onboarding_version": 0,
         "auto_inject_context": DEFAULT_SETTINGS["auto_inject_context"],
     }
-    config = write_config_defaults.copy()
+    config = initial_config.copy()
     if CONFIG_PATH.exists() and not defaults:
         # Malformed existing config falls back to defaults; an unexpected bug still surfaces.
         with contextlib.suppress(OSError, ValueError):
@@ -34,7 +34,6 @@ def run(*, defaults: bool = False, auto_inject_context: bool | None = None) -> N
     if not defaults and auto_inject_context is not None:
         config["auto_inject_context"] = auto_inject_context
 
-    # Mark onboarding complete
     config["onboarding_completed"] = True
     config["onboarding_version"] = CURRENT_ONBOARDING_VERSION
 

--- a/src/ccrecall/migrations.py
+++ b/src/ccrecall/migrations.py
@@ -14,11 +14,11 @@ import time
 from pathlib import Path
 
 from ccrecall.content import parse_origin
+from ccrecall.models import BUSY_TIMEOUT_MS
 from ccrecall.parsing import build_aggregated_content, extract_session_uuid
 from ccrecall.schema import SCHEMA_CORE, SCHEMA_FTS4, SCHEMA_FTS5, detect_fts_support
 from ccrecall.summarizer import truncate_mid
 
-BUSY_TIMEOUT_MS = 5000
 _MIGRATION_BATCH_SIZE = 50
 _MIGRATION_V6_MAX_JSON_BYTES = 50 * 1024
 

--- a/src/ccrecall/migrations.py
+++ b/src/ccrecall/migrations.py
@@ -18,8 +18,9 @@ from ccrecall.parsing import build_aggregated_content, extract_session_uuid
 from ccrecall.schema import SCHEMA_CORE, SCHEMA_FTS4, SCHEMA_FTS5, detect_fts_support
 from ccrecall.summarizer import truncate_mid
 
+BUSY_TIMEOUT_MS = 5000
 _MIGRATION_BATCH_SIZE = 50
-_MIGRATION_V6_MAX_JSON_BYTES = 51200  # 50 KB
+_MIGRATION_V6_MAX_JSON_BYTES = 50 * 1024
 
 
 def migrate_db(conn: sqlite3.Connection) -> bool:
@@ -70,7 +71,7 @@ def migrate_db(conn: sqlite3.Connection) -> bool:
     # Reconnect and create fresh schema
     new_conn = sqlite3.connect(str(db_path) if db_path else ":memory:")
     new_conn.execute("PRAGMA journal_mode = WAL")
-    new_conn.execute("PRAGMA busy_timeout = 5000")
+    new_conn.execute(f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS}")
     fts = detect_fts_support(new_conn)
     new_conn.executescript(SCHEMA_CORE)
     if fts == "fts5":

--- a/src/ccrecall/models.py
+++ b/src/ccrecall/models.py
@@ -17,6 +17,11 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 # (the lowest-level module) so db/session_ops/hooks can import it without a cycle.
 LOGGER_NAME = "claude-memory"
 
+# Base SQLite busy_timeout (ms) for this app's connections. Lives here, the lowest
+# module, so db.py, migrations.py, and token_schema.py share one value without an
+# import cycle (db imports migrations; the token subsystem keeps db.py decoupled).
+BUSY_TIMEOUT_MS = 5000
+
 _LOG = logging.getLogger(LOGGER_NAME)
 
 

--- a/src/ccrecall/models.py
+++ b/src/ccrecall/models.py
@@ -11,10 +11,13 @@ import logging
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
-# Use the named logger setup_logging() configures so boundary skip-logs reach the
-# same rotating file as the rest of the app; a module logger would propagate to an
-# unconfigured root and silently drop them.
-_LOG = logging.getLogger("claude-memory")
+# The single logger name setup_logging() configures. Shared so boundary skip-logs
+# and hook exceptions reach the same rotating file as the rest of the app; a module
+# logger would propagate to an unconfigured root and silently drop them. Defined here
+# (the lowest-level module) so db/session_ops/hooks can import it without a cycle.
+LOGGER_NAME = "claude-memory"
+
+_LOG = logging.getLogger(LOGGER_NAME)
 
 
 def is_valid(model: type[BaseModel], data: object, label: str) -> bool:

--- a/src/ccrecall/parsing.py
+++ b/src/ccrecall/parsing.py
@@ -16,6 +16,11 @@ from ccrecall.content import (
 )
 from ccrecall.models import TranscriptEntry, is_valid
 
+# Recursion guard for the parent->child branch walk in find_all_branches — caps
+# descendant search depth so a pathological/cyclic transcript tree can't blow the
+# stack.
+MAX_BRANCH_DEPTH = 100
+
 
 def is_valid_entry(obj: object) -> bool:
     """Validate a raw transcript entry at the ingest boundary.
@@ -161,7 +166,7 @@ def find_all_branches(all_entries: list[dict]) -> list[dict]:
 
     # Step 2: Find rewind forks on the active path
     def has_user_descendant(uuid: str, depth: int = 0) -> bool:
-        if depth > 100:
+        if depth > MAX_BRANCH_DEPTH:
             return False
         entry = uuid_to_entry.get(uuid)
         if entry and entry.get("type") == "user":
@@ -263,11 +268,11 @@ def compute_branch_metadata(
         exchange_count += 1
 
     # Deduplicate files preserving order
-    seen = {}
+    seen_files = {}
     unique_files = []
     for f in all_files:
-        if f not in seen:
-            seen[f] = True
+        if f not in seen_files:
+            seen_files[f] = True
             unique_files.append(f)
 
     return exchange_count, unique_files, all_commits, tool_counts

--- a/src/ccrecall/project_ops.py
+++ b/src/ccrecall/project_ops.py
@@ -28,35 +28,21 @@ def upsert_project(
     cwd: str | None = None,
     project_dir: Path | None = None,
 ) -> int:
-    """Upsert a project row and return its database ID.
+    """Upsert a project row and return its ``projects.id``.
 
-    Path derivation strategy:
-    - When ``cwd`` is provided (sync path), use it directly (after normalization).
-    - When ``project_dir`` is provided (import path), probe the first JSONL in that
-      directory for cwd metadata; fall back to lossy hyphen reconstruction if no
-      metadata is found.
-    - If neither is provided, fall back to lossy hyphen reconstruction from the key.
-
-    Args:
-        cursor: SQLite cursor for the current connection.
-        project_key: The encoded project directory name (e.g. ``-home-user-repo``).
-                     Worktree suffixes are stripped automatically.
-        cwd: Working directory from session metadata (sync path).
-        project_dir: Project directory to probe for JSONL metadata (import path).
-
-    Returns:
-        The ``projects.id`` of the upserted row.
+    ``project_key`` is the encoded project directory name (e.g. ``-home-user-repo``);
+    worktree suffixes are stripped automatically. The project path is derived by one
+    of three strategies, in order: a provided ``cwd`` (sync path) is used directly
+    after normalization; otherwise a provided ``project_dir`` (import path) is probed
+    for cwd metadata in its first JSONL; if neither yields a path, fall back to lossy
+    hyphen reconstruction from the key.
     """
     normalized_key = normalize_project_key(project_key)
 
-    # Determine raw path using the appropriate strategy
     raw_path: str | None = None
-
     if cwd is not None:
-        # Sync path: use cwd directly
         raw_path = cwd
     elif project_dir is not None:
-        # Import path: probe first JSONL for real cwd metadata
         raw_path = _probe_project_dir(project_dir)
 
     if not raw_path:
@@ -66,7 +52,6 @@ def upsert_project(
     project_path = normalize_cwd(raw_path)
     project_name = extract_project_name(project_path)
 
-    # Find existing project by key
     cursor.execute("SELECT id, path FROM projects WHERE key = ?", (normalized_key,))
     existing = cursor.fetchone()
 

--- a/src/ccrecall/recent_chats.py
+++ b/src/ccrecall/recent_chats.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python3
-"""
-Retrieve recent conversation sessions from the memory database.
+"""Retrieve recent conversation sessions from the memory database.
 
 Returns markdown by default (token-efficient), or JSON when output_format="json"
 (the CLI maps the global --json flag onto that argument).
@@ -11,7 +9,6 @@ import sqlite3
 import sys
 from pathlib import Path
 
-# Local imports
 from ccrecall.db import DEFAULT_DB_PATH, get_db_connection
 from ccrecall.formatting import format_json_sessions, format_markdown_session
 from ccrecall.serialization import decode_json_column

--- a/src/ccrecall/recent_chats.py
+++ b/src/ccrecall/recent_chats.py
@@ -9,7 +9,8 @@ import sqlite3
 import sys
 from pathlib import Path
 
-from ccrecall.db import DEFAULT_DB_PATH, get_db_connection
+from ccrecall.content import escape_like
+from ccrecall.db import DEFAULT_DB_PATH, fetch_branch_messages, get_db_connection
 from ccrecall.formatting import format_json_sessions, format_markdown_session
 from ccrecall.serialization import decode_json_column
 
@@ -53,8 +54,7 @@ def get_recent_sessions(
 
     if session_id:
         sql += " AND s.uuid LIKE ? ESCAPE '\\'"
-        escaped = session_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-        params.append(f"{escaped}%")
+        params.append(f"{escape_like(session_id)}%")
 
     if before:
         sql += " AND b.started_at < ?"
@@ -71,8 +71,7 @@ def get_recent_sessions(
 
     if path:
         sql += " AND s.cwd LIKE ? ESCAPE '\\'"
-        escaped = path.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-        params.append(f"%{escaped}%")
+        params.append(f"%{escape_like(path)}%")
 
     order = "DESC" if sort_order == "desc" else "ASC"
     sql += f" ORDER BY b.ended_at {order} LIMIT ?"
@@ -115,21 +114,7 @@ def get_recent_sessions(
             ) = session
             tool_counts_json = None
 
-        cursor.execute(
-            """
-            SELECT m.role, m.content, m.timestamp, COALESCE(m.is_notification, 0) as is_notification
-            FROM branch_messages bm
-            JOIN messages m ON bm.message_id = m.id
-            WHERE bm.branch_id = ?
-              AND (? OR COALESCE(m.is_notification, 0) = 0)
-            ORDER BY m.timestamp ASC
-        """,
-            (branch_db_id, include_notifications),
-        )
-
-        messages = [
-            {"role": r, "content": c, "timestamp": t, "is_notification": notif} for r, c, t, notif in cursor.fetchall()
-        ]
+        messages = fetch_branch_messages(cursor, branch_db_id, include_notifications)
 
         session_data = {
             "uuid": uuid,

--- a/src/ccrecall/recent_chats.py
+++ b/src/ccrecall/recent_chats.py
@@ -9,8 +9,7 @@ import sqlite3
 import sys
 from pathlib import Path
 
-from ccrecall.content import escape_like
-from ccrecall.db import DEFAULT_DB_PATH, fetch_branch_messages, get_db_connection
+from ccrecall.db import DEFAULT_DB_PATH, escape_like, fetch_branch_messages, get_db_connection
 from ccrecall.formatting import format_json_sessions, format_markdown_session
 from ccrecall.serialization import decode_json_column
 

--- a/src/ccrecall/search_conversations.py
+++ b/src/ccrecall/search_conversations.py
@@ -11,11 +11,12 @@ from pathlib import Path
 
 import sqlite_vec
 
-from ccrecall.content import sanitize_fts_term
+from ccrecall.content import escape_like, sanitize_fts_term
 from ccrecall.db import (
     DEFAULT_DB_PATH,
     EMBEDDABLE_BRANCH_FILTER,
     branch_vec_queryable,
+    fetch_branch_messages,
     get_db_connection,
 )
 from ccrecall.embeddings import (
@@ -85,13 +86,11 @@ def _get_fts_branch_ids(
 
         if session_id:
             sql += " AND s.uuid LIKE ? ESCAPE '\\'"
-            escaped = session_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-            params.append(f"{escaped}%")
+            params.append(f"{escape_like(session_id)}%")
 
         if path:
             sql += " AND s.cwd LIKE ? ESCAPE '\\'"
-            escaped = path.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-            params.append(f"%{escaped}%")
+            params.append(f"%{escape_like(path)}%")
 
         if fts_level == "fts5":
             sql += " ORDER BY bm25(branches_fts) LIMIT ?"
@@ -119,13 +118,11 @@ def _get_fts_branch_ids(
 
         if session_id:
             sql += " AND s.uuid LIKE ? ESCAPE '\\'"
-            escaped = session_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-            params.append(f"{escaped}%")
+            params.append(f"{escape_like(session_id)}%")
 
         if path:
             sql += " AND s.cwd LIKE ? ESCAPE '\\'"
-            escaped = path.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-            params.append(f"%{escaped}%")
+            params.append(f"%{escape_like(path)}%")
 
         sql += " ORDER BY b.ended_at DESC LIMIT ?"
         params.append(top_k)
@@ -175,7 +172,7 @@ def _get_vec_branch_ids(
           AND b.embedding_version = ?
           AND b.embedding_model = ?
     """
-    filter_params: list = [*list(candidate_ids), EMBEDDING_VERSION, EMBEDDING_MODEL]
+    filter_params: list = [*candidate_ids, EMBEDDING_VERSION, EMBEDDING_MODEL]
 
     if projects:
         proj_placeholders = ",".join("?" * len(projects))
@@ -184,13 +181,11 @@ def _get_vec_branch_ids(
 
     if session_id:
         filter_sql += " AND s.uuid LIKE ? ESCAPE '\\'"
-        escaped = session_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-        filter_params.append(f"{escaped}%")
+        filter_params.append(f"{escape_like(session_id)}%")
 
     if path:
         filter_sql += " AND s.cwd LIKE ? ESCAPE '\\'"
-        escaped = path.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-        filter_params.append(f"%{escaped}%")
+        filter_params.append(f"%{escape_like(path)}%")
 
     try:
         valid_ids = {row[0] for row in cursor.execute(filter_sql, filter_params).fetchall()}
@@ -273,21 +268,7 @@ def _hydrate_branches(
             branch_db_id,
         ) = row
 
-        cursor.execute(
-            """
-            SELECT m.role, m.content, m.timestamp, COALESCE(m.is_notification, 0) as is_notification
-            FROM branch_messages bm
-            JOIN messages m ON bm.message_id = m.id
-            WHERE bm.branch_id = ?
-              AND (? OR COALESCE(m.is_notification, 0) = 0)
-            ORDER BY m.timestamp ASC
-        """,
-            (branch_db_id, include_notifications),
-        )
-
-        messages = [
-            {"role": r, "content": c, "timestamp": t, "is_notification": notif} for r, c, t, notif in cursor.fetchall()
-        ]
+        messages = fetch_branch_messages(cursor, branch_db_id, include_notifications)
 
         session_data = {
             "uuid": uuid,

--- a/src/ccrecall/search_conversations.py
+++ b/src/ccrecall/search_conversations.py
@@ -11,11 +11,12 @@ from pathlib import Path
 
 import sqlite_vec
 
-from ccrecall.content import escape_like, sanitize_fts_term
+from ccrecall.content import sanitize_fts_term
 from ccrecall.db import (
     DEFAULT_DB_PATH,
     EMBEDDABLE_BRANCH_FILTER,
     branch_vec_queryable,
+    escape_like,
     fetch_branch_messages,
     get_db_connection,
 )

--- a/src/ccrecall/search_conversations.py
+++ b/src/ccrecall/search_conversations.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python3
-"""
-Search conversations using full-text search with FTS5/FTS4/LIKE fallback,
-optionally fused with vector KNN via Reciprocal Rank Fusion.
+"""Search conversations with FTS5/FTS4/LIKE, optionally fused with vector KNN via RRF.
 
 Returns markdown by default (token-efficient), or JSON when output_format="json"
 (the CLI maps the global --json flag onto that argument).
@@ -15,8 +12,6 @@ from pathlib import Path
 import sqlite_vec
 
 from ccrecall.content import sanitize_fts_term
-
-# Local imports
 from ccrecall.db import (
     DEFAULT_DB_PATH,
     EMBEDDABLE_BRANCH_FILTER,
@@ -38,6 +33,11 @@ from ccrecall.serialization import decode_json_column
 # Upper bound on --max-results, single-sourced here and referenced by the CLI
 # validator (cli/commands.py) so the clamp and the validator can't drift apart.
 MAX_SEARCH_RESULTS = 10
+
+# Each ranker (FTS, vector KNN) is over-fetched before fusion + per-session dedup,
+# so the post-filter top-N still has enough candidates: top_k = max(N * mult, floor).
+OVERFETCH_MULTIPLIER = 4
+OVERFETCH_FLOOR = 20
 
 
 def _get_fts_branch_ids(
@@ -151,10 +151,9 @@ def _get_vec_branch_ids(
     """
     try:
         serialized = sqlite_vec.serialize_float32(query_vec)
-        knn_k = top_k
         rows = cursor.execute(
             "SELECT branch_id, distance FROM branch_vec WHERE embedding MATCH ? AND k = ? ORDER BY distance",
-            (serialized, knn_k),
+            (serialized, top_k),
         ).fetchall()
     except sqlite3.Error:
         return []
@@ -179,8 +178,8 @@ def _get_vec_branch_ids(
     filter_params: list = [*list(candidate_ids), EMBEDDING_VERSION, EMBEDDING_MODEL]
 
     if projects:
-        ph2 = ",".join("?" * len(projects))
-        filter_sql += f" AND p.name IN ({ph2})"
+        proj_placeholders = ",".join("?" * len(projects))
+        filter_sql += f" AND p.name IN ({proj_placeholders})"
         filter_params.extend(projects)
 
     if session_id:
@@ -216,12 +215,12 @@ def _dedup_by_session(cursor: sqlite3.Cursor, ordered_branch_ids: list[int]) -> 
         ordered_branch_ids,
     ).fetchall()
 
-    id_to_session: dict[int, int] = {row[0]: row[1] for row in rows}
+    branch_to_session: dict[int, int] = {row[0]: row[1] for row in rows}
 
     seen_sessions: set[int] = set()
     deduped: list[int] = []
     for bid in ordered_branch_ids:
-        sess = id_to_session.get(bid)
+        sess = branch_to_session.get(bid)
         if sess is None:
             continue
         if sess not in seen_sessions:
@@ -331,7 +330,7 @@ def search_sessions(
         return []
 
     cursor = conn.cursor()
-    top_k = max(max_results * 4, 20)
+    top_k = max(max_results * OVERFETCH_MULTIPLIER, OVERFETCH_FLOOR)
 
     use_fusion = not keyword_only
     query_vec: list[float] | None = None

--- a/src/ccrecall/session_ops.py
+++ b/src/ccrecall/session_ops.py
@@ -32,6 +32,7 @@ from ccrecall.content import (
 from ccrecall.db import branch_vec_queryable, write_branch_embedding
 from ccrecall.embeddings import embed_text
 from ccrecall.formatting import normalize_project_key
+from ccrecall.models import LOGGER_NAME
 from ccrecall.parsing import (
     build_aggregated_content,
     compute_branch_metadata,
@@ -53,33 +54,20 @@ def sync_session(
     file_hash: str | None = None,
     _project_id: int | None = None,
 ) -> int:
-    """Import a single JSONL session file into the database.
+    """Import a single JSONL session file, returning the count of new messages inserted (or -1 if skipped).
 
     Handles session upsert, message insertion with UUID dedup (without
     ``has_tool_use`` / ``tool_summary`` in the INSERT), branch detection via
     ``find_all_branches``, branch metadata computation, branch_messages diff
     (add/remove), aggregated content assembly, and context summary computation.
 
-    Deduplication logic for ``import_log``:
-    - If ``write_import_log=True`` and ``file_hash`` matches an existing
-      *non-NULL* hash in ``import_log``, the file is unchanged — return -1.
-    - If the stored hash is ``NULL`` (sync wrote a placeholder) and
-      ``file_hash`` is provided, treat the row as stale and re-process.
-
-    Args:
-        conn: Open SQLite connection.
-        filepath: Path to the JSONL session file.
-        project_dir: Parent project directory (used for project upsert when
-            ``_project_id`` is not provided).
-        write_import_log: If True, create or update an ``import_log`` row.
-        file_hash: MD5 hash of the file, or None (sync path).
-        _project_id: Pre-resolved project database ID.  When provided,
-            the project upsert step is skipped.  Used by the import_session
-            adapter in import_conversations.py to respect a caller-resolved
-            project without triggering a second DB lookup.
-
-    Returns:
-        Number of *new* messages inserted (>= 0), or -1 if skipped.
+    ``write_import_log`` controls the ``import_log`` row, and ``file_hash``
+    drives its dedup: when ``write_import_log`` is set and ``file_hash`` matches
+    an existing *non-NULL* hash, the file is unchanged and the function returns
+    -1; a stored ``NULL`` hash (a sync-written placeholder) with a provided
+    ``file_hash`` is treated as stale and re-processed. ``_project_id``, when
+    provided by the import_conversations.py adapter, is used directly so the
+    project upsert step is skipped and no second DB lookup runs.
     """
     cursor = conn.cursor()
 
@@ -168,9 +156,8 @@ def sync_session(
         if uuid not in valid_branch_uuids:
             continue
 
-        notification = (
-            1 if (entry_type == "user" and (is_task_notification(content) or is_teammate_message(content))) else 0
-        )
+        is_notification = entry_type == "user" and (is_task_notification(content) or is_teammate_message(content))
+        notification = int(is_notification)
 
         text, _has_tool_use, has_thinking, _tool_summary = extract_text_content(content)
         if not text:
@@ -359,7 +346,7 @@ def sync_session(
             # outer handler in the import loop). The branch stays eligible for
             # backfill, and the failure is observable in the log instead of being
             # silently swallowed.
-            logging.getLogger("claude-memory").exception("sync: summary write failed for branch %s", branch_db_id)
+            logging.getLogger(LOGGER_NAME).exception("sync: summary write failed for branch %s", branch_db_id)
             summary_md = None
 
         # Embed-on-write: compute and upsert vector after summary succeeds.

--- a/src/ccrecall/session_tail.py
+++ b/src/ccrecall/session_tail.py
@@ -59,6 +59,11 @@ _TEXT_CLIP = 600
 _HOOK_TAIL_LINES = 400
 DEFAULT_TAIL_EVENTS = 8  # CLI -n default
 
+# Clip lengths for pending-question option descriptions and the session preview.
+_INJECTION_OPTION_CLIP = 160
+_CLI_OPTION_CLIP = 140
+_PREVIEW_CLIP = 90
+
 
 def transcript_dir(cwd: str, projects_dir: Path = DEFAULT_PROJECTS_DIR) -> Path:
     """Directory holding this cwd's transcripts (raw slug — see module docstring)."""
@@ -196,8 +201,8 @@ def last_assistant_text(entries: list[dict]) -> str | None:
 
 
 def build_tail(entries: list[dict], k: int) -> list[tuple[str, str]]:
-    """Last K main-chain events as (kind, body). One assistant entry can yield
-    several events (its text plus each tool_use); K bounds the output, not input."""
+    """Last ``k`` main-chain events as (kind, body). One assistant entry can yield
+    several events (its text plus each tool_use); ``k`` bounds the output, not input."""
     if k <= 0:
         return []
     events: list[tuple[str, str]] = []
@@ -236,7 +241,8 @@ def format_pending_block(payload: dict, *, for_injection: bool = False) -> str:
         for q in payload.get("questions", []):
             lines.append(f"- **Q:** {q.get('question', '')}")
             lines.extend(
-                f"  - {opt.get('label', '')}: {clip(opt.get('description', ''), 160)}" for opt in q.get("options", [])
+                f"  - {opt.get('label', '')}: {clip(opt.get('description', ''), _INJECTION_OPTION_CLIP)}"
+                for opt in q.get("options", [])
             )
     else:
         lines.append("⚠ PENDING QUESTION — prior session stopped at an UNANSWERED AskUserQuestion.")
@@ -244,7 +250,7 @@ def format_pending_block(payload: dict, *, for_injection: bool = False) -> str:
         for q in payload.get("questions", []):
             lines.append(f"  Q: {q.get('question', '')}")
             for i, opt in enumerate(q.get("options", []), 1):
-                desc = clip(opt.get("description", ""), 140)
+                desc = clip(opt.get("description", ""), _CLI_OPTION_CLIP)
                 lines.append(f"     {i}. {opt.get('label', '')} — {desc}")
     return "\n".join(lines)
 
@@ -280,7 +286,7 @@ def first_typed_preview(path: Path) -> str:
     for entry in load_entries(path):
         text = typed_instruction(entry)
         if text:
-            return clip(text, 90)
+            return clip(text, _PREVIEW_CLIP)
     return "(no user message)"
 
 

--- a/src/ccrecall/summarizer.py
+++ b/src/ccrecall/summarizer.py
@@ -17,6 +17,26 @@ from ccrecall.serialization import decode_json_field
 _FRONT_CHARS = 300
 _BACK_CHARS = 600
 
+# Exchange retention: a session at or below the short threshold renders all its
+# exchanges once; a longer one keeps the first FIRST_EXCHANGES + last
+# LAST_EXCHANGES with a gap marker between. The threshold is their sum, so the
+# split never drops a middle exchange that both ends already cover.
+FIRST_EXCHANGES = 2
+LAST_EXCHANGES = 6
+SHORT_SESSION_MAX_EXCHANGES = FIRST_EXCHANGES + LAST_EXCHANGES
+
+# Topic truncation lengths: the full topic stored in JSON vs. the shorter form
+# used in the recall-priming footer.
+_TOPIC_MAX_CHARS = 120
+_TOPIC_FOOTER_MAX_CHARS = 80
+
+# Metadata display caps in the rendered markdown.
+_MAX_FILES_SHOWN = 6
+_MAX_COMMITS_SHOWN = 3
+_MAX_TOOLS_SHOWN = 8
+# Compact file-basename previews (gap summary and footer).
+_MAX_FILE_PREVIEW = 3
+
 # Session disposition patterns
 _COMPLETION_RE = re.compile(
     r"(?:done|pushed|merged|all (?:tests? )?pass|completed|finished|shipped|deployed|"
@@ -83,11 +103,10 @@ def detect_disposition(exchanges: list[dict], commits: list[str] | None = None) 
 
 
 def build_exchange_pairs(messages: list[dict]) -> list[dict]:
-    """
-    Build exchange pairs from sequential messages.
+    """Pair sequential messages into user/assistant exchanges.
 
-    Each message is {"role": str, "content": str, "timestamp": str}.
-    Returns list of {"user": str, "assistant": str, "timestamp": str, "index": int}.
+    All assistant parts following a user message accumulate into that exchange's
+    single ``assistant`` string (joined with blank lines) until the next user turn.
     """
     exchanges = []
     current_user = None
@@ -149,8 +168,8 @@ def build_context_summary_json(branch_row: dict, messages: list[dict]) -> dict:
 
     # Topic from first user message
     topic = exchanges[0]["user"]
-    if len(topic) > 120:
-        topic = topic[:120] + "..."
+    if len(topic) > _TOPIC_MAX_CHARS:
+        topic = topic[:_TOPIC_MAX_CHARS] + "..."
 
     # Parse JSON fields from branch_row (raw column strings or already decoded)
     files = decode_json_field(branch_row.get("files_modified"), [])
@@ -159,18 +178,18 @@ def build_context_summary_json(branch_row: dict, messages: list[dict]) -> dict:
 
     disposition = detect_disposition(exchanges, commits=commits)
 
-    # First exchanges (up to 2) — truncate exchange text to bound JSON size
+    # First exchanges — truncate exchange text to bound JSON size
     first_exchanges = [
         {
             "user": truncate_mid(ex["user"]),
             "assistant": truncate_mid(ex["assistant"]),
             "timestamp": ex["timestamp"],
         }
-        for ex in exchanges[:2]
+        for ex in exchanges[:FIRST_EXCHANGES]
     ]
 
-    # Last exchanges (up to 6) — truncate exchange text to bound JSON size
-    if len(exchanges) <= 8:
+    # Last exchanges — truncate exchange text to bound JSON size
+    if len(exchanges) <= SHORT_SESSION_MAX_EXCHANGES:
         # Short/medium session: all exchanges go into last_exchanges
         last_exchanges = [
             {
@@ -181,14 +200,13 @@ def build_context_summary_json(branch_row: dict, messages: list[dict]) -> dict:
             for ex in exchanges
         ]
     else:
-        # Take last 6 exchanges
         last_exchanges = [
             {
                 "user": truncate_mid(ex["user"]),
                 "assistant": truncate_mid(ex["assistant"]),
                 "timestamp": ex["timestamp"],
             }
-            for ex in exchanges[-6:]
+            for ex in exchanges[-LAST_EXCHANGES:]
         ]
 
     return {
@@ -213,9 +231,22 @@ def _build_gap_summary(summary_json: dict) -> str:
     """Build a one-line summary of what happened in the omitted middle exchanges."""
     files = summary_json.get("metadata", {}).get("files_modified", [])
     if files:
-        short = [f.rsplit("/", 1)[-1] for f in files[:3]]
+        short = [f.rsplit("/", 1)[-1] for f in files[:_MAX_FILE_PREVIEW]]
         return ", ".join(short)
     return ""
+
+
+def render_exchange_block(exchanges: list[dict], lines: list[str]) -> None:
+    """Append the User/Assistant markdown for each exchange to ``lines``."""
+    for ex in exchanges:
+        t = format_time(ex.get("timestamp"))
+        lines.append(f"**[{t}] User:**")
+        lines.append(ex["user"])
+        lines.append("")
+        if ex["assistant"]:
+            lines.append(f"**[{t}] Assistant:**")
+            lines.append(truncate_mid(ex["assistant"]))
+            lines.append("")
 
 
 def render_context_summary(summary_json: dict) -> str:
@@ -255,20 +286,20 @@ def render_context_summary(summary_json: dict) -> str:
     # Metadata: files, commits, tools
     files = meta.get("files_modified", [])
     if files:
-        file_strs = [f"`{f}`" for f in files[:6]]
+        file_strs = [f"`{f}`" for f in files[:_MAX_FILES_SHOWN]]
         line = "Modified: " + ", ".join(file_strs)
-        if len(files) > 6:
-            line += f" +{len(files) - 6} more"
+        if len(files) > _MAX_FILES_SHOWN:
+            line += f" +{len(files) - _MAX_FILES_SHOWN} more"
         lines.append(line)
 
     commits = meta.get("commits", [])
     if commits:
-        commit_strs = commits[:3]
+        commit_strs = commits[:_MAX_COMMITS_SHOWN]
         lines.append("Commits: " + "; ".join(commit_strs))
 
     tool_counts = meta.get("tool_counts", {})
     if tool_counts:
-        sorted_tools = sorted(tool_counts.items(), key=lambda x: x[1], reverse=True)[:8]
+        sorted_tools = sorted(tool_counts.items(), key=lambda x: x[1], reverse=True)[:_MAX_TOOLS_SHOWN]
         tools_str = ", ".join(f"{name}({count})" for name, count in sorted_tools)
         lines.append("Tools: " + tools_str)
 
@@ -279,31 +310,15 @@ def render_context_summary(summary_json: dict) -> str:
     first_exs = summary_json.get("first_exchanges", [])
     last_exs = summary_json.get("last_exchanges", [])
 
-    if exchange_count <= 8:
+    if exchange_count <= SHORT_SESSION_MAX_EXCHANGES:
         # Short/medium session: render all exchanges once
         lines.append("### Conversation\n")
-        for ex in last_exs:
-            t = format_time(ex.get("timestamp"))
-            lines.append(f"**[{t}] User:**")
-            lines.append(ex["user"])
-            lines.append("")
-            if ex["assistant"]:
-                lines.append(f"**[{t}] Assistant:**")
-                lines.append(truncate_mid(ex["assistant"]))
-                lines.append("")
+        render_exchange_block(last_exs, lines)
     else:
         # Where We Left Off first — most recent context at top, where attention is
         # highest and where inline-preview truncation (if any) clips from below.
         lines.append("### Where We Left Off\n")
-        for ex in last_exs:
-            t = format_time(ex.get("timestamp"))
-            lines.append(f"**[{t}] User:**")
-            lines.append(ex["user"])
-            lines.append("")
-            if ex["assistant"]:
-                lines.append(f"**[{t}] Assistant:**")
-                lines.append(truncate_mid(ex["assistant"]))
-                lines.append("")
+        render_exchange_block(last_exs, lines)
 
         # Gap indicator with summary of middle exchanges
         gap = exchange_count - len(first_exs) - len(last_exs)
@@ -317,25 +332,15 @@ def render_context_summary(summary_json: dict) -> str:
         # Earlier in This Session — first 2 exchanges kept for origin context,
         # placed last so they're the first thing clipped under truncation.
         lines.append("### Earlier in This Session\n")
-        for ex in first_exs:
-            t = format_time(ex.get("timestamp"))
-            lines.append(f"**[{t}] User:**")
-            lines.append(ex["user"])
-            lines.append("")
-            if ex["assistant"]:
-                lines.append(f"**[{t}] Assistant:**")
-                lines.append(truncate_mid(ex["assistant"]))
-                lines.append("")
+        render_exchange_block(first_exs, lines)
 
-    # Contextual recall priming footer
-    topic = summary_json.get("topic", "")
-    files = meta.get("files_modified", [])
+    # Contextual recall priming footer (topic and files reused from above)
     footer_parts = [f"{exchange_count} exchanges"]
     if topic:
-        short_topic = topic[:80] + "..." if len(topic) > 80 else topic
+        short_topic = topic[:_TOPIC_FOOTER_MAX_CHARS] + "..." if len(topic) > _TOPIC_FOOTER_MAX_CHARS else topic
         footer_parts.append(f'about "{short_topic}"')
     if files:
-        short_files = [f.rsplit("/", 1)[-1] for f in files[:3]]
+        short_files = [f.rsplit("/", 1)[-1] for f in files[:_MAX_FILE_PREVIEW]]
         footer_parts.append(f"({', '.join(short_files)})")
     footer = " ".join(footer_parts)
     lines.append(

--- a/src/ccrecall/summarizer.py
+++ b/src/ccrecall/summarizer.py
@@ -384,7 +384,9 @@ def compute_context_summary(cursor: sqlite3.Cursor, branch_db_id: int) -> tuple[
         "git_branch": row[6],
     }
 
-    # Fetch messages for this branch
+    # Fetch messages for this branch. Standalone (not db.fetch_branch_messages):
+    # summarizer sits below db in the import graph (db -> migrations -> summarizer),
+    # so it can't import db; this query also needs only the 3 non-notification columns.
     cursor.execute(
         """
         SELECT m.role, m.content, m.timestamp

--- a/src/ccrecall/token_analytics.py
+++ b/src/ccrecall/token_analytics.py
@@ -12,8 +12,6 @@ from ccrecall.token_parser import (
     compute_session_analytics,
 )
 
-# ── DB Import ─────────────────────────────────────────────────���───────
-
 
 def import_session(conn: sqlite3.Connection, session: ParsedSession, jnl: JnlFile) -> None:
     sid = session.session_id
@@ -136,9 +134,6 @@ def import_session(conn: sqlite3.Connection, session: ParsedSession, jnl: JnlFil
                    VALUES (?,?,?,?)""",
                 (sid, hc["hook_command"], hc["duration_ms"], hc["is_error"]),
             )
-
-
-# ── Backfill token_snapshots ─────────────────────────────────────────
 
 
 def backfill_token_snapshots(conn: sqlite3.Connection) -> None:

--- a/src/ccrecall/token_dashboard.py
+++ b/src/ccrecall/token_dashboard.py
@@ -23,9 +23,6 @@ from ccrecall.token_schema import connect_token_db, ensure_schema
 DASHBOARD_TEMPLATE_PATH = Path(__file__).parent / "templates" / "dashboard.html"
 
 
-# ── Dashboard Deploy ──────────────────────────────────────────────────
-
-
 def deploy_dashboard(json_str: str, dashboard_out_path: Path) -> None:
     try:
         html = DASHBOARD_TEMPLATE_PATH.read_text(encoding="utf-8")
@@ -39,9 +36,6 @@ def deploy_dashboard(json_str: str, dashboard_out_path: Path) -> None:
         print(f"Warning: could not deploy dashboard: {e}", file=sys.stderr)
 
 
-# ── Main ──────────────────────────────────────────────────────────────
-
-
 def run() -> None:
     """Ingest token data, refresh the dashboard, and print a slim summary to stdout."""
     db_path = get_db_path()
@@ -51,18 +45,15 @@ def run() -> None:
 
     ensure_schema(conn)
 
-    # Discover files
     files = discover_jsonl_files()
     print(f"Discovered {len(files)} JSONL files", file=sys.stderr)
 
-    # Filter to files needing import
     to_import = [f for f in files if not should_skip_file(conn, f.path)]
     print(
         f"Files to import: {len(to_import)} (skipping {len(files) - len(to_import)} unchanged)",
         file=sys.stderr,
     )
 
-    # Parse and import
     imported = 0
     errors = 0
     for i, jnl in enumerate(to_import):
@@ -88,7 +79,6 @@ def run() -> None:
     conn.commit()
     print(f"Imported {imported} sessions ({errors} errors)", file=sys.stderr)
 
-    # Backfill token_snapshots
     print("Backfilling token_snapshots...", file=sys.stderr)
     backfill_token_snapshots(conn)
 
@@ -96,7 +86,6 @@ def run() -> None:
     conn.execute("ANALYZE")
     conn.commit()
 
-    # Build output
     output = build_output(conn)
     conn.close()
 

--- a/src/ccrecall/token_insights.py
+++ b/src/ccrecall/token_insights.py
@@ -12,7 +12,17 @@ from ccrecall.token_parser import (
     turn_cost,
 )
 
-# ── Public API ─────────────────────────────────────────────────────────
+# Per-insight waste-token estimates (tokens wasted per occurrence).
+WASTE_TOKENS_PER_CACHE_CLIFF = 15000
+WASTE_TOKENS_PER_MAX_TOKEN_STOP = 5000
+WASTE_TOKENS_PER_BASH_ANTIPATTERN = 200
+WASTE_TOKENS_PER_REDUNDANT_READ = 500
+WASTE_TOKENS_PER_EDIT_RETRY = 300
+WASTE_TOKENS_PER_IDLE_GAP = 2000
+
+# Fallback per-million-token cost rates when no model split is available.
+FALLBACK_INPUT_CPM = 5.0
+FALLBACK_OUTPUT_CPM = 25.0
 
 
 def build_insights_and_trends(
@@ -65,8 +75,8 @@ def build_insights_and_trends(
     ]
 
     # Weighted average cost rates for waste-to-dollar conversion
-    avg_input_cpm = 5.0
-    avg_output_cpm = 25.0
+    avg_input_cpm = FALLBACK_INPUT_CPM
+    avg_output_cpm = FALLBACK_OUTPUT_CPM
     if model_split:
         weighted_in = sum(m["input_tokens"] * get_pricing(m["model"])["input"] for m in model_split)
         weighted_out = sum(m["output_tokens"] * get_pricing(m["model"])["output"] for m in model_split)
@@ -111,9 +121,6 @@ def build_insights_and_trends(
         "recommendations": recommendations,
         "trends": trends,
     }
-
-
-# ── Trends Engine (week-on-week comparison) ───────────────────────────
 
 
 def build_trends(conn: sqlite3.Connection) -> dict:
@@ -346,9 +353,6 @@ def build_trends(conn: sqlite3.Connection) -> dict:
     }
 
 
-# ── Insights Engine (findings + root causes + solutions) ──────────────
-
-
 def _build_insights(**kw) -> list[dict]:
     """Build unified insights: finding + root cause + solution + dollar cost.
 
@@ -357,8 +361,8 @@ def _build_insights(**kw) -> list[dict]:
     """
     insights = []
     sessions = kw["total_sessions"] or 1
-    avg_input_rate = kw.get("avg_input_cost_per_mtok", 5.0)
-    avg_output_rate = kw.get("avg_output_cost_per_mtok", 25.0)
+    avg_input_rate = kw.get("avg_input_cost_per_mtok", FALLBACK_INPUT_CPM)
+    avg_output_rate = kw.get("avg_output_cost_per_mtok", FALLBACK_OUTPUT_CPM)
 
     def _waste_usd(tokens: int, is_output: bool = False) -> float:
         rate = avg_output_rate if is_output else avg_input_rate
@@ -372,11 +376,10 @@ def _build_insights(**kw) -> list[dict]:
             return "WARNING"
         return "INFO"
 
-    # ── Cache Cliffs ──
     tier = kw.get("dominant_cache_tier", "1h")
     ttl_label = "5 minutes" if tier == "5m" else "1 hour"
     if kw["cache_cliffs"] > 0:
-        waste_tok = kw["cache_cliffs"] * 15000
+        waste_tok = kw["cache_cliffs"] * WASTE_TOKENS_PER_CACHE_CLIFF
         waste_dollars = _waste_usd(waste_tok)
         cliff_projects = kw.get("cache_cliff_projects", [])
         top_proj = cliff_projects[0] if cliff_projects else None
@@ -405,9 +408,8 @@ def _build_insights(**kw) -> list[dict]:
             }
         )
 
-    # ── Context Pressure (max_tokens) ──
     if kw["max_token_stops"] > 0:
-        waste_tok = kw["max_token_stops"] * 5000
+        waste_tok = kw["max_token_stops"] * WASTE_TOKENS_PER_MAX_TOKEN_STOP
         waste_dollars = _waste_usd(waste_tok, is_output=True)
         insights.append(
             {
@@ -429,9 +431,8 @@ def _build_insights(**kw) -> list[dict]:
             }
         )
 
-    # ── Bash Antipatterns ──
     if kw["bash_antipatterns"] > 0:
-        waste_tok = kw["bash_antipatterns"] * 200
+        waste_tok = kw["bash_antipatterns"] * WASTE_TOKENS_PER_BASH_ANTIPATTERN
         waste_dollars = _waste_usd(waste_tok, is_output=True)
         bash_projects = kw.get("bash_antipattern_projects", [])
         top_cmds = kw.get("top_bash_antipattern_cmds", [])
@@ -489,9 +490,8 @@ def _build_insights(**kw) -> list[dict]:
             }
         )
 
-    # ── Redundant Reads ──
     if kw["redundant_reads"] > 0:
-        waste_tok = kw["redundant_reads"] * 500
+        waste_tok = kw["redundant_reads"] * WASTE_TOKENS_PER_REDUNDANT_READ
         waste_dollars = _waste_usd(waste_tok)
         top_files = kw.get("top_redundant_files", [])
         file_detail = (
@@ -523,9 +523,8 @@ def _build_insights(**kw) -> list[dict]:
             }
         )
 
-    # ── Edit Retry Chains ──
     if kw["edit_retries"] > 0:
-        waste_tok = kw["edit_retries"] * 300
+        waste_tok = kw["edit_retries"] * WASTE_TOKENS_PER_EDIT_RETRY
         waste_dollars = _waste_usd(waste_tok, is_output=True)
         retry_projects = kw.get("edit_retry_projects", [])
         proj_detail = (
@@ -557,7 +556,6 @@ def _build_insights(**kw) -> list[dict]:
             }
         )
 
-    # ── Thinking Token Overhead ──
     if kw["total_thinking"] > 0:
         pct = round(kw["total_thinking"] / kw["total_output"] * 100, 1) if kw["total_output"] else 0
         thinking_dollars = _waste_usd(kw["total_thinking"], is_output=True)
@@ -584,7 +582,6 @@ def _build_insights(**kw) -> list[dict]:
             }
         )
 
-    # ── Idle Gap Impact ──
     tier = kw.get("dominant_cache_tier", "1h")
     ttl_label = "5 minutes" if tier == "5m" else "1 hour"
     rtd = kw["response_time_dist"]
@@ -595,7 +592,7 @@ def _build_insights(**kw) -> list[dict]:
     if idle_over_ttl > 0:
         total_gaps = sum(rtd.values())
         pct = round(idle_over_ttl / total_gaps * 100, 1) if total_gaps else 0
-        waste_tok = idle_over_ttl * 2000
+        waste_tok = idle_over_ttl * WASTE_TOKENS_PER_IDLE_GAP
         waste_dollars = _waste_usd(waste_tok)
         insights.append(
             {
@@ -618,7 +615,6 @@ def _build_insights(**kw) -> list[dict]:
             }
         )
 
-    # ── Cost Concentration ──
     cost_by_project = kw.get("cost_by_project", [])
     total_cost = kw.get("total_cost_usd", 0)
     if cost_by_project and total_cost > 0:
@@ -646,7 +642,6 @@ def _build_insights(**kw) -> list[dict]:
                 }
             )
 
-    # ── Context Overhead ──
     seg = kw.get("context_seg_summary", {})
     base_pct = seg.get("base_overhead_pct", 0)
     avg_base = seg.get("avg_base_ctx", 0)

--- a/src/ccrecall/token_output.py
+++ b/src/ccrecall/token_output.py
@@ -17,8 +17,6 @@ from ccrecall.token_parser import (
     turn_cost,
 )
 
-# ── Build Output ──────────────────────────────────────────────────────
-
 
 def build_output(conn: sqlite3.Connection) -> dict:
     cur = conn.cursor()

--- a/src/ccrecall/token_parser.py
+++ b/src/ccrecall/token_parser.py
@@ -17,6 +17,8 @@ PROJECTS_DIR = Path.home() / ".claude" / "projects"
 BATCH_SIZE = 50
 PROGRESS_INTERVAL = 100
 COMMAND_TRUNCATE = 200
+CHARS_PER_TOKEN = 4
+SLUG_LABEL_MAX = 30
 
 # SQL fragment: true Bash antipatterns — standalone cat/grep/find/ls that have
 # a dedicated tool equivalent. Excludes legitimate patterns:
@@ -46,7 +48,7 @@ _BASH_ANTIPATTERN_PREDICATE = """
     AND tc.command NOT LIKE 'tail % | %'
 """.strip()
 
-# ── Pricing (USD per million tokens) ─────────────────────────────────
+# Pricing (USD per million tokens)
 # Source: https://docs.anthropic.com/en/docs/about-claude/pricing
 # Keys are substrings matched against model IDs (checked in order).
 # cache_write_5m = 1.25x input, cache_write_1h = 2x input, cache_read = 0.1x input.
@@ -153,9 +155,6 @@ def turn_cost(
     return cost
 
 
-# ── File Discovery ────────────────────────────────────────────────────
-
-
 @dataclass
 class JnlFile:
     path: Path
@@ -214,9 +213,6 @@ def record_import(conn: sqlite3.Connection, filepath: Path, session_id: str, tur
     )
 
 
-# ── JSONL Parser ──────────────────────────────────────────────────────
-
-
 @dataclass
 class ToolCall:
     tool_name: str
@@ -269,10 +265,6 @@ class ParsedSession:
     hook_calls: list[dict] = field(default_factory=list)
 
 
-def _parse_timestamp(line: dict) -> str | None:
-    return line.get("timestamp")
-
-
 def _extract_usage(msg: dict) -> dict:
     usage = msg.get("usage", {}) or {}
     cache_creation = usage.get("cache_creation", {}) or {}
@@ -314,7 +306,7 @@ def parse_session(filepath: Path, jnl: JnlFile) -> ParsedSession | None:
 
         line_type = line.get("type")
         subtype = line.get("subtype", "")
-        ts = _parse_timestamp(line)
+        ts = line.get("timestamp")
 
         # Capture session metadata from any line that has it
         if not metadata_captured:
@@ -393,8 +385,8 @@ def parse_session(filepath: Path, jnl: JnlFile) -> ParsedSession | None:
                 if btype == "thinking":
                     # Count thinking text length as proxy (actual token count not in JSONL)
                     thinking_text = block.get("thinking", "")
-                    # Rough estimate: 1 token ≈ 4 chars
-                    current_turn.thinking_tokens += len(thinking_text) // 4
+                    # Rough estimate: 1 token ≈ CHARS_PER_TOKEN chars
+                    current_turn.thinking_tokens += len(thinking_text) // CHARS_PER_TOKEN
 
                 elif btype == "tool_use":
                     tc = ToolCall(
@@ -457,7 +449,7 @@ def parse_session(filepath: Path, jnl: JnlFile) -> ParsedSession | None:
                                 if isinstance(result_content, list):
                                     texts = [c.get("text", "") for c in result_content if isinstance(c, dict)]
                                     result_content = " ".join(texts)
-                                tc.error_text = str(result_content)[:200] if result_content else None
+                                tc.error_text = str(result_content)[:COMMAND_TRUNCATE] if result_content else None
 
         # ── System events ──
         elif line_type == "system":
@@ -501,9 +493,6 @@ def parse_session(filepath: Path, jnl: JnlFile) -> ParsedSession | None:
         session.session_id = filepath.stem
 
     return session if session.turns else None
-
-
-# ── Session Analytics ─────────────────────────────────────────────────
 
 
 def _detect_cache_ttl_ms(session: ParsedSession) -> tuple[int, str]:
@@ -578,9 +567,6 @@ def compute_session_analytics(session: ParsedSession) -> dict:
     }
 
 
-# ── Helpers ───────────────────────────────────────────────────────────
-
-
 _WORKTREE_MARKERS = ("/.claude/worktrees/", "//claude/worktrees/")
 
 
@@ -629,4 +615,4 @@ def project_slug(path: str | None) -> str:
     else:
         slug = "-".join(meaningful[-3:])
     # Cap length for chart labels
-    return slug[:30] if slug else "unknown"
+    return slug[:SLUG_LABEL_MAX] if slug else "unknown"

--- a/src/ccrecall/token_schema.py
+++ b/src/ccrecall/token_schema.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from ccrecall.token_parser import _WORKTREE_MARKERS
 
 SCHEMA_VERSION = 4
+BUSY_TIMEOUT_MS = 5000
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS turns (
@@ -200,6 +201,6 @@ def connect_token_db(db_path: Path) -> sqlite3.Connection:
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(db_path))
     conn.execute("PRAGMA journal_mode = WAL")
-    conn.execute("PRAGMA busy_timeout = 5000")
+    conn.execute(f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS}")
     conn.execute("PRAGMA foreign_keys = ON")
     return conn

--- a/src/ccrecall/token_schema.py
+++ b/src/ccrecall/token_schema.py
@@ -7,10 +7,10 @@ import sqlite3
 import sys
 from pathlib import Path
 
+from ccrecall.models import BUSY_TIMEOUT_MS
 from ccrecall.token_parser import _WORKTREE_MARKERS
 
 SCHEMA_VERSION = 4
-BUSY_TIMEOUT_MS = 5000
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS turns (

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -20,9 +20,8 @@ from ccrecall.db import CURRENT_ONBOARDING_VERSION
 
 
 def _patch_config_path(monkeypatch, path: Path) -> None:
-    """Patch CONFIG_PATH in both ccrecall.db and the onboarding module."""
+    """Patch CONFIG_PATH in ccrecall.db (onboarding reads config via db.load_config)."""
     monkeypatch.setattr(_db_mod, "CONFIG_PATH", path)
-    monkeypatch.setattr(onboarding, "CONFIG_PATH", path)
 
 
 def _run_main_captured(monkeypatch, cfg_path: Path) -> dict:

--- a/tests/test_sync_hook.py
+++ b/tests/test_sync_hook.py
@@ -358,7 +358,7 @@ class TestPidGuard:
         """When a live PID file exists, _spawn_background skips spawning."""
 
         pid_path = tmp_path / ".pid-cm-test-cmd"
-        monkeypatch.setattr(memory_setup, "_PID_DIR", tmp_path)
+        monkeypatch.setattr(memory_setup, "pid_file_path", lambda pid_key: tmp_path / f".pid-{pid_key}")
 
         # Write our own PID (current process) as a "live" PID
         pid_path.write_text(str(os.getpid()))
@@ -371,7 +371,7 @@ class TestPidGuard:
         """When PID file holds a dead PID, _spawn_background reaps it and spawns."""
 
         pid_path = tmp_path / ".pid-cm-test-cmd"
-        monkeypatch.setattr(memory_setup, "_PID_DIR", tmp_path)
+        monkeypatch.setattr(memory_setup, "pid_file_path", lambda pid_key: tmp_path / f".pid-{pid_key}")
 
         # We need a real PID that is guaranteed dead. Spawn a trivial subprocess
         # and reap it. Deliberately NOT os.fork(): by the time this test runs the
@@ -399,7 +399,7 @@ class TestPidGuard:
     def test_pid_guard_atomic_create(self, tmp_path, monkeypatch):
         """PID file creation uses O_CREAT | O_EXCL to prevent TOCTOU races."""
 
-        monkeypatch.setattr(memory_setup, "_PID_DIR", tmp_path)
+        monkeypatch.setattr(memory_setup, "pid_file_path", lambda pid_key: tmp_path / f".pid-{pid_key}")
 
         created_flags = []
 


### PR DESCRIPTION
## Summary

Full clean-code / style-and-structure cleanup pass across the `ccrecall` package. Originally scoped narrowly (issue #15 listed a handful of files), but a fresh full-tree `/mine-clean-code` pass plus the reviewer trio surfaced the same classes of debt package-wide, so this cleans the whole tree.

**Behavior-preserving throughout.** Net **+385/−427** across 31 files. Every batch ended green.

Closes #15.

## What changed (by batch)

- **Core / search** — `escape_like` (8 duplicated LIKE-escape sites → 1), `db.fetch_branch_messages` (deduped per-branch message hydration), `apply_base_pragmas` (deduped PRAGMA block), `models.LOGGER_NAME`, `content.extract_plain_text`; named the magic numbers (overfetch, hash chunk, MB conversion, file-display cap, etc.).
- **Hooks** — unified PID/temp-file handling (`db.pid_file_path` / `remove_pid_file`, shared `CLEAR_HANDOFF_FILENAME` / `SYNC_TEMP_PREFIX`), `memory_context._emit_empty` (8 duplicated empty-responses), extracted `_select_cleared_sessions` to flatten 5-level nesting; named stale/topic/candidate/nice constants; removed dead `onboarding.CONFIG_PATH` import and dead `sync_current` shebang.
- **Ops / session / summarizer** — `render_exchange_block` (3 byte-identical loops → 1), named the coupled exchange constants (`FIRST_EXCHANGES + LAST_EXCHANGES = SHORT_SESSION_MAX_EXCHANGES`), removed `Args:`/`Returns:` docstring blocks (they violate the project's own style guide), extracted `is_notification` from an inline ternary, `MAX_BRANCH_DEPTH`.
- **Migrations** — named `busy_timeout` and the v6 JSON cap.
- **Token subsystem** — named the per-insight waste-token estimates + fallback pricing (`WASTE_TOKENS_PER_*`, `FALLBACK_*_CPM`), `CHARS_PER_TOKEN`, reused `COMMAND_TRUNCATE`, inlined a dead one-line wrapper, stripped decorative section-divider banners (one carried a corrupted U+FFFD character).
- **Review fixes** — single-sourced `BUSY_TIMEOUT_MS` in `models.py` (was defined identically in three modules — parallel-drift risk; the cycle constraint keeps it out of `db.py`), relocated `escape_like` from `content.py` to the SQL layer (`db.py`).

## Verification

- `pytest` — **656 passed** after every batch
- `ruff check` + `ruff format` — clean
- `pyright` — clean
- Observed the live CLI (`ccrecall stats` / `search` / `recent`) behaving identically after the refactor
- Reviewer trio (code-reviewer / integration-reviewer / wtf-reviewer): code-reviewer **APPROVE**; both HIGH findings (BUSY_TIMEOUT_MS triplication, escape_like misplacement) resolved

## Deliberately deferred (good follow-up issue)

Out of scope for a behavior-preserving *style* PR — these are feature-sized refactors that deserve their own review:

- Splitting the large functions: `build_output` (~710 lines), `sync_session` (~353), `_build_insights` (~341), `build_trends` (~227), `migrate_columns` (~145)
- Deduping the cost-accumulation loops / (detail + aggregate) SQL query pairs in the token subsystem
- The `insights` / `findings` / `recommendations` triple-representation in the output (a behavior question)
- Pre-existing nits the reviewers noticed: `sanitize_fts_term` placement in `content.py`, `_CONFIG_KEYS` naming in `db.py`
