### PR TITLE
Improve /ccr-resume; keep uv.lock in sync across releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,12 @@ on:
 # workflow + the `pypi` environment (a "pending publisher" before the first
 # release exists). Publisher config: PyPI project `ccrecall`, owner `NodeJSmith`,
 # repo `claude-code-recall`, workflow `release-please.yml`, environment `pypi`.
+#
+# release-please bumps the version in pyproject.toml and (via extra-files)
+# plugin.json, but does NOT know about uv.lock — whose self-referenced ccrecall
+# version would otherwise stay stale until a contributor's next `uv sync`, surfacing
+# as a spurious lockfile diff. The sync-lockfile job below closes that gap by
+# re-locking on the release PR branch so the bump lands in the same PR.
 permissions:
     contents: write
     pull-requests: write
@@ -28,6 +34,8 @@ jobs:
         outputs:
             release_created: ${{ steps.release.outputs.release_created }}
             tag_name: ${{ steps.release.outputs.tag_name }}
+            prs_created: ${{ steps.release.outputs.prs_created }}
+            pr: ${{ steps.release.outputs.pr }}
         steps:
             - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
               id: release
@@ -35,6 +43,49 @@ jobs:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   config-file: release-please-config.json
                   manifest-file: .release-please-manifest.json
+
+    sync-lockfile:
+        needs: release-please
+        if: needs.release-please.outputs.prs_created == 'true'
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        permissions:
+            contents: write
+        steps:
+            # Check out the release PR branch (not main) so the re-lock commit
+            # lands in that PR and merges together with the version bump.
+            # persist-credentials: false avoids leaving the token in the local
+            # git config; the push step below authenticates explicitly instead.
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+              with:
+                  ref: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
+                  persist-credentials: false
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+              with:
+                  python-version: "3.13"
+
+            - name: Re-lock to pick up the bumped version
+              run: uv lock
+
+            # Branch/repo/token go through env, not inline ${{ }}, so nothing
+            # untrusted is interpolated into the shell.
+            - name: Commit and push if uv.lock changed
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PR_BRANCH: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
+                  REPO: ${{ github.repository }}
+              run: |
+                  if git diff --quiet -- uv.lock; then
+                      echo "uv.lock already in sync."
+                      exit 0
+                  fi
+                  git config user.name "github-actions[bot]"
+                  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                  git add uv.lock
+                  git commit -m "chore: sync uv.lock to release version"
+                  git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "HEAD:${PR_BRANCH}"
 
     publish-pypi:
         needs: release-please

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,7 +34,6 @@ jobs:
         outputs:
             release_created: ${{ steps.release.outputs.release_created }}
             tag_name: ${{ steps.release.outputs.tag_name }}
-            prs_created: ${{ steps.release.outputs.prs_created }}
             pr: ${{ steps.release.outputs.pr }}
         steps:
             - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
@@ -44,9 +43,12 @@ jobs:
                   config-file: release-please-config.json
                   manifest-file: .release-please-manifest.json
 
+    # Runs only when release-please has an open PR (not on the push that creates
+    # the release itself). Guarding on `pr` truthiness also keeps the fromJSON
+    # below from erroring on an empty value.
     sync-lockfile:
         needs: release-please
-        if: needs.release-please.outputs.prs_created == 'true'
+        if: needs.release-please.outputs.pr && needs.release-please.outputs.release_created != 'true'
         runs-on: ubuntu-latest
         timeout-minutes: 15
         permissions:
@@ -61,10 +63,11 @@ jobs:
                   ref: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
                   persist-credentials: false
 
+            # uv lock resolves from metadata, so no interpreter pin is needed.
             - name: Install uv
               uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
               with:
-                  python-version: "3.13"
+                  enable-cache: true
 
             - name: Re-lock to pick up the bumped version
               run: uv lock
@@ -77,6 +80,7 @@ jobs:
                   PR_BRANCH: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
                   REPO: ${{ github.repository }}
               run: |
+                  set -euo pipefail
                   if git diff --quiet -- uv.lock; then
                       echo "uv.lock already in sync."
                       exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Enforced by `prek` (pre-commit) hooks + custom checks in `tools/`:
 - **No `from __future__ import annotations`** and **no lazy imports** (imports inside functions) — both have dedicated checks. Use `X | None`, not `Optional[X]`.
 - **`whenever`** for all date/time, not stdlib `datetime` (convert only at library boundaries).
 - **setuptools** build backend (never hatchling). License is declared as an SPDX expression (`license = "MIT"` + `license-files`).
