### PR TITLE
fix: clear-handoff hook missing stdout and improve logging defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ Onboarding sets `auto_inject_context`. The remaining settings are tunable by edi
 | `auto_inject_context` | bool | `true` | Inject a summary of your previous session at session start. |
 | `max_context_sessions` | int | `2` | How many recent sessions to include in that injected context. |
 | `exclude_projects` | list[str] | `[]` | Project names to skip when **storing** conversations — excluded projects are not imported or synced. Matched against the project's directory name. This is write-side only: it prevents new data from being indexed; it does not remove or hide conversations already stored before the project was excluded. |
-| `logging_enabled` | bool | `false` | Write hook diagnostics (including swallowed hook exceptions) to `~/.ccrecall/ccrecall.log`. Useful for troubleshooting a misbehaving hook. |
+| `logging_enabled` | bool | `true` | Write hook diagnostics (including swallowed hook exceptions) to `~/.ccrecall/ccrecall.log`. Set to `false` to suppress the log. |
+| `log_level` | str | `"INFO"` | Logging verbosity when `logging_enabled` is true. Accepts standard Python level names: `DEBUG`, `INFO`, `WARNING`, `ERROR`. |
 
 ## Database
 

--- a/src/ccrecall/db.py
+++ b/src/ccrecall/db.py
@@ -401,7 +401,7 @@ def setup_logging(settings: dict | None = None) -> logging.Logger:
     logger = logging.getLogger(LOGGER_NAME)
     logger.handlers.clear()
 
-    if not settings or not settings.get("logging_enabled", False):
+    if not settings or not settings.get("logging_enabled", True):
         logger.addHandler(logging.NullHandler())
         return logger
 

--- a/src/ccrecall/db.py
+++ b/src/ccrecall/db.py
@@ -56,7 +56,8 @@ DEFAULT_SETTINGS = {
     "auto_inject_context": True,
     "max_context_sessions": 2,
     "exclude_projects": [],
-    "logging_enabled": False,
+    "logging_enabled": True,
+    "log_level": "INFO",
     "alert_snooze_hours": 24,
 }
 
@@ -415,7 +416,8 @@ def setup_logging(settings: dict | None = None) -> logging.Logger:
     formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
     handler.setFormatter(formatter)
     logger.addHandler(handler)
-    logger.setLevel(logging.INFO)
+    level_name = settings.get("log_level", "INFO")
+    logger.setLevel(getattr(logging, level_name.upper(), logging.INFO))
 
     return logger
 

--- a/src/ccrecall/hooks/clear_handoff.py
+++ b/src/ccrecall/hooks/clear_handoff.py
@@ -1,35 +1,34 @@
 """SessionEnd hook (matcher: clear) — writes handoff file for SessionStart to link sessions."""
 
-import contextlib
 import json
 import sys
 
 from pydantic import ValidationError
 from whenever import Instant
 
-from ccrecall.db import CLEAR_HANDOFF_FILENAME, get_db_path, load_settings
+from ccrecall.db import CLEAR_HANDOFF_FILENAME, get_db_path, load_settings, log_hook_exception
 from ccrecall.models import HookInput
 
 
 def main():
-    raw = sys.stdin.read()
     try:
-        # model_validate_json parses then validates, so this also covers invalid
-        # or empty JSON (empty stdin -> "" -> ValidationError -> return).
-        hook_input = HookInput.model_validate_json(raw)
-    except ValidationError:
-        return
+        raw = sys.stdin.read()
+        try:
+            hook_input = HookInput.model_validate_json(raw)
+        except ValidationError:
+            print(json.dumps({}))
+            return
 
-    if hook_input.end_reason != "clear":
-        return
+        if hook_input.end_reason != "clear":
+            print(json.dumps({}))
+            return
 
-    session_id = hook_input.session_id
-    cwd = hook_input.cwd
-    if not session_id or not cwd:
-        return
+        session_id = hook_input.session_id
+        cwd = hook_input.cwd
+        if not session_id or not cwd:
+            print(json.dumps({}))
+            return
 
