### PR TITLE
fix: remove disposition field from session summaries

### DIFF
--- a/skills/ccr-recall/SKILL.md
+++ b/skills/ccr-recall/SKILL.md
@@ -27,7 +27,7 @@ ccrecall recent --n 3
 ```bash
 ccrecall search --query "keyword"
 ```
-Each card carries a relevance `score` (normalized 0–1; `null` for a single result or the unranked LIKE path), `project`, `git_branch`, date, `topic`, `disposition`, exchange/file/commit counts, and a `handle`. The JSON envelope includes a `ranked` field (`false` on the LIKE-only fallback). To read the full session, use `ccrecall tail <handle>`.
+Each card carries a relevance `score` (normalized 0–1; `null` for a single result or the unranked LIKE path), `project`, `git_branch`, date, `topic`, exchange/file/commit counts, and a `handle`. The JSON envelope includes a `ranked` field (`false` on the LIKE-only fallback). To read the full session, use `ccrecall tail <handle>`.
 
 **search_conversations.py / Entrypoint B** — search matched exchanges, returns **bounded snippets**:
 ```bash

--- a/skills/ccr-recall/references/tool-reference.md
+++ b/skills/ccr-recall/references/tool-reference.md
@@ -51,7 +51,7 @@ ccrecall search --query "keyword"
 ```
 ## 0.87  ccrecall · review-format · 2026-06-25
 Topic:  redesign search result format — two-entrypoint split
-Status: IN_PROGRESS · 41 exchanges · 2 files · 1 commits
+41 exchanges · 2 files · 1 commits
 Handle: ef098861   → ccrecall tail ef098861
 ```
 
@@ -69,7 +69,7 @@ The score prefix is omitted from the heading when only one result is returned or
 (keyword fallback — unranked, ordered by recency)
 ```
 
-When a branch has no cached summary (`context_summary_json`), the card falls back to the first user message as the topic and omits `disposition` from the Status line — the card still renders and the command still exits 0.
+When a branch has no cached summary (`context_summary_json`), the card falls back to the first user message as the topic — the card still renders and the command still exits 0.
 
 **JSON (`ccrecall --json search -q "keyword"`):**
 
@@ -89,7 +89,6 @@ When a branch has no cached summary (`context_summary_json`), the card falls bac
       "started_at": "2026-06-25T07:30:00Z",
       "ended_at": "2026-06-25T13:09:42Z",
       "topic": "redesign search result format — two-entrypoint split",
-      "disposition": "IN_PROGRESS",
       "exchange_count": 41,
       "files_modified": ["src/ccrecall/search_conversations.py", "src/ccrecall/formatting.py"],
       "commits": ["docs: update tool reference for cards and snippets"],

--- a/src/ccrecall/formatting.py
+++ b/src/ccrecall/formatting.py
@@ -198,7 +198,7 @@ def apply_scores(results: list[dict], ranked: bool) -> list[dict]:
 # Contract markdown template:
 #   ## {score:.2f}  {project} · {git_branch} · {ended_date}
 #   Topic:  {topic}
-#   Status: {disposition} · {exchange_count} exchanges · {n_files} files · {n_commits} commits
+#   {exchange_count} exchanges · {n_files} files · {n_commits} commits
 #   Handle: {handle}   → ccrecall tail {handle}
 
 _TOPIC_FALLBACK = "(topic unavailable)"
@@ -231,18 +231,14 @@ def format_card_markdown(card: dict, verbose: bool = False) -> str:
     n_files = len(files_modified)
     n_commits = len(commits)
 
-    disposition = card.get("disposition")
-    if disposition:
-        status = f"Status: {disposition} · {exchange_count} exchanges · {n_files} files · {n_commits} commits"
-    else:
-        status = f"Status: {exchange_count} exchanges · {n_files} files · {n_commits} commits"
+    counts = f"{exchange_count} exchanges · {n_files} files · {n_commits} commits"
 
     handle = card.get("handle", "")
 
     lines = [
         heading,
         f"Topic:  {topic}",
-        status,
+        counts,
         f"Handle: {handle}   → ccrecall tail {handle}",
     ]
 
@@ -281,7 +277,6 @@ def format_card_json(card: dict) -> dict:
         "started_at": card.get("started_at"),
         "ended_at": card.get("ended_at"),
         "topic": card.get("topic"),