-- **Conventional Commits.** Releases are automated by **release-please**; the version lives in `pyproject.toml` and is mirrored into `.claude-plugin/plugin.json`. `feat`/`fix`/`perf`/`refactor`/`docs` land in the changelog.
+- **Conventional Commits.** Releases are automated by **release-please**; the version lives in `pyproject.toml`, is mirrored into `.claude-plugin/plugin.json` (release-please `extra-files`), and `uv.lock` is re-locked on the release PR by a `sync-lockfile` CI job so its self-version never drifts. `feat`/`fix`/`perf`/`refactor`/`docs` land in the changelog.
 
 ## Commands
 

--- a/skills/ccr-resume/SKILL.md
+++ b/skills/ccr-resume/SKILL.md
@@ -7,7 +7,7 @@ disable-model-invocation: true
 
 # Resume
 
-Pick up work in a fresh session after the previous one ended — via `/clear` (to avoid resending a large uncached context), after being stopped, or after sitting at an unanswered `AskUserQuestion`. `/clear` starts a **new session with a new transcript file**; the prior session's transcript stays on disk. This skill reads its **tail** to recover what the disk can't tell you: the user's last instruction and any decision that was never resolved.
+Pick up work in a fresh session after the previous one ended — via `/clear` (to avoid resending a large uncached context), after being stopped, or after a question the prior session left open (a rejected `AskUserQuestion` *or* one asked in prose). `/clear` starts a **new session with a new transcript file**; the prior session's transcript stays on disk. This skill reads its **tail** to recover what the disk can't tell you: the user's last instruction and any decision that was never resolved.
 
 ## Why this exists — the failure mode it prevents
 
