### PR TITLE
feat(tail): fall back to global search when selector not found locally

### DIFF
--- a/.worktree-setup
+++ b/.worktree-setup
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+uv sync

--- a/src/ccrecall/session_tail.py
+++ b/src/ccrecall/session_tail.py
@@ -318,6 +318,30 @@ def resolve_target(pdir: Path, selector: str | None) -> Path | None:
     return sessions[1] if len(sessions) >= 2 else None
 
 
+def resolve_target_global(selector: str, projects_dir: Path = DEFAULT_PROJECTS_DIR) -> Path | None:
+    """Search all project dirs for a transcript matching *selector* by substring.
+
+    Called as a fallback when resolve_target finds no match in the local project.
+    Returns the newest match (by last-event timestamp) when multiple projects
+    contain a matching session id.
+    """
+    if not projects_dir.is_dir():
+        return None
+    matches: list[Path] = [
+        p
+        for project_dir in projects_dir.iterdir()
+        if project_dir.is_dir()
+        for p in project_dir.glob("*.jsonl")
+        if p.is_file() and selector in p.stem
+    ]
+    if not matches:
+        return None
+    if len(matches) == 1:
+        return matches[0]
+    matches.sort(key=_last_event_timestamp, reverse=True)
+    return matches[0]
+
+
 def first_typed_preview(path: Path) -> str:
     for entry in load_entries(path):
         text = typed_instruction(entry)
@@ -404,6 +428,8 @@ def run(
         return 0
 
     target = resolve_target(pdir, selector)
+    if target is None and selector:
+        target = resolve_target_global(selector)
     if target is None:
         if selector:
             print(

--- a/tests/test_session_tail.py
+++ b/tests/test_session_tail.py
@@ -12,6 +12,7 @@ from ccrecall.session_tail import (
     list_transcripts,
     load_tail_entries,
     resolve_target,
+    resolve_target_global,
     transcript_dir,
     typed_instruction,
 )
@@ -248,6 +249,50 @@ class TestResolveTarget:
     def test_single_session_returns_none(self, tmp_path):
         self._write(tmp_path, "only")
         assert resolve_target(tmp_path, None) is None
+
+
+class TestResolveTargetGlobal:
+    def _write(self, path, stem, timestamp=None):
+        path.mkdir(parents=True, exist_ok=True)
+        f = path / f"{stem}.jsonl"
+        entry = {"type": "user", "uuid": "u", "message": {}}
+        if timestamp:
+            entry["timestamp"] = timestamp
+        f.write_text(json.dumps(entry) + "\n")
+        return f
+
+    def test_finds_session_in_other_project(self, tmp_path):
+        proj_a = tmp_path / "project-a"
+        proj_b = tmp_path / "project-b"
+        self._write(proj_a, "aaaa-1111")
+        self._write(proj_b, "bbbb-2222")
+        result = resolve_target_global("bbbb", projects_dir=tmp_path)
+        assert result is not None
+        assert result.stem == "bbbb-2222"
+
+    def test_no_match_returns_none(self, tmp_path):
+        proj = tmp_path / "project-a"
+        self._write(proj, "aaaa-1111")
+        assert resolve_target_global("zzzz", projects_dir=tmp_path) is None
+
+    def test_picks_newest_when_ambiguous(self, tmp_path):
+        proj_a = tmp_path / "project-a"
+        proj_b = tmp_path / "project-b"
+        self._write(proj_a, "abc-older", timestamp="2024-01-01T00:00:00Z")
+        self._write(proj_b, "abc-newer", timestamp="2024-06-01T00:00:00Z")
+        result = resolve_target_global("abc", projects_dir=tmp_path)
+        assert result is not None
+        assert result.stem == "abc-newer"
+
+    def test_skips_non_directories(self, tmp_path):
+        (tmp_path / "not-a-dir.txt").write_text("hi")
+        proj = tmp_path / "project-a"
+        self._write(proj, "aaaa-1111")
+        result = resolve_target_global("aaaa", projects_dir=tmp_path)
+        assert result is not None
+
+    def test_missing_projects_dir_returns_none(self, tmp_path):
+        assert resolve_target_global("anything", projects_dir=tmp_path / "nope") is None
 
 
 class TestLastEventTimestampFallback:


### PR DESCRIPTION
### `ccrecall tail` — fall back to global session search

- When a selector doesn't match any transcript in the current project directory, `resolve_target_global` now searches every project directory under `~/.claude/projects/` before giving up. This fixes the common workflow where `ccrecall search` returns a handle from a *different* project and `ccrecall tail <handle>` used to fail with "no session matching" because the lookup was project-scoped.
- When the selector matches sessions in more than one project, the newest match (by last-event timestamp) wins, consistent with how ambiguity is already resolved elsewhere in `session_tail.py`.

### Housekeeping

- Add `.worktree-setup` to run `uv sync` automatically when a new worktree is created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session transcripts can now be found across all project directories.
  * When multiple matching sessions exist, the most recently active transcript is selected.
  * Searches safely handle missing project directories and ignore non-project entries.

* **Chores**
  * Worktree setup now automatically synchronizes project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->