### PR TITLE
feat: honest branch-grain embedding coverage in stats and --status

### DIFF
--- a/src/ccrecall/db.py
+++ b/src/ccrecall/db.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import sqlite_vec
 
-from ccrecall.embeddings import EMBEDDING_DIM
+from ccrecall.embeddings import EMBEDDING_DIM, EMBEDDING_MODEL, EMBEDDING_VERSION
 from ccrecall.models import BUSY_TIMEOUT_MS, LOGGER_NAME
 from ccrecall.schema import SCHEMA_CORE, SCHEMA_FTS4, SCHEMA_FTS5, detect_fts_support
 
@@ -347,6 +347,30 @@ def get_db_connection(settings: dict | None = None, load_vec: bool = False) -> s
         conn.execute(f"PRAGMA busy_timeout = {VEC_BUSY_TIMEOUT_MS}")
 
     return conn
+
+
+def branch_embedding_coverage(conn: sqlite3.Connection) -> tuple[int, int]:
+    """Return (embedded, total) embeddable branches by watermark.
+
+    `total` is every CHUNK_EMBEDDABLE branch; `embedded` is those whose
+    watermark (embedding_version/embedding_model) is at the current version and
+    model. Vec-free — reads only the branches table, whose embedding columns
+    live in the base schema — so coverage reports work even where sqlite-vec
+    can't load. Shared by `ccrecall stats` and search's `print_status` so the
+    two surfaces can't drift (see CHUNK_EMBEDDABLE_BRANCH_FILTER).
+
+    This is the watermark view. `backfill embeddings --status` reports a
+    stricter, heal-aware count (its eligible set also flags watermark-current
+    branches that lost a chunk_vec row), so on a DB with orphaned vectors that
+    surface can show slightly fewer embedded branches than this one.
+    """
+    total = conn.execute(f"SELECT COUNT(*) FROM branches WHERE {CHUNK_EMBEDDABLE_BRANCH_FILTER}").fetchone()[0]
+    embedded = conn.execute(
+        f"SELECT COUNT(*) FROM branches WHERE {CHUNK_EMBEDDABLE_BRANCH_FILTER} "
+        "AND embedding_version = ? AND embedding_model = ?",
+        (EMBEDDING_VERSION, EMBEDDING_MODEL),
+    ).fetchone()[0]
+    return embedded, total
 
 
 def setup_logging(settings: dict | None = None) -> logging.Logger:

--- a/src/ccrecall/hooks/backfill_embeddings.py
+++ b/src/ccrecall/hooks/backfill_embeddings.py
@@ -111,15 +111,20 @@ def build_selection(days: int | None) -> tuple[str, list]:
 
 
 def count_status(cursor: sqlite3.Cursor, days: int | None) -> dict[str, int]:
-    """Count chunk-coverage backfill progress without doing any work.
+    """Count backfill progress without doing any work.
 
-    universe = chunks belonging to CHUNK_EMBEDDABLE branches.
-    done     = chunks with a current-version chunk_vec row.
-    eligible = branches still needing work (build_selection predicate; branch count).
-    errored  = branches marked with the content-error sentinel (branch count).
+    universe          = chunks belonging to CHUNK_EMBEDDABLE branches.
+    done              = chunks with a current-version chunk_vec row.
+    total_branches    = all CHUNK_EMBEDDABLE branches — the honest coverage
+                        denominator (branch count).
+    embedded_branches = embeddable branches that are neither pending nor errored.
+    eligible          = branches still needing work (build_selection predicate).
+    errored           = branches marked with the content-error sentinel.
 