-    # Best-effort: a failed handoff write must not surface an error on session clear.
-    with contextlib.suppress(Exception):
         settings = load_settings()
         db_path = get_db_path(settings)
         handoff_path = db_path.parent / CLEAR_HANDOFF_FILENAME
@@ -43,6 +42,10 @@ def main():
             ),
             encoding="utf-8",
         )
+    except Exception:
+        log_hook_exception("clear-handoff")
+
+    print(json.dumps({}))
 
 
 if __name__ == "__main__":

--- a/src/ccrecall/hooks/clear_handoff.py
+++ b/src/ccrecall/hooks/clear_handoff.py
@@ -16,17 +16,14 @@ def main():
         try:
             hook_input = HookInput.model_validate_json(raw)
         except ValidationError:
-            print(json.dumps({}))
             return
 
         if hook_input.end_reason != "clear":
-            print(json.dumps({}))
             return
 
         session_id = hook_input.session_id
         cwd = hook_input.cwd
         if not session_id or not cwd:
-            print(json.dumps({}))
             return
 
         settings = load_settings()
@@ -44,8 +41,8 @@ def main():
         )
     except Exception:
         log_hook_exception("clear-handoff")
-
-    print(json.dumps({}))
+    finally:
+        print(json.dumps({}))
 
 
 if __name__ == "__main__":

--- a/src/ccrecall/hooks/memory_context.py
+++ b/src/ccrecall/hooks/memory_context.py
@@ -583,7 +583,7 @@ def main():
             conn = get_db_connection(settings)
         except Exception:
             # conn stays None; DB probe will report this as a persist fault.
-            logger.debug("DB connection failed — DB probe will report fault")
+            logger.warning("DB connection failed — DB probe will report fault")
 
     # ── Proactive alert evaluation ──────────────────────────────────────────────
     # Must run before ALL early-return gates so alerts fire even when sessions is

--- a/src/ccrecall/models.py
+++ b/src/ccrecall/models.py
@@ -33,7 +33,7 @@ def is_valid(model: type[BaseModel], data: object, label: str) -> bool:
     try:
         model.model_validate(data)
     except ValidationError as e:
-        _LOG.warning("Skipping malformed %s: %s", label, e)
+        _LOG.info("Skipping malformed %s: %s", label, e)
         return False
     return True
 

--- a/src/ccrecall/models.py
+++ b/src/ccrecall/models.py
@@ -33,7 +33,7 @@ def is_valid(model: type[BaseModel], data: object, label: str) -> bool:
     try:
         model.model_validate(data)
     except ValidationError as e:
-        _LOG.debug("Skipping malformed %s: %s", label, e)
+        _LOG.warning("Skipping malformed %s: %s", label, e)
         return False
     return True
 

