### PR TITLE
fix: load sqlite-vec before cascade-triggering branch delete

### DIFF
--- a/src/ccrecall/db.py
+++ b/src/ccrecall/db.py
@@ -40,6 +40,11 @@ CHUNK_EMBEDDABLE_BRANCH_FILTER = "is_active = 1 AND EXISTS(SELECT 1 FROM branch_
 # "errored".
 CONTENT_ERROR_VERSION = -1
 
+# Trigger names created by _ensure_vec_schema. Exposed as constants so callers
+# that need to probe for the cascade (e.g. import_session's empty-session
+# cleanup) stay in sync with the definition site.
+TRIGGER_CHUNKS_VEC_AD = "chunks_vec_ad"
+
 # Vec-loaded connections (concurrent embedding writers) wait longer than the
 # base BUSY_TIMEOUT_MS on a collision.
 VEC_BUSY_TIMEOUT_MS = 30000
@@ -210,7 +215,7 @@ def _ensure_vec_schema(conn: sqlite3.Connection) -> None:
         # Drop the trigger first: SQLite does not cascade-drop a trigger when its
         # target table is dropped, so a surviving chunks_vec_ad would fire against
         # a missing chunk_vec. (DROP TABLE works on virtual tables.)
-        conn.execute("DROP TRIGGER IF EXISTS chunks_vec_ad")
+        conn.execute(f"DROP TRIGGER IF EXISTS {TRIGGER_CHUNKS_VEC_AD}")
         conn.execute("DROP TABLE chunk_vec")
         # Reset branch watermarks: chunk_vec drop leaves branches reporting
         # EMBEDDING_VERSION while their vectors are gone; zero forces backfill
@@ -229,7 +234,7 @@ def _ensure_vec_schema(conn: sqlite3.Connection) -> None:
         " BEGIN DELETE FROM chunks WHERE branch_id = OLD.id; END"
     )
     conn.execute(
-        "CREATE TRIGGER IF NOT EXISTS chunks_vec_ad"
+        f"CREATE TRIGGER IF NOT EXISTS {TRIGGER_CHUNKS_VEC_AD}"
         " AFTER DELETE ON chunks"
         " BEGIN DELETE FROM chunk_vec WHERE chunk_id = OLD.id; END"
     )

--- a/src/ccrecall/hooks/import_conversations.py
+++ b/src/ccrecall/hooks/import_conversations.py
@@ -15,7 +15,13 @@ import sys
 from pathlib import Path
 
 from ccrecall.config import DEFAULT_DB_PATH, get_db_path, load_settings, remove_pid_file, setup_logging
-from ccrecall.db import DEFAULT_PROJECTS_DIR, branch_embedding_coverage, get_connection, vec_available
+from ccrecall.db import (
+    DEFAULT_PROJECTS_DIR,
+    TRIGGER_CHUNKS_VEC_AD,
+    branch_embedding_coverage,
+    get_connection,
+    vec_available,
+)
 from ccrecall.formatting import extract_project_name, normalize_project_key
 from ccrecall.parsing import extract_session_uuid
 from ccrecall.project_ops import upsert_project
@@ -31,11 +37,11 @@ PID_KEY = "ccrecall-import"
 
 def get_file_hash(filepath: Path) -> str:
     """Get MD5 hash of file for change detection."""
