### PR TITLE
fix: stamp embedding watermark for zero-exchange branches

### DIFF
--- a/src/ccrecall/session_ops.py
+++ b/src/ccrecall/session_ops.py
@@ -377,6 +377,19 @@ def write_branch_summary(cursor: sqlite3.Cursor, branch_db_id: int) -> str | Non
 MAX_WRITE_PATH_EMBEDS_PER_SYNC = 8
 
 
+def _stamp_branch_watermark(cursor: sqlite3.Cursor, branch_db_id: int) -> None:
+    """Set a branch's embedding watermark to the current version + model.
+
+    Meaning: every current exchange of this branch has a current-version chunk
+    vector. Written at the three points that establish that invariant — the
+    zero-exchange case, the idempotent repair, and the step-8 success path.
+    """
+    cursor.execute(
+        "UPDATE branches SET embedding_version = ?, embedding_model = ? WHERE id = ?",
+        (EMBEDDING_VERSION, EMBEDDING_MODEL, branch_db_id),
+    )
+
+
 def embed_branch_chunks(
     cursor: sqlite3.Cursor,
     branch_db_id: int,
@@ -407,13 +420,23 @@ def embed_branch_chunks(
 
     Raises on failure — callers (sync_branch) must wrap in
     contextlib.suppress(Exception). Does not commit; the single commit at
-    sync_current.py:137 owns the transaction.
+    sync_current.py:239 owns the transaction.
     """
-    if not (is_active and vec_writable and branch_msgs):
+    if not (is_active and vec_writable):
         return 0
 
     exchanges = build_exchange_pairs(branch_msgs)
     if not exchanges:
+        # Active, writable branch with no embeddable exchange — e.g. a sub-agent /
+        # sidechain branch whose messages are all assistant-role, or one left with
+        # only notifications after the notification filter. There is nothing to
+        # embed, but the branch is still eligible for the backfill, so stamp the
+        # watermark to current: with zero exchanges the "all exchanges embedded"
+        # invariant holds trivially. This drops the branch out of the eligible
+        # set so the backfill doesn't re-select it forever and abort via the
+        # no-progress guard. Self-correcting: if a user turn later lands, the
+        # content diff re-clears the watermark and the new exchange is embedded.
+        _stamp_branch_watermark(cursor, branch_db_id)
         return 0
 
     # Step 3 — compute embedded text, content hash, and bounded display text per exchange.
@@ -469,15 +492,12 @@ def embed_branch_chunks(
         if exchange_data and all(
             existing_chunks.get(ed["index"], {}).get("embedding_version") == EMBEDDING_VERSION for ed in exchange_data
         ):
-            cursor.execute(
-                "UPDATE branches SET embedding_version = ?, embedding_model = ? WHERE id = ?",
-                (EMBEDDING_VERSION, EMBEDDING_MODEL, branch_db_id),
-            )
+            _stamp_branch_watermark(cursor, branch_db_id)
         return 0
 
     # Step 5a — clear-first: if any exchange needs embedding, clear the watermark
     # BEFORE the loop so a mid-loop exception leaves the branch stale, never
-    # stale-but-true (single commit — sync_current.py:137 — persists this state).
+    # stale-but-true (single commit — sync_current.py:239 — persists this state).
     if needing_embed_full:
         cursor.execute("UPDATE branches SET embedding_version = 0 WHERE id = ?", (branch_db_id,))
 
@@ -548,10 +568,7 @@ def embed_branch_chunks(
             all_current = False
             break
     if all_current:
-        cursor.execute(
-            "UPDATE branches SET embedding_version = ?, embedding_model = ? WHERE id = ?",
-            (EMBEDDING_VERSION, EMBEDDING_MODEL, branch_db_id),
-        )
+        _stamp_branch_watermark(cursor, branch_db_id)
 
     return len(needing_embed)
 

--- a/tests/test_backfill_embeddings.py
+++ b/tests/test_backfill_embeddings.py
@@ -109,6 +109,38 @@ def _insert_branch_with_messages(
     return branch_id
 
 
+def _insert_assistant_only_branch(conn: sqlite3.Connection, num_messages: int = 3) -> int:
+    """Insert an active branch whose only messages are assistant-role (no user turns).
+
+    Mirrors a sub-agent / sidechain transcript: eligible under CHUNK_EMBEDDABLE
+    (it has branch_messages) but build_exchange_pairs yields nothing, so there is
+    nothing to embed. Such a branch must not perpetually re-select and stall.
+    """
+    _branch_counter[0] += 1
+    uid = _branch_counter[0]
+
+    conn.execute("INSERT INTO sessions(uuid, project_id) VALUES (?, NULL)", (f"sess-{uid}",))
+    session_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+    conn.execute(
+        "INSERT INTO branches(session_id, leaf_uuid, summary_version, is_active) VALUES (?, ?, 0, 1)",
+        (session_id, f"leaf-{uid}"),
+    )
+    branch_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+    for i in range(num_messages):
+        ts_h = 10 + i
+        conn.execute(
+            "INSERT INTO messages(session_id, uuid, role, content, timestamp) VALUES (?, ?, 'assistant', ?, ?)",
+            (session_id, f"a-{uid}-{i}", f"Assistant message {i}", f"2024-01-01T{ts_h:02d}:00:00Z"),
+        )
+        msg_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        conn.execute("INSERT INTO branch_messages(branch_id, message_id) VALUES (?, ?)", (branch_id, msg_id))
+
+    conn.commit()
+    return branch_id
+
+
 def _branch_embedding_version(conn: sqlite3.Connection, branch_id: int) -> int | None:
     row = conn.execute("SELECT embedding_version FROM branches WHERE id = ?", (branch_id,)).fetchone()
     return row[0] if row else None
@@ -431,6 +463,41 @@ class TestBackfillNoProgressGuard:
         # Row was never stamped (embed was a no-op), confirming exit via the guard.
         ev = _branch_embedding_version(conn, bid)
         assert ev != EMBEDDING_VERSION, "Row should not be at EMBEDDING_VERSION — embed was no-op"
+
+
+@_VEC_SKIP
+class TestBackfillZeroExchangeBranches:
+    """Assistant-only (sub-agent/sidechain) branches are eligible under
+    CHUNK_EMBEDDABLE but have no embeddable exchange. They must leave the
+    eligible set instead of re-selecting forever and stalling the backfill."""
+
+    def test_assistant_only_branch_does_not_stall(self):
+        """A branch with no user turns embeds nothing but advances its watermark,
+        so it isn't perpetually re-selected."""
+        conn = make_vec_conn()
+        bid = _insert_assistant_only_branch(conn)
+
+        _run_backfill_with_stub(conn)
+
+        assert _chunk_count(conn) == 0
+        assert _branch_embedding_version(conn, bid) == EMBEDDING_VERSION
+
+    def test_assistant_only_does_not_block_real_branch(self):
+        """A whole batch of zero-exchange branches must not prevent a real,
+        embeddable branch behind them from being reached and embedded — the
+        roadblock that the pre-fix no-progress guard hit."""
+        conn = make_vec_conn()
+        # Insert the zero-exchange branches first so they fill the first batch
+        # (selection is ORDER BY id) and the real branch lands in a later batch.
+        for _ in range(BATCH_SIZE):
+            _insert_assistant_only_branch(conn)
+        real = _insert_branch_with_messages(conn)
+
+        _run_backfill_with_stub(conn)
+
+        assert _branch_has_chunk_vecs(conn, real), (
+            "real branch must embed, not be blocked behind zero-exchange branches"
+        )
 
 
 # Failure modes: model failure marks nothing; content errors mark only that row

--- a/tests/test_session_ops.py
+++ b/tests/test_session_ops.py
@@ -613,6 +613,53 @@ class TestEmbedBranchChunks:
 
         conn.close()
 
+    def test_zero_exchange_branch_stamps_watermark(self, tmp_path):
+        """An active branch with no embeddable exchange (all-assistant messages,
+        as in a sub-agent/sidechain transcript) embeds nothing but advances its
+        watermark to current, so the backfill stops re-selecting it and stalling."""
+        conn = _make_vec_conn(tmp_path)
+        if conn is None:
+            pytest.skip("sqlite-vec not available")
+
+        cursor = conn.cursor()
+        branch_id = _seed_branch(cursor)  # embedding_version defaults to 0
+        conn.commit()
+
+        # Assistant-only messages form no user->assistant exchange pair.
+        msgs = [{"role": "assistant", "content": "sidechain output", "timestamp": "2024-01-01T00:00:30", "uuid": None}]
+
+        with patch("ccrecall.session_ops.embed_text") as mock_embed:
+            returned = embed_branch_chunks(cursor, branch_id, msgs, is_active=True, vec_writable=True)
+
+        assert returned == 0
+        assert mock_embed.call_count == 0, "no exchange means no embedding"
+        ev = cursor.execute("SELECT embedding_version FROM branches WHERE id = ?", (branch_id,)).fetchone()[0]
+        assert ev == EMBEDDING_VERSION, "zero-exchange branch must advance watermark to leave the eligible set"
+
+        conn.close()
+
+    def test_zero_exchange_inactive_branch_not_stamped(self):
+        """An inactive branch must not have its watermark set by the zero-exchange
+        path: the is_active guard early-returns before any stamping. Uses a plain
+        connection — this path never reaches the vector layer, so it must run even
+        where sqlite-vec is unavailable."""
+        conn = sqlite3.connect(":memory:")
+        conn.executescript(SCHEMA)
+        conn.commit()
+
+        cursor = conn.cursor()
+        branch_id = _seed_branch(cursor, is_active=0)
+        conn.commit()
+
+        msgs = [{"role": "assistant", "content": "x", "timestamp": "2024-01-01T00:00:30", "uuid": None}]
+        returned = embed_branch_chunks(cursor, branch_id, msgs, is_active=False, vec_writable=True)
+
+        assert returned == 0
+        ev = cursor.execute("SELECT embedding_version FROM branches WHERE id = ?", (branch_id,)).fetchone()[0]
+        assert ev == 0, "inactive branch must not be stamped"
+
+        conn.close()
+
     def test_prune_on_exchange_shrink(self, tmp_path):
         """Removing an exchange deletes its chunks and chunk_vec rows (cascade)."""
         conn = _make_vec_conn(tmp_path)


### PR DESCRIPTION
## What

Fixes a backfill stall: `ccrecall backfill embeddings` could report progress like

```
ccrecall backfill embeddings: 0 exchanges embedded across 20/47 branches, 27 remaining
ccrecall backfill embeddings: no progress — same batch re-selected, aborting
```

and abort without embedding anything.

## Root cause

`embed_branch_chunks` returned early for an active, writable branch that has **no embeddable exchange** — an all-assistant sub-agent/sidechain transcript, or a branch left with only notifications after the notification filter — *without* advancing that branch's embedding watermark. Such branches stay in the backfill's eligible set indefinitely. A full batch of them causes the backfill to re-select the same rows, make zero progress, and abort via the no-progress guard, blocking any real branch queued behind them.

## Fix

Stamp the watermark to the current version whenever there are no exchanges to embed. With zero exchanges, the "all current exchanges have a current-version vector" invariant holds trivially, so the branch correctly leaves the eligible set. It is self-correcting: if a user turn later lands on the branch, the content diff re-clears the watermark and the new exchange is embedded.

Also drops `branch_msgs` from the entry guard so the empty-messages case reaches the same stamp, and extracts a small `_stamp_branch_watermark` helper used at the three watermark-write sites (previously three duplicated `UPDATE` statements).

## Verification

RED → GREEN sequence:

- **RED** (`test:` commit) — `TestBackfillZeroExchangeBranches` reproduces the stall (`no progress — same batch re-selected, aborting`) and fails against the unfixed code.
- **GREEN** (`fix:` commit) — the fix; tests pass.

Coverage added:
- Direct unit tests of `embed_branch_chunks` for the zero-exchange active and inactive cases.
- Two backfill-level tests: a batch of zero-exchange branches no longer stalls, and a real embeddable branch behind them is still reached.

Full suite: **780 passed**; `prek run --all-files` clean (ruff, pyright, custom checks).