-        "disposition": card.get("disposition"),
         "exchange_count": card.get("exchange_count") or 0,
         "files_modified": list(card.get("files_modified") or []),
         "commits": list(card.get("commits") or []),

--- a/src/ccrecall/search_conversations.py
+++ b/src/ccrecall/search_conversations.py
@@ -370,7 +370,7 @@ def _hydrate_cards(
 ) -> list[dict]:
     """Build Track A session-summary card dicts for an ordered list of branch IDs.
 
-    Reads context_summary_json (topic/disposition) and branch/session/project join
+    Reads context_summary_json (topic) and branch/session/project join
     columns. Does NOT call fetch_branch_messages — A renders from summary data only
     (no full transcript hydration).
 
@@ -440,17 +440,15 @@ def _hydrate_cards(
             ) = row
             tool_counts_json = None
 
-        # Prefer join columns for list metadata; parse summary for topic/disposition
+        # Prefer join columns for list metadata; parse summary for topic
         files_modified: list = decode_json_column(files_json, [])
         commits: list = decode_json_column(commits_json, [])
         tool_counts: dict = decode_json_column(tool_counts_json, {}) if has_tool_counts else {}
 
         topic: str | None = None
-        disposition: str | None = None
         summary = decode_json_column(summary_json, {})
         if summary:
             topic = summary.get("topic") or None
-            disposition = summary.get("disposition") or None
 
         # Graceful degrade: no context_summary_json → first user message as topic
         if not topic:
@@ -478,7 +476,6 @@ def _hydrate_cards(
                 "started_at": started_at,
                 "ended_at": ended_at,
                 "topic": topic,
-                "disposition": disposition,
                 "exchange_count": exchange_count or 0,
                 "files_modified": files_modified,
                 "commits": commits,

--- a/src/ccrecall/summarizer.py
+++ b/src/ccrecall/summarizer.py
@@ -15,7 +15,7 @@ from ccrecall.serialization import decode_json_field
 
 # Schema version stamped on each generated summary. Bumped when the JSON shape
 # or extraction logic changes so the backfill path can detect stale summaries.
-SUMMARY_VERSION = 3
+SUMMARY_VERSION = 4
 
 # Truncation limits
 _FRONT_CHARS = 300
@@ -44,81 +44,12 @@ _MAX_TOOLS_SHOWN = 8
 # Compact file-basename previews (gap summary and footer).
 _MAX_FILE_PREVIEW = 3
 
-# Session disposition values stamped into the summary JSON.
-DISPOSITION_COMPLETED = "COMPLETED"
-DISPOSITION_IN_PROGRESS = "IN_PROGRESS"
-DISPOSITION_ABANDONED = "ABANDONED"
-
-# A trailing user message at or below this length counts as a brief sign-off
-# (not a substantive new turn) when classifying disposition.
-_SHORT_USER_REPLY_MAX_CHARS = 30
-# An ABANDONED classification requires more than this many exchanges — a session
-# with fewer that lacks a final user reply is normal, not abandoned.
-_ABANDONED_MIN_EXCHANGES = 2
-
-# Session disposition patterns
-_COMPLETION_RE = re.compile(
-    r"(?:done|pushed|merged|all (?:tests? )?pass|completed|finished|shipped|deployed|"
-    r"PR #?\d+|commit(?:ted)?|changes? (?:are )?live)",
-    re.IGNORECASE,
-)
-_SHORT_CONFIRM_RE = re.compile(
-    r"^(?:y(?:a|ep|es)?|thanks?|(?:looks? )?good|nice|perfect|great|ok|lgtm|k)\s*[.!]?$",
-    re.IGNORECASE,
-)
-_NEW_INSTRUCTION_RE = re.compile(r"^(?:now |next |also |can you |let\'?s |please |I (?:want|need) )", re.IGNORECASE)
-
 
 def truncate_mid(text: str, front: int = _FRONT_CHARS, back: int = _BACK_CHARS) -> str:
     """Mid-truncate text, keeping front and back portions."""
     if not text or len(text) <= front + back + _TRUNCATE_MARGIN:
         return text
     return text[:front] + "\n[... truncated ...]\n" + text[-back:]
-
-
-def detect_disposition(exchanges: list[dict], commits: list[str] | None = None) -> str:
-    """Classify session ending as COMPLETED, IN_PROGRESS, or ABANDONED.
-
-    Heuristics based on the final exchange pair and commit metadata:
-    - COMPLETED: non-empty commits list (work shipped), or assistant uses completion
-      language and user confirms briefly
-    - ABANDONED: final exchange has an assistant response but no subsequent user
-      message, AND the session has more than 2 exchanges
-    - IN_PROGRESS: user gives a new instruction as their last message, or default
-    """
-    # Non-empty commits list is a strong COMPLETED signal — a commit was made
-    if commits:
-        return DISPOSITION_COMPLETED
-
-    if not exchanges:
-        return DISPOSITION_ABANDONED
-
-    last = exchanges[-1]
-    last_user = last.get("user", "").strip()
-    last_asst = last.get("assistant", "").strip()
-
-    # If user's last message is a new instruction, work is in progress
-    if _NEW_INSTRUCTION_RE.search(last_user):
-        return DISPOSITION_IN_PROGRESS
-
-    # If assistant used completion language and user confirmed briefly
-    if _COMPLETION_RE.search(last_asst) and _SHORT_CONFIRM_RE.match(last_user):
-        return DISPOSITION_COMPLETED
-
-    # If assistant used completion language (even without user confirm — session may have ended)
-    if _COMPLETION_RE.search(last_asst) and len(last_user) < _SHORT_USER_REPLY_MAX_CHARS:
-        return DISPOSITION_COMPLETED
-
-    # If user confirmed briefly (likely accepting the work)
-    if _SHORT_CONFIRM_RE.match(last_user):
-        return DISPOSITION_COMPLETED
-
-    # ABANDONED: assistant responded but no subsequent user message, and the session
-    # has more than _ABANDONED_MIN_EXCHANGES (short sessions without a reply are normal)
-    if last_asst and not last_user and len(exchanges) > _ABANDONED_MIN_EXCHANGES:
-        return DISPOSITION_ABANDONED
-
-    return DISPOSITION_IN_PROGRESS
 
 
 def build_exchange_pairs(messages: list[dict]) -> list[dict]:
@@ -201,8 +132,6 @@ def build_context_summary_json(branch_row: dict, messages: list[dict]) -> dict:
     commits = decode_json_field(branch_row.get("commits"), [])
     tool_counts = decode_json_field(branch_row.get("tool_counts"), {})
 
-    disposition = detect_disposition(exchanges, commits=commits)
-
     # First exchanges — truncate exchange text to bound JSON size
     first_exchanges = [
         {
@@ -237,7 +166,6 @@ def build_context_summary_json(branch_row: dict, messages: list[dict]) -> dict:
     return {
         "version": SUMMARY_VERSION,
         "topic": topic,
-        "disposition": disposition,
         "first_exchanges": first_exchanges,
         "last_exchanges": last_exchanges,
         "metadata": {
@@ -296,16 +224,9 @@ def render_context_summary(summary_json: dict) -> str:
         header += f" (branch: {branch})"
     lines.append(header + "\n")
 
-    # Topic and disposition
     topic = summary_json.get("topic", "")
-    disposition = summary_json.get("disposition", "")
-    if topic or disposition:
-        parts = []
-        if topic:
-            parts.append(f"**Topic:** {topic}")
-        if disposition:
-            parts.append(f"**Status:** {disposition}")
-        lines.append(" | ".join(parts))
+    if topic:
+        lines.append(f"**Topic:** {topic}")
         lines.append("")
 
     # Metadata: files, commits, tools

--- a/tests/test_context_injection.py
+++ b/tests/test_context_injection.py
@@ -25,7 +25,6 @@ from ccrecall.hooks.memory_context import (
 )
 from ccrecall.summarizer import (
     build_exchange_pairs,
-    detect_disposition,
     render_context_summary,
 )
 
@@ -705,11 +704,9 @@ class TestBuildFallbackContext:
         # Build the same thing via render_context_summary directly
         exchanges = build_exchange_pairs(messages)
         topic = exchanges[0]["user"][:TOPIC_PREVIEW_MAX_CHARS] if exchanges else ""
-        disposition = detect_disposition(exchanges, commits=commits)
         summary_json = {
-            "version": 3,
+            "version": 4,
             "topic": topic,
-            "disposition": disposition,
             "first_exchanges": [
                 {
                     "user": ex["user"],

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -295,7 +295,7 @@ class TestFormatMarkdownSession:
 # Fixtures
 
 
-def _make_card(score_raw=0.03, score=0.87, topic="some topic", disposition="IN_PROGRESS"):
+def _make_card(score_raw=0.03, score=0.87, topic="some topic"):
     """Return a minimal valid Track A card dict."""
     return {
         "score": score,
@@ -307,7 +307,6 @@ def _make_card(score_raw=0.03, score=0.87, topic="some topic", disposition="IN_P
         "started_at": "2026-06-25T07:30:00Z",
         "ended_at": "2026-06-25T13:09:42Z",
         "topic": topic,
-        "disposition": disposition,
         "exchange_count": 41,
         "files_modified": ["src/ccrecall/search_conversations.py", "src/ccrecall/formatting.py"],
         "commits": ["chore(main): release 0.11.1"],
@@ -354,10 +353,9 @@ class TestFormatCardMarkdown:
         md = format_card_markdown(card)
         assert "Topic:  redesign search result format" in md
 
-    def test_status_line_with_disposition(self):
-        card = _make_card(disposition="IN_PROGRESS")
+    def test_counts_line(self):
+        card = _make_card()
         md = format_card_markdown(card)
-        assert "Status: IN_PROGRESS" in md
         assert "41 exchanges" in md
         assert "2 files" in md
         assert "1 commits" in md
@@ -438,14 +436,6 @@ class TestFormatCardMarkdown:
         assert "Topic:" in md
         assert "None" not in md
 
-    def test_uncached_branch_no_disposition(self):
-        """Card with disposition=None renders without disposition in Status, no crash."""
-        card = _make_card(disposition=None)
-        md = format_card_markdown(card)
-        assert "Status:" in md
-        assert "None" not in md
-        assert "IN_PROGRESS" not in md
-
     def test_does_not_mutate_input(self):
         """Renderer does not modify the input dict."""
         card = _make_card()
@@ -471,7 +461,6 @@ class TestFormatCardJson:
             "started_at",
             "ended_at",
             "topic",
-            "disposition",
             "exchange_count",
             "files_modified",
             "commits",

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1003,10 +1003,10 @@ class TestExceptionNarrowing:
 
 
 class TestCardFields:
-    """_hydrate_cards must produce the output contract fields (session_uuid, handle, topic, disposition)."""
+    """_hydrate_cards must produce the output contract fields (session_uuid, handle, topic)."""
 
     def _seed_with_summary(self, conn):
-        """Seed a branch with context_summary_json carrying topic + disposition."""
+        """Seed a branch with context_summary_json carrying topic."""
         cursor = conn.cursor()
         cursor.execute(
             "INSERT INTO projects (path, key, name) VALUES (?, ?, ?)",
@@ -1022,7 +1022,6 @@ class TestCardFields:
             {
                 "version": 1,
                 "topic": "Debugging a pytest fixture",
-                "disposition": "shipped",
                 "first_exchanges": [],
                 "last_exchanges": [],
                 "metadata": {"exchange_count": 4, "files_modified": ["a.py"], "commits": ["abc123"], "tool_counts": {}},
@@ -1057,7 +1056,7 @@ class TestCardFields:
         return branch_id
 
     def test_card_fields_from_context_summary_json(self):
-        """Cards include session_uuid, handle, topic, disposition from context_summary_json."""
+        """Cards include session_uuid, handle, topic from context_summary_json."""
         conn = sqlite3.connect(":memory:")
         conn.executescript(SCHEMA)
         conn.commit()
@@ -1070,7 +1069,6 @@ class TestCardFields:
         assert card["session_uuid"] == "cf-sess-uuid"
         assert card["handle"] == "cf-sess-"  # first 8 chars of "cf-sess-uuid"
         assert card["topic"] == "Debugging a pytest fixture"
-        assert card["disposition"] == "shipped"
         assert card["exchange_count"] == 4
         assert card["git_branch"] == "main"
         assert card["project"] == "cf"
@@ -1103,8 +1101,6 @@ class TestCardFields:
         # Graceful degrade: topic from first user message
         assert card["topic"] is not None
         assert "deadline" in card["topic"].lower()
-        # No context_summary_json → disposition is None
-        assert card["disposition"] is None
         conn.close()
 
     def test_keyword_only_flag_ranked_by_rung(self, search_db):
@@ -1203,7 +1199,6 @@ class TestVerboseCardMarkdown:
             "git_branch": "main",
             "ended_at": "2025-06-01T10:00:00Z",
             "topic": "Wiring verbose",
-            "disposition": "shipped",
             "exchange_count": 4,
             "files_modified": ["a.py", "b.py"],
             "commits": ["abc123"],

--- a/tests/test_session_ops.py
+++ b/tests/test_session_ops.py
@@ -75,7 +75,7 @@ class TestSyncSessionCreatesBranches:
         row = cursor.fetchone()
         assert row is not None
         assert row[0], "Context summary should be populated"
-        assert row[1] == 3, "summary_version should be 3"
+        assert row[1] == 4, "summary_version should be 4"
 
     def test_no_has_tool_use_in_insert(self, memory_db):
         """has_tool_use and tool_summary columns should NOT be in the INSERT column list in session_ops.

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -11,13 +11,10 @@ from ccrecall.db import CONTENT_ERROR_VERSION
 from ccrecall.hooks import backfill_summaries, memory_setup
 from ccrecall.schema import SCHEMA
 from ccrecall.summarizer import (
-    DISPOSITION_ABANDONED,
-    DISPOSITION_COMPLETED,
-    DISPOSITION_IN_PROGRESS,
+    SUMMARY_VERSION,
     build_context_summary_json,
     build_exchange_pairs,
     compute_context_summary,
-    detect_disposition,
     render_context_summary,
     truncate_mid,
 )