-    h = hashlib.md5(usedforsecurity=False)
-    with open(filepath, "rb") as f:
-        for chunk in iter(lambda: f.read(HASH_CHUNK_SIZE), b""):
-            h.update(chunk)
-    return h.hexdigest()
+    hasher = hashlib.md5(usedforsecurity=False)
+    with open(filepath, "rb") as fh:
+        for chunk in iter(lambda: fh.read(HASH_CHUNK_SIZE), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
 
 
 def import_session(
@@ -101,9 +107,13 @@ def import_session(
         # loaded, the DELETE crashes with "no such module: vec0". Load it
         # on demand (same approach as _apply_migrations, which loads vec
         # before migration DML that triggers the same cascade).
-        has_vec_cascade = cursor.execute(
-            "SELECT 1 FROM sqlite_master WHERE type='trigger' AND name='chunks_vec_ad'"
-        ).fetchone()
+        has_vec_cascade = (
+            cursor.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='trigger' AND name=?",
+                (TRIGGER_CHUNKS_VEC_AD,),
+            ).fetchone()
+            is not None
+        )
         if has_vec_cascade:
             vec_available(conn)
 

--- a/src/ccrecall/hooks/import_conversations.py
+++ b/src/ccrecall/hooks/import_conversations.py
@@ -15,7 +15,7 @@ import sys
 from pathlib import Path
 
 from ccrecall.config import DEFAULT_DB_PATH, get_db_path, load_settings, remove_pid_file, setup_logging
-from ccrecall.db import DEFAULT_PROJECTS_DIR, branch_embedding_coverage, get_connection
+from ccrecall.db import DEFAULT_PROJECTS_DIR, branch_embedding_coverage, get_connection, vec_available
 from ccrecall.formatting import extract_project_name, normalize_project_key
 from ccrecall.parsing import extract_session_uuid
 from ccrecall.project_ops import upsert_project
@@ -95,6 +95,18 @@ def import_session(
         # inserted branch rows before that filtering. Tear down the FK chain
         # grandchild->child->parent (branch_messages -> branches -> sessions) so
         # the session delete doesn't trip the branches.session_id constraint.
+        #
+        # The branches_chunks_ad → chunks_vec_ad cascade reaches chunk_vec (a
+        # vec0 virtual table). If the trigger exists and the extension isn't
+        # loaded, the DELETE crashes with "no such module: vec0". Load it
+        # on demand (same approach as _apply_migrations, which loads vec
+        # before migration DML that triggers the same cascade).
+        has_vec_cascade = cursor.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='trigger' AND name='chunks_vec_ad'"
+        ).fetchone()
+        if has_vec_cascade:
+            vec_available(conn)
+
         cursor.execute(
             "DELETE FROM branch_messages WHERE branch_id IN (SELECT id FROM branches WHERE session_id = ?)",
             (session_id,),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ def vec_available_in_env() -> bool:
 
 
 VEC_AVAILABLE = vec_available_in_env()
+VEC_SKIP = pytest.mark.skipif(not VEC_AVAILABLE, reason="sqlite-vec not available in this environment")
 
 
 def make_vec_conn(db_path: str = ":memory:") -> sqlite3.Connection:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,22 @@ def patched_clear(sidecar: Path):
     return lambda: clear_embedding_failure(path=sidecar)
 
 
+def vec_available_in_env() -> bool:
+    """Return True if the sqlite-vec extension can be loaded in this test run."""
+    try:
+        conn = sqlite3.connect(":memory:")
+        conn.enable_load_extension(True)
+        sqlite_vec.load(conn)
+        conn.enable_load_extension(False)
+        conn.close()
+        return True
+    except Exception:
+        return False
+
+
+VEC_AVAILABLE = vec_available_in_env()
+
+
 def make_vec_conn(db_path: str = ":memory:") -> sqlite3.Connection:
     """Return a connection with schema + sqlite-vec extension loaded.
 

--- a/tests/test_backfill_embeddings.py
+++ b/tests/test_backfill_embeddings.py
@@ -17,7 +17,7 @@ import sqlite3
 from unittest.mock import MagicMock, patch
 
 import pytest
-from conftest import VEC_AVAILABLE, make_vec_conn, patched_clear, patched_record
+from conftest import VEC_SKIP, make_vec_conn, patched_clear, patched_record
 
 from ccrecall.db import CONTENT_ERROR_VERSION
 from ccrecall.embed_ops import MAX_WRITE_PATH_EMBEDS_PER_SYNC
@@ -48,7 +48,7 @@ def _isolate_embedding_status(monkeypatch):
 _branch_counter = [0]
 
 
-_VEC_SKIP = pytest.mark.skipif(not VEC_AVAILABLE, reason="sqlite-vec not available in this environment")
+_VEC_SKIP = VEC_SKIP
 
 
 # Helpers

--- a/tests/test_backfill_embeddings.py
+++ b/tests/test_backfill_embeddings.py
@@ -17,8 +17,7 @@ import sqlite3
 from unittest.mock import MagicMock, patch
 
 import pytest
-import sqlite_vec
-from conftest import make_vec_conn, patched_clear, patched_record
+from conftest import VEC_AVAILABLE, make_vec_conn, patched_clear, patched_record
 
 from ccrecall.db import CONTENT_ERROR_VERSION
 from ccrecall.embed_ops import MAX_WRITE_PATH_EMBEDS_PER_SYNC
@@ -49,19 +48,7 @@ def _isolate_embedding_status(monkeypatch):
 _branch_counter = [0]
 
 
-def _vec_available() -> bool:
-    try:
-        conn = sqlite3.connect(":memory:")
-        conn.enable_load_extension(True)
-        sqlite_vec.load(conn)
-        conn.enable_load_extension(False)
-        conn.close()
-        return True
-    except Exception:
-        return False
-
-
-_VEC_SKIP = pytest.mark.skipif(not _vec_available(), reason="sqlite-vec not available in this environment")
+_VEC_SKIP = pytest.mark.skipif(not VEC_AVAILABLE, reason="sqlite-vec not available in this environment")
 
 
 # Helpers

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 import pytest
 import sqlite_vec
-from conftest import make_vec_conn
+from conftest import VEC_AVAILABLE, make_vec_conn
 
 import ccrecall.config as config_module
 import ccrecall.db as db_module
@@ -259,19 +259,7 @@ class TestLoadSettingsWithConfig:
 # vec schema, columns, trigger, vec_available, load_vec
 
 
-def _vec_available_in_env() -> bool:
-    """Return True if the sqlite-vec extension can be loaded in this test run."""
-    try:
-        conn = sqlite3.connect(":memory:")
-        conn.enable_load_extension(True)
-        sqlite_vec.load(conn)
-        conn.close()
-        return True
-    except Exception:
-        return False
-
-
-_VEC_AVAILABLE = _vec_available_in_env()
+_VEC_AVAILABLE = VEC_AVAILABLE
 
 
 class TestVecAvailable:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 import pytest
 import sqlite_vec
-from conftest import VEC_AVAILABLE, make_vec_conn
+from conftest import VEC_SKIP, make_vec_conn
 
 import ccrecall.config as config_module
 import ccrecall.db as db_module
@@ -259,9 +259,6 @@ class TestLoadSettingsWithConfig:
 # vec schema, columns, trigger, vec_available, load_vec
 
 
-_VEC_AVAILABLE = VEC_AVAILABLE
-
-
 class TestVecAvailable:
     """vec_available(conn) returns bool and never raises."""
 
@@ -298,7 +295,7 @@ class TestVecAvailable:
             result = vec_available(_FakeConn())
             assert result is False
 
-    @pytest.mark.skipif(not _VEC_AVAILABLE, reason="sqlite-vec not available in this environment")
+    @VEC_SKIP
     def test_returns_true_when_available(self):
         """Returns True when the extension loads successfully."""
         conn = sqlite3.connect(":memory:")
@@ -329,7 +326,7 @@ class TestVecSchema:
         cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='branches'")
         assert cursor.fetchone() is not None
 
-    @pytest.mark.skipif(not _VEC_AVAILABLE, reason="sqlite-vec not available in this environment")
+    @VEC_SKIP
     def test_branch_vec_absent_after_teardown(self):
         """branch_vec teardown: _ensure_vec_schema unconditionally drops branch_vec.
 
@@ -342,7 +339,7 @@ class TestVecSchema:
         assert "branch_vec" not in tables, "branch_vec must be absent after T06 teardown"
         conn.close()
 
-    @pytest.mark.skipif(not _VEC_AVAILABLE, reason="sqlite-vec not available in this environment")
+    @VEC_SKIP
     def test_branches_vec_ad_trigger_absent_and_chunk_triggers_present(self):
         """branch_vec teardown: branches_vec_ad is dropped; branches_chunks_ad + chunks_vec_ad are present."""
         conn = make_vec_conn()
@@ -352,7 +349,7 @@ class TestVecSchema:
         assert "chunks_vec_ad" in triggers, "chunks_vec_ad must exist after _ensure_vec_schema"
         conn.close()
 
-    @pytest.mark.skipif(not _VEC_AVAILABLE, reason="sqlite-vec not available in this environment")
+    @VEC_SKIP
     def test_existing_branch_vec_dropped_and_watermarks_reset(self):
         """When branch_vec existed before _ensure_vec_schema, it is dropped and watermarks reset to 0.
 
@@ -398,7 +395,7 @@ class TestVecSchema:
         assert wm == 0, "embedding_version must be reset to 0 when branch_vec is torn down"
         conn.close()
 
-    @pytest.mark.skipif(not _VEC_AVAILABLE, reason="sqlite-vec not available in this environment")
+    @VEC_SKIP
     def test_ensure_vec_schema_idempotent_no_branch_vec(self):
         """Running _ensure_vec_schema twice when branch_vec was never present: watermarks untouched.
 
@@ -456,7 +453,7 @@ class TestLoadVecParameter:
             assert "embedding_model" in cols
             assert "summary_version_at_embed" in cols
 
-    @pytest.mark.skipif(not _VEC_AVAILABLE, reason="sqlite-vec not available in this environment")
+    @VEC_SKIP
     def test_load_vec_true_allows_chunk_vec_query(self, tmp_path, monkeypatch):
         """get_connection(load_vec=True) returns a connection that can query chunk_vec."""
         db_file = tmp_path / "conversations.db"
@@ -765,7 +762,7 @@ class TestSchemaVersioning:
 
             assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
 
-    @pytest.mark.skipif(not _VEC_AVAILABLE, reason="sqlite-vec not available in this environment")
+    @VEC_SKIP
     def test_migration_purges_orphaned_chunk_vec_without_crashing(self, tmp_path):
         """The mainline load_vec=False migration path must not crash on a real upgrade DB.
 
@@ -863,7 +860,7 @@ class TestSchemaVersioning:
         assert not errors, f"unexpected errors in racing threads: {errors}"
         assert call_count == 1
 
-    @pytest.mark.skipif(not _VEC_AVAILABLE, reason="sqlite-vec not available in this environment")
+    @VEC_SKIP
     def test_vec_self_heal_runs_outside_version_gate(self, tmp_path):
         """_ensure_vec_schema's self-heal runs on every vec-loaded connection, not just when migrating.
 
@@ -1173,7 +1170,7 @@ class TestChunkSchema:
         assert "idx_chunks_branch" in indexes
         assert "idx_chunks_version" in indexes
 
-    @pytest.mark.skipif(not _VEC_AVAILABLE, reason="sqlite-vec not available in this environment")
+    @VEC_SKIP
     def test_chunk_vec_exists_after_ensure_vec_schema(self):
         """chunk_vec virtual table is created by _ensure_vec_schema."""
         conn = make_vec_conn()
@@ -1181,7 +1178,7 @@ class TestChunkSchema:
         assert "chunk_vec" in tables
         conn.close()
 
-    @pytest.mark.skipif(not _VEC_AVAILABLE, reason="sqlite-vec not available in this environment")
+    @VEC_SKIP
     def test_branch_vec_absent_chunk_vec_present_after_teardown(self):
         """branch_vec teardown: branch_vec absent, chunk_vec present after _ensure_vec_schema."""
         conn = make_vec_conn()
@@ -1190,7 +1187,7 @@ class TestChunkSchema:
         assert "chunk_vec" in tables, "chunk_vec must be present after _ensure_vec_schema"
         conn.close()
 
-    @pytest.mark.skipif(not _VEC_AVAILABLE, reason="sqlite-vec not available in this environment")
+    @VEC_SKIP
     def test_both_cascade_triggers_exist(self):
         """branches_chunks_ad and chunks_vec_ad triggers exist after _ensure_vec_schema."""
         conn = make_vec_conn()
@@ -1199,7 +1196,7 @@ class TestChunkSchema:
         assert "chunks_vec_ad" in triggers
         conn.close()
 
-    @pytest.mark.skipif(not _VEC_AVAILABLE, reason="sqlite-vec not available in this environment")
+    @VEC_SKIP
     def test_two_level_cascade_delete(self):
         """deleting a branch row removes all its chunks rows and their chunk_vec rows."""
         conn = make_vec_conn()
@@ -1242,7 +1239,7 @@ class TestChunkSchema:
         )
         conn.close()
 
-    @pytest.mark.skipif(not _VEC_AVAILABLE, reason="sqlite-vec not available in this environment")
+    @VEC_SKIP
     def test_chunk_vec_stale_dim_rebuilds_and_resets_watermarks(self):
         """A stale-dim chunk_vec is rebuilt at EMBEDDING_DIM and branch watermarks reset to 0.
 
@@ -1288,7 +1285,7 @@ class TestChunkSchema:
         assert wm == 0, "chunk_vec drop must reset branches.embedding_version watermark to 0"
         conn.close()
 
-    @pytest.mark.skipif(not _VEC_AVAILABLE, reason="sqlite-vec not available in this environment")
+    @VEC_SKIP
     def test_write_chunk_embedding_round_trip(self):
         """write_chunk_embedding writes the vector FIRST, then the chunk's version/model bookkeeping."""
         conn = make_vec_conn()
@@ -1320,7 +1317,7 @@ class TestChunkSchema:
         assert model == EMBEDDING_MODEL
         conn.close()
 
-    @pytest.mark.skipif(not _VEC_AVAILABLE, reason="sqlite-vec not available in this environment")
+    @VEC_SKIP
     def test_upsert_chunk_vec_replaces_without_error(self):
         """upsert_chunk_vec (DELETE+INSERT) replaces an existing row without error."""
         conn = make_vec_conn()
@@ -1363,7 +1360,7 @@ class TestChunkVecQueryable:
         assert db_module.chunk_vec_queryable(conn) is False
         conn.close()
 
-    @pytest.mark.skipif(not _VEC_AVAILABLE, reason="sqlite-vec not available in this environment")
+    @VEC_SKIP
     def test_returns_true_with_vec_loaded(self):
         """chunk_vec_queryable returns True when chunk_vec exists and is queryable."""
         conn = make_vec_conn()

--- a/tests/test_import_pipeline.py
+++ b/tests/test_import_pipeline.py
@@ -1,13 +1,16 @@
 """Integration tests for the import pipeline with v3 schema guards."""
 
 import shutil
+import sqlite3
 import tempfile
 from pathlib import Path
 
 import pytest
+import sqlite_vec
+from conftest import VEC_AVAILABLE, make_vec_conn
 
 from ccrecall.db import get_connection
-from ccrecall.embeddings import EMBEDDING_MODEL, EMBEDDING_VERSION
+from ccrecall.embeddings import EMBEDDING_DIM, EMBEDDING_MODEL, EMBEDDING_VERSION
 from ccrecall.hooks.import_conversations import import_project, import_session, print_stats
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
@@ -806,3 +809,84 @@ class TestPrintStatsEmbeddingCoverage:
         out = capsys.readouterr().out
 
         assert "Embeddings: 0/0 branches" in out
+
+
+class TestEmptySessionCascadeRegression:
+    """Regression: #59 — empty-session cleanup must not crash when cascade
+    triggers reach chunk_vec on a load_vec=False connection."""
+
+    @pytest.mark.skipif(not VEC_AVAILABLE, reason="sqlite-vec not available in this environment")
+    def test_branch_delete_with_chunk_vec_cascade(self, tmp_path):
+        """Deleting branches during empty-session cleanup loads vec on demand
+        so the chunks_vec_ad cascade trigger can reach chunk_vec."""
+        db_file = tmp_path / "cascade.db"
+        session_uuid = "sess-cascade-59"
+
+        # Phase 1: vec-loaded connection — creates cascade triggers and seeds
+        # a session with chunks + chunk_vec (simulating a prior embedding run).
+        vec_conn = make_vec_conn(str(db_file))
+        vec_conn.execute("PRAGMA foreign_keys = ON")
+        cur = vec_conn.cursor()
+        cur.execute(
+            "INSERT INTO projects (path, key, name) VALUES (?, ?, ?)",
+            ("/p", "-p", "p"),
+        )
+        proj_id = cur.lastrowid
+        cur.execute(
+            "INSERT INTO sessions (uuid, project_id) VALUES (?, ?)",
+            (session_uuid, proj_id),
+        )
+        sess_id = cur.lastrowid
+        cur.execute(
+            "INSERT INTO branches (session_id, leaf_uuid) VALUES (?, ?)",
+            (sess_id, "leaf-59"),
+        )
+        branch_id = cur.lastrowid
+        cur.execute(
+            "INSERT INTO chunks (branch_id, exchange_index, content_hash) VALUES (?, ?, ?)",
+            (branch_id, 0, "hash-0"),
+        )
+        chunk_id = cur.lastrowid
+        vec = sqlite_vec.serialize_float32([0.1] * EMBEDDING_DIM)
+        cur.execute(
+            "INSERT INTO chunk_vec(chunk_id, embedding) VALUES (?, ?)",
+            (chunk_id, vec),
+        )
+        vec_conn.commit()
+        vec_conn.close()
+
+        # Phase 2: non-vec connection (simulating the import path's
+        # load_vec=False). JSONL named after the session UUID so
+        # extract_session_uuid resolves to the pre-existing session.
+        conn = sqlite3.connect(str(db_file))
+        conn.execute("PRAGMA foreign_keys = ON")
+
+        jsonl = tmp_path / f"{session_uuid}.jsonl"
+        jsonl.write_text(
+            '{"type":"file-history-snapshot"}\n'
+            f'{{"uuid":"root","type":"progress","timestamp":"2026-01-01T00:00:00Z",'
+            f'"sessionId":"{session_uuid}","cwd":"/"}}\n'
+            f'{{"uuid":"msg1","parentUuid":"root","type":"user",'
+            f'"timestamp":"2026-01-01T00:00:01Z","sessionId":"{session_uuid}",'
+            f'"message":{{"role":"user","content":[{{"type":"tool_result",'
+            f'"tool_use_id":"t1","content":"result"}}]}}}}\n'
+            f'{{"uuid":"msg2","parentUuid":"msg1","type":"assistant",'
+            f'"timestamp":"2026-01-01T00:00:02Z","sessionId":"{session_uuid}",'
+            f'"message":{{"role":"assistant","content":[{{"type":"tool_use",'
+            f'"id":"t2","name":"Bash","input":{{"placeholder":true}}}}]}}}}\n'
+        )
+
+        # Without the fix this raises:
+        #   sqlite3.OperationalError: no such module: vec0
+        branches_imported, total_messages = import_session(conn, jsonl, proj_id)
+
+        assert branches_imported == -1
+        assert total_messages == 0
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM sessions WHERE uuid = ?",
+                (session_uuid,),
+            ).fetchone()[0]
+            == 0
+        )
+        conn.close()

