### PR TITLE
feat: include session ID in supplementary context blocks

### DIFF
--- a/src/ccrecall/hooks/context_rendering.py
+++ b/src/ccrecall/hooks/context_rendering.py
@@ -130,18 +130,21 @@ def build_origin_block(source: str, sessions: list[dict]) -> str:
 def build_context(sessions: list[dict]) -> str:
     """Build markdown context from selected sessions.
 
-    Uses cached context_summary when available, falls back to
-    truncated last-3 exchanges for uncached branches.
+    Prepends a Session ID blockquote to supplementary session blocks (index
+    > 0) so they are traceable — the primary session's UUID is already in
+    the Session Origin block.  Uses cached context_summary when available,
+    falls back to truncated last-3 exchanges for uncached branches.
     """
     if not sessions:
         return ""
 
     parts = []
-    for session in sessions:
+    for i, session in enumerate(sessions):
         cached = session.get("context_summary")
-        if cached:
-            parts.append(cached)
-        else:
-            parts.append(_build_fallback_context(session))
+        body = cached if cached else _build_fallback_context(session)
+        uuid = session.get("uuid", "")
+        if uuid and i > 0:
+            body = f"> Session ID: {uuid}\n\n{body}"
+        parts.append(body)
 
     return "\n\n---\n\n".join(parts)

--- a/src/ccrecall/hooks/context_rendering.py
+++ b/src/ccrecall/hooks/context_rendering.py
@@ -132,7 +132,7 @@ def build_context(sessions: list[dict]) -> str:
 
     Prepends a Session ID blockquote to supplementary session blocks (index
     > 0) so they are traceable — the primary session's UUID is already in
-    the Session Origin block.  Uses cached context_summary when available,
+    the Session Origin block. Uses cached context_summary when available,
     falls back to truncated last-3 exchanges for uncached branches.
     """
     if not sessions:

--- a/tests/test_context_injection.py
+++ b/tests/test_context_injection.py
@@ -360,6 +360,7 @@ class TestBuildContext:
         """When context_summary is present, it should be used as-is."""
         sessions = [
             {
+                "uuid": "abc-123",
                 "context_summary": "### Session: 2025-01-15 14:30 -> 15:00\nCached content here.",
                 "started_at": "2025-01-15T14:30:00Z",
                 "ended_at": "2025-01-15T15:00:00Z",
@@ -367,11 +368,13 @@ class TestBuildContext:
         ]
         result = build_context(sessions)
         assert "Cached content here." in result
+        assert "Session ID:" not in result
 
     def test_fallback_renders_exchange(self):
         """Without context_summary, fallback should render exchanges."""
         sessions = [
             {
+                "uuid": "fallback-uuid-456",
                 "started_at": "2025-01-15T14:30:00Z",
                 "ended_at": "2025-01-15T15:00:00Z",
                 "files_modified": [],
@@ -391,6 +394,7 @@ class TestBuildContext:
             }
         ]
         result = build_context(sessions)
+        assert "Session ID:" not in result
         assert "### Session:" in result
         assert "How do I use pytest?" in result
         assert "Run pytest from the project root." in result
@@ -401,6 +405,7 @@ class TestBuildContext:
     def test_multi_session_separator(self):
         sessions = [
             {
+                "uuid": "primary-uuid",
                 "started_at": "2025-01-15T14:00:00Z",
                 "ended_at": "2025-01-15T14:30:00Z",
                 "files_modified": [],
@@ -419,6 +424,7 @@ class TestBuildContext:
                 ],
             },
             {
+                "uuid": "supplementary-uuid",
                 "context_summary": "### Session: Second\nCached.",
             },
         ]
@@ -426,6 +432,8 @@ class TestBuildContext:
         assert "---" in result
         assert "First session" in result
         assert "Cached." in result
+        assert "> Session ID: supplementary-uuid" in result
+        assert "> Session ID: primary-uuid" not in result
 
     def test_mixed_cached_and_fallback(self):
         """Sessions can mix cached and uncached."""
@@ -453,6 +461,17 @@ class TestBuildContext:
         result = build_context(sessions)
         assert "Cached session 1." in result
         assert "Uncached session" in result
+
+    def test_no_uuid_omits_session_id_line(self):
+        """Sessions without a uuid should not get a Session ID line."""
+        sessions = [
+            {
+                "context_summary": "Cached without uuid.",
+            }
+        ]
+        result = build_context(sessions)
+        assert "Session ID:" not in result
+        assert "Cached without uuid." in result
 
 
 class TestBuildFallbackContext:


### PR DESCRIPTION
### Session context traceability

- Prepend a `Session ID` blockquote to supplementary session blocks (index > 0) in the SessionStart hook's context output, so multi-session context can be traced back to its source session. The primary session's UUID is already shown in the Session Origin block, so it's skipped there to avoid duplication.
- Fix a double space introduced in the `build_context` docstring while documenting the above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Supplementary session context now includes a quoted session ID line before each additional session’s content.
* **Bug Fixes**
  * Improved context rendering so session ID text is omitted when no ID is available.
  * Kept existing context formatting and content ordering unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->