@@ -163,7 +160,7 @@ class TestBuildContextSummaryJson:
         ]
         result = build_context_summary_json(branch_row, messages)
 
-        assert result["version"] == 3
+        assert result["version"] == 4
         assert result["topic"] == "Fix the bug in main.py"
         assert len(result["first_exchanges"]) == 2
         assert result["first_exchanges"][0]["user"] == "Fix the bug in main.py"
@@ -436,7 +433,7 @@ class TestComputeContextSummary:
         assert "/ccrecall:ccr-recall" in md
 
         parsed = json.loads(json_str)
-        assert parsed["version"] == 3
+        assert parsed["version"] == 4
         assert parsed["topic"] == "How do I fix the parser bug?"
         assert parsed["metadata"]["git_branch"] == "main"
         assert len(parsed["last_exchanges"]) == 3  # Short session (3 exchanges, <=8), all in last
@@ -448,81 +445,6 @@ class TestComputeContextSummary:
         md, json_str = compute_context_summary(cursor, 99999)
         assert md == ""
         assert json_str == ""
-
-
-class TestDetectDispositionWithCommits:
-    """Tests for the improved detect_disposition() with commits parameter."""
-
-    def _make_exchanges(self, count: int, last_user: str = "ok") -> list[dict]:
-        exchanges = [{"user": f"Q{i}", "assistant": f"A{i}", "timestamp": f"t{i}"} for i in range(count - 1)]
-        exchanges.append({"user": last_user, "assistant": "Done.", "timestamp": "t_last"})
-        return exchanges
-
-    def test_detect_disposition_completed_with_commits(self):
-        """Non-empty commits list returns COMPLETED regardless of exchange content."""
-        exchanges = [{"user": "start", "assistant": "working...", "timestamp": "t0"}]
-        result = detect_disposition(exchanges, commits=["fix: resolve issue #42"])
-        assert result == DISPOSITION_COMPLETED
-
-    def test_detect_disposition_completed_with_multiple_commits(self):
-        """Multiple commits still return COMPLETED."""
-        exchanges = [{"user": "what now?", "assistant": "no idea", "timestamp": "t0"}]
-        result = detect_disposition(exchanges, commits=["feat: add thing", "fix: bug"])
-        assert result == DISPOSITION_COMPLETED
-
-    def test_detect_disposition_completed_with_text_only(self):
-        """Existing text heuristics still work when commits is None (or empty)."""
-        exchanges = [
-            {
-                "user": "Run the tests",
-                "assistant": "All tests pass.",
-                "timestamp": "t0",
-            },
-            {"user": "ok", "assistant": "", "timestamp": "t1"},
-        ]
-        result = detect_disposition(exchanges, commits=None)
-        assert result == DISPOSITION_COMPLETED
-
-    def test_detect_disposition_completed_with_empty_commits(self):
-        """Empty commits list does not trigger COMPLETED — falls through to text heuristics."""
-        exchanges = [
-            {
-                "user": "What should I do?",
-                "assistant": "Keep going.",
-                "timestamp": "t0",
-            },
-        ]
-        result = detect_disposition(exchanges, commits=[])
-        assert result == DISPOSITION_IN_PROGRESS
-
-    def test_detect_disposition_abandoned_replaces_interrupted(self):
-        """Zero-exchange sessions return ABANDONED (not INTERRUPTED)."""
-        result = detect_disposition([])
-        assert result == DISPOSITION_ABANDONED
-        # Confirm INTERRUPTED is not returned
-        assert result != "INTERRUPTED"
-
-    def test_detect_disposition_abandoned_no_user_followup(self):
-        """Final exchange with no user reply AND >2 exchanges returns ABANDONED."""
-        # Build exchanges where the last user message is empty (assistant replied, no followup)
-        exchanges = [
-            {"user": "Q1", "assistant": "A1", "timestamp": "t0"},
-            {"user": "Q2", "assistant": "A2", "timestamp": "t1"},
-            {"user": "Q3", "assistant": "Final answer here.", "timestamp": "t2"},
-        ]
-        # Simulate: last exchange has assistant content but no user reply after
-        # We can test this by checking disposition of a last exchange where user="" and assistant is non-empty
-        exchanges_with_no_reply = [*exchanges[:2], {"user": "", "assistant": "No followup.", "timestamp": "t3"}]
-        result = detect_disposition(exchanges_with_no_reply)
-        assert result == DISPOSITION_ABANDONED
-
-    def test_detect_disposition_not_abandoned_for_short_sessions(self):
-        """Sessions with <=2 exchanges are not classified as ABANDONED when no user followup."""
-        # Only 1 exchange — too short for ABANDONED heuristic
-        exchanges = [{"user": "", "assistant": "Some response.", "timestamp": "t0"}]
-        result = detect_disposition(exchanges)
-        # Should not be ABANDONED (<=2 exchanges condition not met)
-        assert result != DISPOSITION_ABANDONED
 
 
 class TestBuildContextSummaryJsonTruncation:
@@ -564,19 +486,19 @@ class TestBuildContextSummaryJsonTruncation:
         # With 1 short exchange of truncated text, should be well under 50KB
         assert json_size < 50_000, f"JSON size {json_size} exceeds 50KB limit"
 
-    def test_version_is_3(self):
-        """build_context_summary_json returns version 3."""
+    def test_version_is_current(self):
+        """build_context_summary_json returns the current SUMMARY_VERSION."""
         branch_row = {}
         messages = [
             {"role": "user", "content": "Hello", "timestamp": "t1"},
             {"role": "assistant", "content": "Hi", "timestamp": "t2"},
         ]
         result = build_context_summary_json(branch_row, messages)
-        assert result["version"] == 3
+        assert result["version"] == 4
 
 
 class TestNeedsBackfillVersionBump:
-    """Test that the backfill threshold is 3 (not 2) in both backfill_summaries and memory_setup."""
+    """Test that the backfill threshold matches SUMMARY_VERSION in both backfill_summaries and memory_setup."""
 
     def _make_db_with_branch(self, summary_version: int) -> sqlite3.Connection:
         """Create an in-memory DB with one branch at the given summary_version."""
@@ -602,29 +524,34 @@ class TestNeedsBackfillVersionBump:
         conn.commit()
         return conn
 