--- a/src/ccrecall/search_conversations.py
+++ b/src/ccrecall/search_conversations.py
@@ -558,7 +558,7 @@ def search_sessions(
                 pre_rollup = len(chunk_results)
                 post_rollup = len(ordered_ids)
                 ratio = pre_rollup / max(post_rollup, 1)
-                _logger.debug(
+                _logger.info(
                     "search under-fill: %d chunks → %d sessions (collapse ratio %.1f); "
                     "consider increasing CHUNK_COLLAPSE_FACTOR",
                     pre_rollup,

--- a/tests/test_clear_handoff_contract.py
+++ b/tests/test_clear_handoff_contract.py
@@ -31,26 +31,28 @@ _find_cleared_from_session_uuid = _memory_context._find_cleared_from_session_uui
 # Helpers
 
 
-def _run_handoff_main(tmp_path: Path, payload: dict) -> Path:
+def _run_handoff_main(tmp_path: Path, payload: dict | str) -> tuple[Path, str]:
     """
     Run clear-handoff.main() with a fake db_path under tmp_path and the given
-    payload piped through stdin. Returns the handoff_path.
+    payload piped through stdin. Returns (handoff_path, captured_stdout).
     """
     fake_db = tmp_path / "conversations.db"
     handoff_path = tmp_path / "clear-handoff.json"
 
     fake_settings = {"db_path": str(fake_db)}
 
-    stdin_data = json.dumps(payload)
+    stdin_data = payload if isinstance(payload, str) else json.dumps(payload)
+    stdout_capture = io.StringIO()
 
     with (
         patch.object(sys, "stdin", io.StringIO(stdin_data)),
+        patch.object(sys, "stdout", stdout_capture),
         patch.object(_clear_handoff, "load_settings", return_value=fake_settings),
         patch.object(_clear_handoff, "get_db_path", return_value=fake_db),
     ):
         _clear_handoff.main()
 
-    return handoff_path
+    return handoff_path, stdout_capture.getvalue()
 
 
 # clear-handoff.py contract tests
@@ -59,7 +61,7 @@ def _run_handoff_main(tmp_path: Path, payload: dict) -> Path:
 class TestClearHandoffWriter:
     def test_writes_file_on_clear(self, tmp_path):
         """Contract 1+2+3: writes file with correct keys when end_reason=clear."""
-        hp = _run_handoff_main(
+        hp, _ = _run_handoff_main(
             tmp_path,
             {
                 "end_reason": "clear",
@@ -76,18 +78,18 @@ class TestClearHandoffWriter:
 
     def test_does_not_write_missing_session_id(self, tmp_path):
         """Contract 2: skips write when session_id is absent."""
-        hp = _run_handoff_main(tmp_path, {"end_reason": "clear", "cwd": "/some/project"})
+        hp, _ = _run_handoff_main(tmp_path, {"end_reason": "clear", "cwd": "/some/project"})
         assert not hp.exists()
 
     def test_does_not_write_missing_cwd(self, tmp_path):
         """Contract 2: skips write when cwd is absent."""
-        hp = _run_handoff_main(tmp_path, {"end_reason": "clear", "session_id": "abc-123"})
+        hp, _ = _run_handoff_main(tmp_path, {"end_reason": "clear", "session_id": "abc-123"})
         assert not hp.exists()
 
     @pytest.mark.parametrize("end_reason", ["interrupt", "crash", "CLEAR", None])
     def test_does_not_write_for_other_reasons(self, tmp_path, end_reason):
         """Contract 1: only end_reason='clear' (exact, case-sensitive) triggers write."""
-        hp = _run_handoff_main(
+        hp, _ = _run_handoff_main(
             tmp_path,
             {
                 "end_reason": end_reason,
@@ -99,14 +101,38 @@ class TestClearHandoffWriter:
 
     def test_does_not_write_on_invalid_json(self, tmp_path):
         """Gracefully ignores malformed stdin."""
-        fake_db = tmp_path / "conversations.db"
-        with (
-            patch.object(sys, "stdin", io.StringIO("not-json")),
-            patch.object(_clear_handoff, "load_settings", return_value={"db_path": str(fake_db)}),
-            patch.object(_clear_handoff, "get_db_path", return_value=fake_db),
-        ):
-            _clear_handoff.main()
-        assert not (tmp_path / "clear-handoff.json").exists()
+        hp, _ = _run_handoff_main(tmp_path, "not-json")
+        assert not hp.exists()
+
+
+class TestClearHandoffStdout:
+    """Hook must always print valid JSON to stdout for the harness."""
+
+    def test_stdout_on_successful_write(self, tmp_path):
+        _, stdout = _run_handoff_main(
+            tmp_path,
+            {"end_reason": "clear", "session_id": "abc-123", "cwd": "/some/project"},
+        )
+        assert json.loads(stdout) == {}
+
+    def test_stdout_on_non_clear_reason(self, tmp_path):
+        _, stdout = _run_handoff_main(
+            tmp_path,
+            {"end_reason": "interrupt", "session_id": "abc-123", "cwd": "/some/project"},
+        )
+        assert json.loads(stdout) == {}
+
+    def test_stdout_on_invalid_json(self, tmp_path):
+        _, stdout = _run_handoff_main(tmp_path, "not-json")
+        assert json.loads(stdout) == {}
+
+    def test_stdout_on_empty_stdin(self, tmp_path):
+        _, stdout = _run_handoff_main(tmp_path, "")
+        assert json.loads(stdout) == {}
+
+    def test_stdout_on_missing_fields(self, tmp_path):
+        _, stdout = _run_handoff_main(tmp_path, {"end_reason": "clear"})
+        assert json.loads(stdout) == {}
 
 
 # _find_cleared_from_session_uuid contract tests

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -86,7 +86,8 @@ class TestLoadSettings:
     def test_default_values(self):
         assert DEFAULT_SETTINGS["auto_inject_context"] is True
         assert DEFAULT_SETTINGS["max_context_sessions"] == 2
-        assert DEFAULT_SETTINGS["logging_enabled"] is False
+        assert DEFAULT_SETTINGS["logging_enabled"] is True
+        assert DEFAULT_SETTINGS["log_level"] == "INFO"
         assert isinstance(DEFAULT_SETTINGS["exclude_projects"], list)
         assert DEFAULT_SETTINGS["alert_snooze_hours"] == 24
 
@@ -215,7 +216,7 @@ class TestLoadSettingsWithConfig:
         result = load_settings()
         assert result["auto_inject_context"] is False
         assert result["max_context_sessions"] == 5
-        assert result["logging_enabled"] is False  # unchanged default
+        assert result["logging_enabled"] is True  # unchanged default
 
     def test_alert_snooze_hours_override_and_default(self, tmp_path, monkeypatch):
         """The snooze window changes when alert_snooze_hours is set in config;
@@ -234,11 +235,11 @@ class TestLoadSettingsWithConfig:
     def test_logging_enabled_and_exclude_projects_honored(self, tmp_path, monkeypatch):
         """logging_enabled and exclude_projects are user-overridable from config.json."""
         cfg = tmp_path / "config.json"
-        cfg.write_text(json.dumps({"logging_enabled": True, "exclude_projects": ["work-secret"]}))
+        cfg.write_text(json.dumps({"logging_enabled": False, "exclude_projects": ["work-secret"]}))
         monkeypatch.setattr("ccrecall.db.CONFIG_PATH", cfg)
 
         result = load_settings()
-        assert result["logging_enabled"] is True
+        assert result["logging_enabled"] is False
         assert result["exclude_projects"] == ["work-secret"]
 
     def test_missing_config_returns_defaults(self, tmp_path, monkeypatch):


### PR DESCRIPTION
### Bug fix: clear-handoff hook missing stdout

The `clear-handoff` SessionEnd hook was silently swallowing all output paths
without writing the `{}` JSON the Claude Code harness requires on stdout. Any
code path that exited early (invalid JSON, wrong `end_reason`, missing fields)
returned with no output at all, which the harness treats as a broken hook.

- Restructured the hook to always `print(json.dumps({}))` as the final
  statement, regardless of which path was taken — mirroring the pattern used by
  the other hooks.
- Replaced the `contextlib.suppress` blanket on the happy path with an explicit
  `try/except` that calls `log_hook_exception` on unexpected errors, then still
  emits the required stdout JSON. Errors are now visible in the log rather than
  silently discarded.
- Added `TestClearHandoffStdout` — five new contract tests that assert the hook
  emits `{}` on stdout for every exit path (success, non-clear reason, invalid
  JSON, empty stdin, missing fields), using stdout capture so the requirement is
  machine-verified.

### Logging defaults

- Changed `logging_enabled` default from `False` to `True` with an `"INFO"`
  level, so hook activity is observable out of the box without requiring users
  to opt in via `config.json`. The setting remains user-overridable.
- Added `log_level` to `DEFAULT_SETTINGS` and wired it into `setup_logging` so
  the level is driven by config rather than hardcoded to `INFO`.
- Promoted the DB-connection failure log in `memory_context.py` from `debug` to
  `warning` — a connection failure is an actionable signal, not routine noise.
- Promoted `is_valid` malformed-input log in `models.py` from `debug` to
  `warning` for the same reason.
- Promoted the search under-fill diagnostic in `search_conversations.py` from
  `debug` to `info` so it surfaces when logging is enabled at the default level.