-    universe/done are chunk-grain; eligible/errored are branch-grain since the
-    iteration unit and the sentinel both live on branches.
+    universe/done are chunk-grain; the rest are branch-grain. Branch grain is
+    the honest coverage signal: a never-chunked branch contributes 0 to
+    universe but 1 to total_branches, so the backlog can't hide in the
+    denominator (the misleading "100% embedded, N remaining" report).
 
     The optional --days recency bound is applied consistently to all queries.
     """
@@ -172,11 +177,29 @@ def count_status(cursor: sqlite3.Cursor, days: int | None) -> dict[str, int]:
     cursor.execute(f"SELECT COUNT(*) FROM branches {where}", params)
     eligible = cursor.fetchone()[0]
 
+    # total_branches: every embeddable branch (branch grain). embedded =
+    # total - eligible - errored: a branch is one of embedded / eligible /
+    # errored, and eligible/errored are disjoint (build_selection excludes the
+    # error sentinel). Note this is stricter than the watermark count in
+    # db.branch_embedding_coverage(): build_selection's heal clause counts a
+    # watermark-current branch with a missing chunk_vec row as eligible, so on a
+    # DB with orphaned vectors `--status` reports fewer embedded than `stats`.
+    cursor.execute(
+        f"SELECT COUNT(*) FROM branches WHERE {CHUNK_EMBEDDABLE_BRANCH_FILTER}{recency_branch}",
+        recency_params,
+    )
+    total_branches = cursor.fetchone()[0]
+
     return {
+        # universe/done are chunk-grain, kept for back-compat with older
+        # --status --json consumers; total_branches/embedded_branches are the
+        # honest branch-grain coverage.
         "universe": universe,
         "done": done,
         "eligible": eligible,
         "errored": errored,
+        "total_branches": total_branches,
+        "embedded_branches": total_branches - eligible - errored,
     }
 
 
@@ -199,7 +222,7 @@ def run_status(
     settings: dict | None,
     logger: logging.Logger,
 ) -> int:
-    """Report chunk coverage (done/universe) and branch eligible/errored counts (read-only)."""
+    """Report branch coverage (embedded/total) plus eligible/errored counts (read-only)."""
     try:
         conn = get_db_connection(settings, load_vec=True)
     except (sqlite3.Error, OSError) as e:
@@ -222,12 +245,12 @@ def run_status(
         print(json.dumps({**counts, "days": days}))
         return EXIT_OK
 
-    universe = counts["universe"]
-    done = counts["done"]
-    pct = (done / universe * 100) if universe else 0.0
+    total = counts["total_branches"]
+    embedded = counts["embedded_branches"]
+    pct = (embedded / total * 100) if total else 0.0
     scope = f" (last {days}d)" if days is not None else ""
     print(f"ccrecall backfill embeddings status{scope}:")
-    print(f"  embedded:  {done} / {universe} chunks  ({pct:.0f}%)")
+    print(f"  branches:  {embedded} / {total} embedded  ({pct:.0f}%)")
     print(f"  remaining: {counts['eligible']} branches")
     if counts["errored"]:
         print(f"  errored:   {counts['errored']} branches  (content errors, won't retry)")

--- a/src/ccrecall/hooks/import_conversations.py
+++ b/src/ccrecall/hooks/import_conversations.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from ccrecall.db import (
     DEFAULT_DB_PATH,
     DEFAULT_PROJECTS_DIR,
+    branch_embedding_coverage,
     get_db_connection,
     get_db_path,
     load_settings,
@@ -191,6 +192,8 @@ def print_stats(db: Path = DEFAULT_DB_PATH) -> None:
         active = cursor.fetchone()[0]
         cursor.execute("SELECT COUNT(*) FROM branches WHERE is_active = 0")
         abandoned = cursor.fetchone()[0]
+        # Branch-grain embedding coverage (vec-free watermark count).
+        embedded, embeddable = branch_embedding_coverage(conn)
 
     db_size = db_path.stat().st_size if db_path.exists() else 0
 
@@ -200,6 +203,10 @@ def print_stats(db: Path = DEFAULT_DB_PATH) -> None:
     print(f"Sessions: {sessions}")
     print(f"Branches: {total_branches} ({active} active, {abandoned} abandoned)")
     print(f"Messages: {messages}")
+    if embeddable:
+        print(f"Embeddings: {embedded}/{embeddable} branches ({embedded / embeddable * 100:.0f}%)")
+    else:
+        print("Embeddings: 0/0 branches")
 
 
 def run(

--- a/src/ccrecall/search_conversations.py
+++ b/src/ccrecall/search_conversations.py
@@ -14,8 +14,8 @@ import sqlite_vec
 
 from ccrecall.content import sanitize_fts_term
 from ccrecall.db import (
-    CHUNK_EMBEDDABLE_BRANCH_FILTER,
     DEFAULT_DB_PATH,
+    branch_embedding_coverage,
     chunk_vec_queryable,
     escape_like,
     get_db_connection,
@@ -758,15 +758,8 @@ def print_status(settings: dict | None) -> None:
             ).fetchone()[0]
             print(f"chunk coverage: {current_chunks}/{total_chunks} chunks at current version")
 
-            # Branch watermark: branches where all chunks are at current version
-            total_branches = conn.execute(
-                f"SELECT count(*) FROM branches WHERE {CHUNK_EMBEDDABLE_BRANCH_FILTER}"
-            ).fetchone()[0]
-            embedded_branches = conn.execute(
-                f"SELECT count(*) FROM branches WHERE {CHUNK_EMBEDDABLE_BRANCH_FILTER}"
-                " AND embedding_version = ? AND embedding_model = ?",
-                (EMBEDDING_VERSION, EMBEDDING_MODEL),
-            ).fetchone()[0]
+            # Branch watermark: branches whose every current exchange is embedded.
+            embedded_branches, total_branches = branch_embedding_coverage(conn)
             print(f"embedded branches: {embedded_branches}/{total_branches} (watermark)")
         except sqlite3.Error as e:
             print(f"chunk coverage: error ({e})")

--- a/tests/test_backfill_embeddings.py
+++ b/tests/test_backfill_embeddings.py
@@ -770,17 +770,22 @@ class TestBackfillStatus:
         assert data["eligible"] == 2
         # errored = branches with content-error sentinel (1)
         assert data["errored"] == 1
+        # branch grain: 6 embeddable total, 3 embedded (= total - eligible - errored)
+        assert data["total_branches"] == 6
+        assert data["embedded_branches"] == 3
         assert data["days"] is None
 
-    def test_human_output_reports_chunk_coverage(self, capsys):
+    def test_human_output_reports_branch_coverage(self, capsys):
         conn = make_vec_conn()
         self._seed_mixed(conn)
 
         out = _run_status(conn, capsys)
 
-        assert "3 / 3 chunks" in out
-        assert "2 branches" in out
+        # Honest branch-grain coverage, not the misleading partial-universe chunk %.
+        assert "3 / 6 embedded" in out
+        assert "remaining: 2 branches" in out
         assert "errored" in out
+        assert "chunks" not in out
 
     def test_days_filters_counts(self, capsys):
         """--status --days N bounds universe/eligible/errored by recency."""
@@ -809,6 +814,9 @@ class TestBackfillStatus:
         # but universe counts existing chunks; recent has none since not yet run)
         assert data["eligible"] == 1
         assert data["errored"] == 1
+        # Branch grain is recency-bounded too: 2 in-window branches, 0 embedded.
+        assert data["total_branches"] == 2
+        assert data["embedded_branches"] == 0
         assert data["days"] == 30
 
     def test_status_does_not_embed(self, capsys):

--- a/tests/test_import_pipeline.py
+++ b/tests/test_import_pipeline.py
@@ -6,7 +6,9 @@ from pathlib import Path
 
 import pytest
 
-from ccrecall.hooks.import_conversations import import_project, import_session
+from ccrecall.db import get_db_connection
+from ccrecall.embeddings import EMBEDDING_MODEL, EMBEDDING_VERSION
+from ccrecall.hooks.import_conversations import import_project, import_session, print_stats
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
 
@@ -697,3 +699,58 @@ class TestEmptyBranchGuardTightened:
             )
         finally:
             temp_path.unlink()
+
+
+class TestPrintStatsEmbeddingCoverage:
+    """`ccrecall stats` reports honest branch-grain embedding coverage."""
+
+    @staticmethod
+    def _seed_embeddable_branch(conn, i: int, *, embedded: bool, is_active: int = 1) -> None:
+        """Insert an active branch with one message (so it's CHUNK_EMBEDDABLE),
+        optionally stamped at the current embedding watermark. ``i`` keys the
+        unique columns so repeated calls don't collide."""
+        cur = conn.cursor()
+        cur.execute("INSERT INTO projects (path, key) VALUES (?, ?)", (f"/p/{i}", f"k-{i}"))
+        project_id = cur.lastrowid
+        cur.execute("INSERT INTO sessions (uuid, project_id) VALUES (?, ?)", (f"sess-{i}", project_id))
+        session_id = cur.lastrowid
+        version, model = (EMBEDDING_VERSION, EMBEDDING_MODEL) if embedded else (0, None)
+        cur.execute(
+            "INSERT INTO branches (session_id, leaf_uuid, is_active, embedding_version, embedding_model) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (session_id, f"leaf-{i}", is_active, version, model),
+        )
+        branch_id = cur.lastrowid
+        cur.execute(
+            "INSERT INTO messages (session_id, uuid, role, content, timestamp) VALUES (?, ?, 'user', 'hi', ?)",
+            (session_id, f"m-{i}", "2024-01-01T00:00:00Z"),
+        )
+        cur.execute("INSERT INTO branch_messages (branch_id, message_id) VALUES (?, ?)", (branch_id, cur.lastrowid))
+        conn.commit()
+
+    def test_reports_partial_coverage(self, tmp_path, capsys):
+        """Two of three embeddable branches embedded → '2/3 branches (67%)'."""
+        db_path = tmp_path / "stats.db"
+        conn = get_db_connection({"db_path": str(db_path)}, load_vec=False)
+        self._seed_embeddable_branch(conn, 1, embedded=True)
+        self._seed_embeddable_branch(conn, 2, embedded=True)
+        self._seed_embeddable_branch(conn, 3, embedded=False)
+        # An inactive branch must not count toward the embeddable denominator.
+        self._seed_embeddable_branch(conn, 4, embedded=False, is_active=0)
+        conn.close()
+
+        print_stats(db=db_path)
+        out = capsys.readouterr().out
+
+        assert "Embeddings: 2/3 branches (67%)" in out
+
+    def test_zero_embeddable_branches(self, tmp_path, capsys):
+        """A DB with no embeddable branches reports 0/0 without dividing by zero."""
+        db_path = tmp_path / "empty.db"
+        conn = get_db_connection({"db_path": str(db_path)}, load_vec=False)
+        conn.close()
+
+        print_stats(db=db_path)
+        out = capsys.readouterr().out
+
+        assert "Embeddings: 0/0 branches" in out


### PR DESCRIPTION
## What

Makes embedding coverage **honest** on the two surfaces a user looks at. ("Item 1" of the post-embeddings roadmap.)

Before:
- `ccrecall backfill embeddings --status` led with chunk coverage — `embedded: done / universe chunks (X%)` — where `universe` counts only chunks belonging to *already-chunked* branches. A never-chunked backlog contributes zero chunks, so it never enters the denominator. Result: `100%` could sit right next to `remaining: N branches`, and the two lines were even in different units (chunks vs branches).
- `ccrecall stats` reported projects / sessions / branches / messages but **nothing** about embeddings — the natural "how am I doing" command gave no signal that the corpus was unembedded.

## Changes

- `count_status` returns branch-grain `total_branches` (all `CHUNK_EMBEDDABLE` branches) and `embedded_branches` (`= total − eligible − errored`). `--status` now leads with honest branch coverage and drops the misleading chunk line.
- `--status --json` keeps `universe`/`done` for back-compat and **adds** `total_branches`/`embedded_branches`.
- `ccrecall stats` gains an `Embeddings: X/Y branches (Z%)` line.
- Extracted `db.branch_embedding_coverage()` (vec-free, watermark-based) as the shared source for `stats` and search's `print_status`, replacing a duplicated inline query (first commit — pure refactor, no behaviour change).

## A documented nuance

`stats`/search report the **watermark** view (branches marked complete); `--status` reports a **stricter, heal-aware** count (its eligible set also flags watermark-current branches that lost a `chunk_vec` row). On a DB with orphaned vectors the two can differ by a hair. This is rare (writes are atomic) and is now documented at both sites so the numbers are reconcilable rather than mysterious. A future `doctor`/health surface (item 2) can unify these.

## Verification

- Observed on the real DB: `stats` → `Embeddings: 352/352 branches (100%)`; `--status` → `branches: 352/352 embedded (100%)`; search `--status` → `embedded branches: 352/352 (watermark)` — all consistent.
- Tests: branch-grain assertions on `--status` JSON (incl. the `--days` path), new `stats` coverage tests (partial `2/3 (67%)` and the `0/0` empty case). Full suite **782 passed**; `prek` clean.
- Reviewed by code / integration / readability reviewers; findings addressed.