-    def test_needs_backfill_version_bump_query(self):
-        """Branches with summary_version=2 should be picked up by the < 3 backfill query."""
-        conn = self._make_db_with_branch(summary_version=2)
+    def test_needs_backfill_stale_version_triggered(self):
+        """Branches with summary_version below SUMMARY_VERSION are picked up by the backfill query."""
+        conn = self._make_db_with_branch(summary_version=SUMMARY_VERSION - 1)
         cursor = conn.cursor()
-        # This is the query used by both backfill_summaries.py and memory_setup.py
-        cursor.execute("SELECT COUNT(*) FROM branches WHERE summary_version IS NULL OR summary_version < 3")
+        cursor.execute(
+            "SELECT COUNT(*) FROM branches WHERE summary_version IS NULL OR summary_version < ?",
+            (SUMMARY_VERSION,),
+        )
         count = cursor.fetchone()[0]
-        assert count == 1, "summary_version=2 branches must be detected by the < 3 backfill query"
+        assert count == 1, "stale branches must be detected by the backfill query"
         conn.close()
 
-    def test_needs_backfill_version_3_not_triggered(self):
-        """Branches with summary_version=3 should NOT be picked up by the < 3 backfill query."""
-        conn = self._make_db_with_branch(summary_version=3)
+    def test_needs_backfill_current_version_not_triggered(self):
+        """Branches at SUMMARY_VERSION are NOT picked up by the backfill query."""
+        conn = self._make_db_with_branch(summary_version=SUMMARY_VERSION)
         cursor = conn.cursor()