@@ -20,17 +20,21 @@ On pickup, the instinct is to read on-disk artifacts (git state, task files, des
 
 ## Arguments
 
-$ARGUMENTS — optional. A session-id substring to target a specific prior session. Omit to auto-pick the most recent prior session in this directory's project.
+$ARGUMENTS — optional. A natural-language directive for how to follow up on the prior session — e.g. "keep going with the refactor but skip the test rewrite", "just summarize where we left off", "did the migration finish?". This is *intent*, not a session selector: it does not get passed to `ccrecall tail`; it shapes how you proceed in Phase 3. Omit it to get a plain orientation and a "how do you want to proceed?" prompt.
+
+To target a session other than the auto-picked prior one (rare), run `ccrecall tail --list`, then `ccrecall tail <id-substring>` directly.
 
 ---
 
 ## Phase 1: Recover the transcript tail (do this first, always)
 
-Run the lever — it locates the prior session's JSONL and prints the tail, the last typed instruction, and any **unanswered** `AskUserQuestion`:
+Run the lever — it auto-picks the prior session, locates its JSONL, and prints the tail, the last typed instruction, the last assistant message, and any **unanswered** `AskUserQuestion`:
 
 ```bash
-ccrecall tail $ARGUMENTS
+ccrecall tail
 ```
+
+Do **not** pass $ARGUMENTS here — it's a follow-up directive, not a session id (see Arguments).
 
 - Auto-detect picks the second-newest session (the newest is *this* one, live). If the wrong session comes up or you need to choose, run `ccrecall tail --list` and re-run with the right id substring.
 - If `ccrecall tail` finds nothing (no project dir, only the current session, or a moved cwd), fall back to `/ccr-recall` to retrieve the tail — never substitute disk artifacts for the transcript.
@@ -49,10 +53,24 @@ Name any mismatch between "what the transcript wanted" and "what the disk shows.
 
 ## Phase 3: Surface — never auto-resolve
 
-**If `ccrecall tail` reported a PENDING QUESTION:** the prior session stopped on a decision the user never made. Re-present it with `AskUserQuestion`, reusing the exact option labels and descriptions from the tail output (the picker appends "Other" automatically). Then **stop** — do not pick an option, and do not act on the work the question gates.
+The prior session may have ended on an **open decision** it was waiting on the user for. It takes two forms — treat them identically:
 
-**If there is no pending question:** give a 3–5 line orientation — where things stand, what the last instruction was, what's reconciled vs. mismatched — and ask how the user wants to proceed before taking any action.
+1. **Structured** — `ccrecall tail` printed a PENDING QUESTION block (an `AskUserQuestion` the user never answered). The lever detects this for you.
+2. **Prose** — no PENDING QUESTION block, but the LAST ASSISTANT MESSAGE excerpt ends by asking the user something or offering a choice ("Want me to also update the tests?", "Should I do X or Y?"). The harness records this as ordinary text, so the lever *cannot* flag it — you have to read the excerpt and judge whether it left a question hanging.
+
+**If either form is present, surface it — do not resolve it:**
+- Structured: re-present with `AskUserQuestion`, reusing the exact option labels and descriptions from the tail block (the picker appends "Other" automatically).
+- Prose: pose the question the assistant left open — as `AskUserQuestion` if it maps to clear choices, otherwise as a plain question.
+
+Then **stop** — do not pick an option, and do not act on the work the decision gates.
+
+**If there is no open decision:** give a 3–5 line orientation — where things stand, the last instruction, what's reconciled vs. mismatched.
+
+**Folding in the $ARGUMENTS directive (if given):** it is the user's answer to "how do we proceed" — but it does *not* override an open decision the prior session was waiting on *from them*. So:
+- Open decision present, and the directive plainly answers it → confirm that reading with the user, then proceed. Otherwise surface the decision first; the directive resolves what comes after.
+- No open decision → act on the directive directly instead of asking how to proceed.
+- No directive → ask how the user wants to proceed before taking any action.
 
 ## The one rule
 
-An unanswered or rejected `AskUserQuestion` is an open decision, not an invitation to choose. Surface it; let the user decide.
+An unanswered, rejected, or interrupted question — structured (`AskUserQuestion`) *or* prose left hanging in the last assistant message — is an open decision, not an invitation to choose. Surface it; let the user decide. A $ARGUMENTS directive answers "how do we proceed," never a decision the prior session was still waiting on.

--- a/uv.lock
+++ b/uv.lock
@@ -52,7 +52,7 @@ wheels = [
 
 [[package]]
 name = "ccrecall"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
### `/ccr-resume` — handle prose questions and reinterpret the argument

Two behavior fixes to the resume skill, prompted by it leaning too hard on a prior structured `AskUserQuestion`:

- **Prose questions are now first-class.** Phase 3 treats an open decision as either *structured* (an unanswered `AskUserQuestion`, which `ccrecall tail` already detects) or *prose* (a question the assistant left hanging in its last message, which the harness records as plain text the lever can't flag). Both are surfaced identically and never auto-resolved. Previously only the structured form was elevated, so a session that ended on a plain-text "want me to also…?" got picked up as if nothing was pending.
- **`$ARGUMENTS` is now a follow-up directive, not a session id.** It carries intent ("keep going but skip the test rewrite", "did the migration finish?") and shapes how Phase 3 proceeds — it no longer gets passed to `ccrecall tail`, which always auto-picks the prior session. A directive answers "how do we proceed" but never overrides a decision the prior session was waiting on. Manual session targeting survives as the rare-case `ccrecall tail --list` escape hatch for the agent, which is the only remaining session-id path (no human is expected to pass one).

No code change — the prose signal already exists in `ccrecall tail`'s "LAST ASSISTANT MESSAGE" output; this is purely how the skill reasons about it.

### Keep `uv.lock` in sync across releases

release-please bumps the version in `pyproject.toml` and `.claude-plugin/plugin.json` (via `extra-files`) but has no knowledge of `uv.lock`, whose self-referenced `ccrecall` version stayed stale until a contributor's next `uv sync` — surfacing as a spurious lockfile diff every release (which is exactly how this PR started).

- New `sync-lockfile` job in `release-please.yml` re-locks `uv.lock` on the release PR branch (`uv lock`) and commits it back, so the bump lands in the same PR that bumps everything else. It checks out with `persist-credentials: false` and pushes with an explicit token to keep zizmor's credential-persistence audit clean.
- Confirmed locally that `uv lock` produces exactly the one-line version change and nothing else, so the job is a minimal, deterministic re-lock.

### Housekeeping

- Sync `uv.lock` to the already-released `0.11.0` to clear the existing drift.
- Note the new lockfile-sync step in `CLAUDE.md`'s release description.