--- a/tests/test_import_pipeline.py
+++ b/tests/test_import_pipeline.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 import sqlite_vec
-from conftest import VEC_AVAILABLE, make_vec_conn
+from conftest import VEC_SKIP, make_vec_conn
 
 from ccrecall.db import get_connection
 from ccrecall.embeddings import EMBEDDING_DIM, EMBEDDING_MODEL, EMBEDDING_VERSION
@@ -815,7 +815,7 @@ class TestEmptySessionCascadeRegression:
     """Regression: #59 — empty-session cleanup must not crash when cascade
     triggers reach chunk_vec on a load_vec=False connection."""
 
-    @pytest.mark.skipif(not VEC_AVAILABLE, reason="sqlite-vec not available in this environment")
+    @VEC_SKIP
     def test_branch_delete_with_chunk_vec_cascade(self, tmp_path):
         """Deleting branches during empty-session cleanup loads vec on demand
         so the chunks_vec_ad cascade trigger can reach chunk_vec."""
@@ -826,29 +826,29 @@ class TestEmptySessionCascadeRegression:
         # a session with chunks + chunk_vec (simulating a prior embedding run).
         vec_conn = make_vec_conn(str(db_file))
         vec_conn.execute("PRAGMA foreign_keys = ON")
-        cur = vec_conn.cursor()
-        cur.execute(
+        cursor = vec_conn.cursor()
+        cursor.execute(
             "INSERT INTO projects (path, key, name) VALUES (?, ?, ?)",
             ("/p", "-p", "p"),
         )
-        proj_id = cur.lastrowid
-        cur.execute(
+        project_id = cursor.lastrowid
+        cursor.execute(
             "INSERT INTO sessions (uuid, project_id) VALUES (?, ?)",
-            (session_uuid, proj_id),
+            (session_uuid, project_id),
         )
-        sess_id = cur.lastrowid
-        cur.execute(
+        session_id = cursor.lastrowid
+        cursor.execute(
             "INSERT INTO branches (session_id, leaf_uuid) VALUES (?, ?)",
-            (sess_id, "leaf-59"),
+            (session_id, "leaf-59"),
         )
-        branch_id = cur.lastrowid
-        cur.execute(
+        branch_id = cursor.lastrowid
+        cursor.execute(
             "INSERT INTO chunks (branch_id, exchange_index, content_hash) VALUES (?, ?, ?)",
             (branch_id, 0, "hash-0"),
         )
-        chunk_id = cur.lastrowid
+        chunk_id = cursor.lastrowid
         vec = sqlite_vec.serialize_float32([0.1] * EMBEDDING_DIM)
-        cur.execute(
+        cursor.execute(
             "INSERT INTO chunk_vec(chunk_id, embedding) VALUES (?, ?)",
             (chunk_id, vec),
         )
@@ -878,7 +878,7 @@ class TestEmptySessionCascadeRegression:
 
         # Without the fix this raises:
         #   sqlite3.OperationalError: no such module: vec0
-        branches_imported, total_messages = import_session(conn, jsonl, proj_id)
+        branches_imported, total_messages = import_session(conn, jsonl, project_id)
 
         assert branches_imported == -1
         assert total_messages == 0


### PR DESCRIPTION
### Bug Fix

- `ccrecall import` crashed with `sqlite3.OperationalError: no such module: vec0` when re-importing a session that filters to zero messages but has existing `chunk_vec` rows from a prior embedding run. The empty-session cleanup path deletes branch rows on a `load_vec=False` connection, but the `branches_chunks_ad → chunks_vec_ad` cascade trigger tries to `DELETE FROM chunk_vec`, which requires the sqlite-vec extension.
- Fix: before the cascade-triggering branch delete, check whether the `chunks_vec_ad` trigger exists and conditionally load sqlite-vec on demand — the same on-demand pattern `_apply_migrations` already uses for the same cascade. The trigger name is now exposed as `TRIGGER_CHUNKS_VEC_AD` in `db.py` so the probe in `import_conversations.py` stays in sync with the definition site.
- Added a regression test (`TestEmptySessionCascadeRegression`) that seeds a session with chunks + chunk_vec via a vec-loaded connection, then re-imports it on a non-vec connection to reproduce the crash without the fix.

### Housekeeping

- Consolidated the triplicated `_vec_available_in_env()` / `_vec_available()` test helper into `conftest.py` as `VEC_AVAILABLE`/`VEC_SKIP`, removing duplicate implementations from `test_db.py` and `test_backfill_embeddings.py`.
- Renamed shadowed `h`/`f` locals to `hasher`/`fh` in `get_file_hash` for clarity.

Closes #59