-        cursor.execute("SELECT COUNT(*) FROM branches WHERE summary_version IS NULL OR summary_version < 3")
+        cursor.execute(
+            "SELECT COUNT(*) FROM branches WHERE summary_version IS NULL OR summary_version < ?",
+            (SUMMARY_VERSION,),
+        )
         count = cursor.fetchone()[0]
-        assert count == 0, "summary_version=3 branches must NOT be detected by the < 3 backfill query"
+        assert count == 0, "current-version branches must NOT be detected by the backfill query"
         conn.close()
 
     def test_backfill_summaries_uses_version_constants(self):
         """backfill_summaries ties its threshold/sentinel to the shared constants.
 
-        SUMMARY_VERSION is the canonical 3 and CONTENT_ERROR_VERSION the -1
+        SUMMARY_VERSION is the canonical 4 and CONTENT_ERROR_VERSION the -1
         sentinel — using the constants (not stale literals) keeps a future
         version bump from silently desyncing this hook.
         """

--- a/tests/test_sync_hook.py
+++ b/tests/test_sync_hook.py
@@ -117,7 +117,7 @@ class TestSyncSessionCreatesBranches:
             assert row is not None
             summary, version = row
             assert summary, "Active branch should have context_summary"
-            assert version == 3, "summary_version should be 3 after sync"
+            assert version == 4, "summary_version should be 4 after sync"
             assert "### Session:" in summary
             assert "/ccrecall:ccr-recall" in summary
 


