### PR TITLE
ci: authenticate release-please with a GitHub App token [needs secrets]

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,8 +6,11 @@ on:
     workflow_dispatch:
 
 # release-please opens/updates the release PR and, when that PR merges, creates
-# the GitHub release + tag and bumps the version in pyproject.toml. It uses the
-# default GITHUB_TOKEN. When a release is created, the publish-pypi job builds the
+# the GitHub release + tag and bumps the version in pyproject.toml. It authenticates
+# with a GitHub App token (secrets RELEASE_PLEASE_APP_ID / RELEASE_PLEASE_APP_PRIVATE_KEY)
+# rather than the default GITHUB_TOKEN, because GitHub suppresses workflow runs for
+# events made with GITHUB_TOKEN — release PRs opened with it never trigger the
+# required prek / tests-complete checks. When a release is created, the publish-pypi job builds the
 # bumped version and uploads it to PyPI via Trusted Publishing (OIDC) — no API
 # token stored in the repo. PyPI must have a publisher configured for this repo +
 # workflow + the `pypi` environment (a "pending publisher" before the first
@@ -36,10 +39,22 @@ jobs:
             tag_name: ${{ steps.release.outputs.tag_name }}
             pr: ${{ steps.release.outputs.pr }}
         steps:
+            # A GitHub App token (not the default GITHUB_TOKEN) so the release PR
+            # and the sync-lockfile commit trigger required checks. GitHub
+            # suppresses workflow runs for events made with GITHUB_TOKEN, which
+            # would otherwise leave release PRs with no prek/tests-complete checks.
+            - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+              id: app-token
+              with:
+                  app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+                  private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+                  permission-contents: write
+                  permission-pull-requests: write
+
             - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
               id: release
               with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ steps.app-token.outputs.token }}
                   config-file: release-please-config.json
                   manifest-file: .release-please-manifest.json
 
@@ -54,6 +69,16 @@ jobs:
         permissions:
             contents: write
         steps:
+            # Re-mint the App token here — tokens are short-lived and don't pass
+            # across jobs — so the lockfile commit is pushed as the App and
+            # therefore triggers the release PR's required checks.
+            - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+              id: app-token
+              with:
+                  app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+                  private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+                  permission-contents: write
+
             # Check out the release PR branch (not main) so the re-lock commit
             # lands in that PR and merges together with the version bump.
             # persist-credentials: false avoids leaving the token in the local
@@ -61,6 +86,7 @@ jobs:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                   ref: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
+                  token: ${{ steps.app-token.outputs.token }}
                   persist-credentials: false
 
             # uv lock resolves from metadata, so no interpreter pin is needed.
@@ -76,7 +102,7 @@ jobs:
             # untrusted is interpolated into the shell.
             - name: Commit and push if uv.lock changed
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
                   PR_BRANCH: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
                   REPO: ${{ github.repository }}
               run: |


### PR DESCRIPTION
> [!WARNING]
> **Do not merge until the App + secrets exist.** This workflow references `secrets.RELEASE_PLEASE_APP_ID` / `secrets.RELEASE_PLEASE_APP_PRIVATE_KEY`. If it reaches `main` before those secrets are set, the next release-please run fails at the `create-github-app-token` step and the release pipeline goes dark. Kept as a **draft** for that reason.

### Why

GitHub deliberately **does not trigger workflow runs for events made with the default `GITHUB_TOKEN`** (loop prevention). Our `protect-main` ruleset requires the `prek` and `tests-complete` checks. The result today: release-please PRs (opened with `GITHUB_TOKEN`) never run those checks, so they can only be merged via an **admin bypass** of the ruleset. This mirrors the fix already proven in `hassette`.

### What changed

- Mint a **GitHub App token** in both the `release-please` and `sync-lockfile` jobs (re-minted per job — App tokens are short-lived and don't cross job boundaries) and use it instead of `GITHUB_TOKEN`. Now the release PR *and* the `uv.lock` sync commit trigger required checks and merge without bypass.
- Tokens are **least-privilege scoped** via `permission-contents` / `permission-pull-requests` (an improvement over hassette's unscoped token; also required to pass our zizmor hook).

### Activation checklist (do before merging)

1. Create a GitHub App (org or personal) with **repository permissions**: `Contents: Read & write`, `Pull requests: Read & write`. No webhook needed.
2. **Install** the App on `NodeJSmith/claude-code-recall`.
3. Generate a **private key** for the App.
4. Add two repo secrets: `RELEASE_PLEASE_APP_ID` (the App's numeric ID) and `RELEASE_PLEASE_APP_PRIVATE_KEY` (the full `.pem` contents).
5. Allow the App to bypass the `protect-main` ruleset if you want it to push the `uv.lock` commit to release branches without the ruleset's PR rule blocking it — or rely on the checks now running. (The App pushes to the release-please branch, not `main`, so the `pull_request` rule on `main` is not in play; `non_fast_forward`/`deletion` only apply to `main`.)
6. Mark this PR ready and merge.

### Sequencing

Stacked on `worktree-improve-ccr-resume` (#28) because it edits the same `sync-lockfile` job. Merge #28 first; GitHub will retarget this PR to `main` automatically.
