### PR TITLE
fix: price Opus 4.7/4.8 at the $5/$25 tier (issue #37)

### DIFF
--- a/src/ccrecall/token_parser.py
+++ b/src/ccrecall/token_parser.py
@@ -4,6 +4,7 @@ for the token ingest pipeline.
 """
 
 import json
+import re
 import sqlite3
 from collections.abc import Sequence
 from dataclasses import dataclass, field
@@ -51,28 +52,40 @@ _BASH_ANTIPATTERN_PREDICATE = """
 
 # Pricing (USD per million tokens)
 # Source: https://docs.anthropic.com/en/docs/about-claude/pricing
-# Keys are substrings matched against model IDs (checked in order).
-# cache_write_5m = 1.25x input, cache_write_1h = 2x input, cache_read = 0.1x input.
+# Keys match as substrings of the lowercased model id, in order, but must NOT be
+# immediately followed by another digit (see get_pricing) — so "opus-4-1" matches
+# claude-opus-4-1 but not claude-opus-4-10. cache_write_5m = 1.25x input,
+# cache_write_1h = 2x input, cache_read = 0.1x input.
 
 MODEL_PRICING: list[tuple[str, dict[str, float]]] = [
+    # Legacy Opus (4.0 / 4.1) — the only Opus models at the old $15/$75 tier; all
+    # three keys alias the same rates. Enumerated explicitly so they're matched
+    # before the generic "opus" fallback below; relative order within this block
+    # doesn't matter (no key is a digit-boundary prefix of another).
+    #   "opus-4-0"        → the 4.0 alias (claude-opus-4-0)
+    #   "opus-4-20250514" → the dated 4.0 id. Must be the FULL date, not a year
+    #     prefix like "opus-4-2025": the digit-boundary rule in get_pricing rejects
+    #     a key immediately followed by a digit, so "opus-4-2025" (followed by "0")
+    #     would never match its own model id.
+    #   "opus-4-1"        → 4.1 (claude-opus-4-1, dated or bare)
     (
-        "opus-4-6",
+        "opus-4-0",
         {
-            "input": 5.0,
-            "output": 25.0,
-            "cache_write_5m": 6.25,
-            "cache_write_1h": 10.0,
-            "cache_read": 0.50,
+            "input": 15.0,
+            "output": 75.0,
+            "cache_write_5m": 18.75,
+            "cache_write_1h": 30.0,
+            "cache_read": 1.50,
         },
     ),
     (
-        "opus-4-5",
+        "opus-4-20250514",
         {
-            "input": 5.0,
-            "output": 25.0,
-            "cache_write_5m": 6.25,
-            "cache_write_1h": 10.0,
-            "cache_read": 0.50,
+            "input": 15.0,
+            "output": 75.0,
+            "cache_write_5m": 18.75,
+            "cache_write_1h": 30.0,
+            "cache_read": 1.50,
         },
     ),
     (
@@ -85,14 +98,18 @@ MODEL_PRICING: list[tuple[str, dict[str, float]]] = [
             "cache_read": 1.50,
         },
     ),
+    # Every other Opus (4.5+ and anything newer) is the current $5/$25 tier.
+    # A generic fallback rather than per-version entries so a new Opus release
+    # prices correctly with no table edit — the failure mode behind issue #37,
+    # where new opus-4-N ids silently hit the legacy $15/$75 catch-all.
     (
-        "opus-4",
+        "opus",
         {
-            "input": 15.0,
-            "output": 75.0,
-            "cache_write_5m": 18.75,
-            "cache_write_1h": 30.0,
-            "cache_read": 1.50,
+            "input": 5.0,
+            "output": 25.0,
+            "cache_write_5m": 6.25,
+            "cache_write_1h": 10.0,
+            "cache_read": 0.50,
         },
     ),
     (
@@ -124,11 +141,16 @@ DEFAULT_PRICING = next(rates for substr, rates in MODEL_PRICING if substr == "so
 
 
 def get_pricing(model: str | None) -> dict[str, float]:
-    """Return pricing dict for a model ID, falling back to Sonnet rates."""
+    """Return pricing dict for a model ID, falling back to Sonnet rates.
+
+    A key matches as a substring of the model id but must not be immediately
+    followed by another digit, so a version key like "opus-4-1" matches
+    claude-opus-4-1 without also matching a future claude-opus-4-10.
+    """
     if model:
         m = model.lower()
         for substr, rates in MODEL_PRICING:
-            if substr in m:
+            if re.search(re.escape(substr) + r"(?!\d)", m):
                 return rates
     return DEFAULT_PRICING
 

--- a/src/ccrecall/token_parser.py
+++ b/src/ccrecall/token_parser.py
@@ -57,9 +57,20 @@ _BASH_ANTIPATTERN_PREDICATE = """
 # claude-opus-4-1 but not claude-opus-4-10. cache_write_5m = 1.25x input,
 # cache_write_1h = 2x input, cache_read = 0.1x input.
 
+# Shared by the three legacy-Opus keys below so a legacy-rate correction is a
+# one-line edit instead of three in-sync copies. Read-only — get_pricing returns
+# it as-is and callers never mutate the dict.
+_LEGACY_OPUS_RATES: dict[str, float] = {
+    "input": 15.0,
+    "output": 75.0,
+    "cache_write_5m": 18.75,
+    "cache_write_1h": 30.0,
+    "cache_read": 1.50,
+}
+
 MODEL_PRICING: list[tuple[str, dict[str, float]]] = [
     # Legacy Opus (4.0 / 4.1) — the only Opus models at the old $15/$75 tier; all
-    # three keys alias the same rates. Enumerated explicitly so they're matched
+    # three keys alias _LEGACY_OPUS_RATES. Enumerated explicitly so they're matched
     # before the generic "opus" fallback below; relative order within this block
     # doesn't matter (no key is a digit-boundary prefix of another).
     #   "opus-4-0"        → the 4.0 alias (claude-opus-4-0)
@@ -68,36 +79,9 @@ MODEL_PRICING: list[tuple[str, dict[str, float]]] = [
     #     a key immediately followed by a digit, so "opus-4-2025" (followed by "0")
     #     would never match its own model id.
     #   "opus-4-1"        → 4.1 (claude-opus-4-1, dated or bare)
-    (
-        "opus-4-0",
-        {
-            "input": 15.0,
-            "output": 75.0,
-            "cache_write_5m": 18.75,
-            "cache_write_1h": 30.0,
-            "cache_read": 1.50,
-        },
-    ),
-    (
-        "opus-4-20250514",
-        {
-            "input": 15.0,
-            "output": 75.0,
-            "cache_write_5m": 18.75,
-            "cache_write_1h": 30.0,
-            "cache_read": 1.50,
-        },
-    ),
-    (
-        "opus-4-1",
-        {
-            "input": 15.0,
-            "output": 75.0,
-            "cache_write_5m": 18.75,
-            "cache_write_1h": 30.0,
-            "cache_read": 1.50,
-        },
-    ),
+    ("opus-4-0", _LEGACY_OPUS_RATES),
+    ("opus-4-20250514", _LEGACY_OPUS_RATES),
+    ("opus-4-1", _LEGACY_OPUS_RATES),
     # Every other Opus (4.5+ and anything newer) is the current $5/$25 tier.
     # A generic fallback rather than per-version entries so a new Opus release
     # prices correctly with no table edit — the failure mode behind issue #37,

--- a/tests/test_token_parser.py
+++ b/tests/test_token_parser.py
@@ -147,22 +147,43 @@ class TestParseSessionCharacterization:
 
 class TestGetPricing:
     def test_opus_46(self):
+        # No explicit 4-6 entry anymore — resolved by the generic "opus" $5/$25 fallback.
         assert get_pricing("claude-opus-4-6-20260101")["input"] == 5.0
 
-    def test_opus_47_not_caught_by_opus_4_catch_all(self):
-        # opus-4-7 must hit the $5/$25 tier, not fall through to the opus-4 catch-all ($15/$75).
+    def test_opus_47_current_tier(self):
+        # opus-4-7 must hit the current $5/$25 tier, not the legacy $15/$75 tier (issue #37).
         p = get_pricing("claude-opus-4-7")
         assert p["input"] == 5.0
         assert p["output"] == 25.0
 
-    def test_opus_48_not_caught_by_opus_4_catch_all(self):
-        # opus-4-8 must hit the $5/$25 tier, not fall through to the opus-4 catch-all ($15/$75).
+    def test_opus_48_current_tier(self):
+        # opus-4-8 must hit the current $5/$25 tier, not the legacy $15/$75 tier (issue #37).
         p = get_pricing("claude-opus-4-8")
         assert p["input"] == 5.0
         assert p["output"] == 25.0
 
-    def test_opus_41_distinct_from_46(self):
-        # opus-4-1 is the older, pricier tier — must not collide with opus-4-6.
+    def test_unknown_future_opus_defaults_to_current_tier(self):
+        # The structural fix for issue #37: an unrecognized Opus id falls through to the
+        # generic "opus" entry (current $5/$25), NOT the legacy $15/$75 rate. Guards against
+        # a future Opus release being silently mispriced 3x high until someone edits the table.
+        # The 4-10/4-11/4-12 cases pin the digit-boundary rule: without it, "opus-4-1" would
+        # prefix-match those and re-introduce the legacy-rate misprice.
+        for model in (
+            "claude-opus-4-9",
+            "claude-opus-4-10",
+            "claude-opus-4-11",
+            "claude-opus-4-12",
+            "claude-opus-5",
+            "claude-opus-9-99",
+        ):
+            p = get_pricing(model)
+            assert p["input"] == 5.0, model
+            assert p["output"] == 25.0, model
+
+    def test_legacy_opus_40_and_41_priced_at_old_tier(self):
+        # The only Opus models still at $15/$75 — alias, dated, and 4.1 forms.
+        assert get_pricing("claude-opus-4-0")["input"] == 15.0
+        assert get_pricing("claude-opus-4-20250514")["input"] == 15.0
         assert get_pricing("claude-opus-4-1-20250805")["input"] == 15.0
 
     def test_sonnet(self):

--- a/tests/test_token_parser.py
+++ b/tests/test_token_parser.py
@@ -149,6 +149,18 @@ class TestGetPricing:
     def test_opus_46(self):
         assert get_pricing("claude-opus-4-6-20260101")["input"] == 5.0
 
+    def test_opus_47_not_caught_by_opus_4_catch_all(self):
+        # opus-4-7 must hit the $5/$25 tier, not fall through to the opus-4 catch-all ($15/$75).
+        p = get_pricing("claude-opus-4-7")
+        assert p["input"] == 5.0
+        assert p["output"] == 25.0
+
+    def test_opus_48_not_caught_by_opus_4_catch_all(self):
+        # opus-4-8 must hit the $5/$25 tier, not fall through to the opus-4 catch-all ($15/$75).
+        p = get_pricing("claude-opus-4-8")
+        assert p["input"] == 5.0
+        assert p["output"] == 25.0
+
     def test_opus_41_distinct_from_46(self):
         # opus-4-1 is the older, pricier tier — must not collide with opus-4-6.
         assert get_pricing("claude-opus-4-1-20250805")["input"] == 15.0


### PR DESCRIPTION
## Summary

Opus 4.7 and 4.8 were overstated 3× in all `/ccr-tokens` cost output. `MODEL_PRICING` in `token_parser.py` had no entries for `opus-4-7`/`opus-4-8`, and `get_pricing` does ordered substring matching, so both fell through to the legacy `"opus-4"` catch-all ($15/$75 input/output) instead of the current Opus tier ($5/$25).

### The fix — restructure, don't keep patching

The naive fix is to add per-version entries for 4.7 and 4.8. But that just defers the same bug to the next Opus release — whoever adds 4.9 has to remember to put it above the catch-all, or it gets mispriced again. Instead the pricing table is inverted so the failure mode can't recur:

- **Enumerate only the legacy $15/$75 models** — `opus-4-0` (alias), `opus-4-20250514` (dated 4.0), and `opus-4-1`. These are the only Opus models that were ever at that tier.
- **A generic `"opus"` key is the $5/$25 fallback** for every other Opus — current (4.5–4.8) and any future release — so a new Opus prices correctly with no table edit.

### Digit-boundary matching

Substring matching has a subtler trap: `"opus-4-1"` is a prefix of `"opus-4-10"`, so once Anthropic ships Opus 4.10 it would have hit the legacy `opus-4-1` entry and been mispriced again. `get_pricing` now matches on a digit boundary (`re.search(re.escape(substr) + r"(?!\d)", m)`): a version key only matches when not immediately followed by another digit. `"opus-4-1"` matches `claude-opus-4-1` and its dated form, but not `claude-opus-4-10`. The dated 4.0 key is the full date (`opus-4-20250514`) rather than a year prefix for the same reason — a year prefix is followed by a digit and would never match itself.

### Tests

- Regression tests pin 4.7/4.8 (the reported models) at the $5/$25 tier — committed first as a failing RED test, then made to pass.
- A parametrized test pins the structural guarantee: unrecognized/future Opus ids (`4-9`, `4-10`, `4-11`, `4-12`, `opus-5`) default to the current tier, and the legacy 4.0/4.1 forms stay at $15/$75.

### Housekeeping

- The three legacy keys share one `_LEGACY_OPUS_RATES` constant instead of three byte-identical rate dicts, so a legacy-rate correction is a one-line edit.

Closes #37