### PR DESCRIPTION
### Disposition removal

- `detect_disposition()` and its constants (`DISPOSITION_COMPLETED`, `IN_PROGRESS`, `ABANDONED`) are removed from `summarizer.py`. 57% of branches were falsely labeled IN_PROGRESS because the function defaulted to that label for any session not matching narrow completion heuristics — the signal-to-noise ratio was too low to keep.
- Since disposition was never used for filtering, sorting, or any non-display logic, removal is cleaner than fixing the heuristics. There is no behavioral regression for callers.
- `disposition` is dropped from `build_context_summary_json()` output and from `format_card_json()`, removing it from the JSON contract.
- Card markdown simplified: "Status: IN_PROGRESS · 41 exchanges · 2 files" becomes "41 exchanges · 2 files" — the status prefix was adding noise without signal.
- `search_conversations.py` no longer reads or propagates `disposition` from stored summaries.

### SUMMARY_VERSION bump (3 → 4)

- Version bumped so existing summaries carrying the now-stale `disposition` field are detected and regenerated by the backfill path. No in-place migration — backfill rewrites them cleanly.
- Backfill threshold tests updated to reference the `SUMMARY_VERSION` constant rather than a hardcoded literal, so a future bump doesn't silently desync the tests.

### Housekeeping

- Skill docs (`SKILL.md`, `tool-reference.md`) updated to remove all `disposition` references from card format examples and field descriptions.
- 81 lines of disposition-specific tests deleted — `TestDetectDispositionWithCommits` and related assertions are gone along with the function they covered.
