### PR TITLE
feat: show tool detail in tail output instead of bare tool names

### DIFF
--- a/src/ccrecall/session_tail.py
+++ b/src/ccrecall/session_tail.py
@@ -73,6 +73,7 @@ DEFAULT_TAIL_EVENTS = 8  # CLI -n default
 _INJECTION_OPTION_CLIP = 160
 _CLI_OPTION_CLIP = 140
 _PREVIEW_CLIP = 90
+_TOOL_CLIP = 80
 
 
 def transcript_dir(cwd: str, projects_dir: Path = DEFAULT_PROJECTS_DIR) -> Path:
@@ -210,9 +211,48 @@ def last_assistant_text(entries: list[dict]) -> str | None:
     return None
 
 
+def _brief_path(path: str) -> str:
+    """Last two path components — enough to identify the file without noise."""
+    parts = Path(path).parts
+    if len(parts) <= 2:
+        return path
+    return "…/" + "/".join(parts[-2:])
+
+
+def _tool_event(block: dict) -> tuple[str, str]:
+    """Extract (lowercase_tag, brief_summary) from a tool_use block."""
+    name = block.get("name", "?")
+    inp = block.get("input", {})
+    tag = name.lower()
+
+    if name == "Bash":
+        return tag, clip(inp.get("command", ""), _TOOL_CLIP)
+    if name == "Read":
+        return tag, _brief_path(inp.get("file_path", ""))
+    if name in ("Edit", "Write", "MultiEdit"):
+        return tag, _brief_path(inp.get("file_path", ""))
+    if name == "Agent":
+        desc = inp.get("description", "")
+        return tag, desc or clip(inp.get("prompt", ""), _TOOL_CLIP)
+    if name == "Skill":
+        return tag, inp.get("skill", "")
+    if name in ("Grep", "Glob"):
+        return tag, clip(inp.get("pattern", ""), _TOOL_CLIP)
+    if name == "AskUserQuestion":
+        qs = inp.get("questions", [])
+        if qs:
+            return "ask", clip(qs[0].get("question", ""), _TOOL_CLIP)
+        return "ask", ""
+    return tag, ""
+
+
 def build_tail(entries: list[dict], k: int) -> list[tuple[str, str]]:
-    """Last ``k`` main-chain events as (kind, body). One assistant entry can yield
-    several events (its text plus each tool_use); ``k`` bounds the output, not input."""
+    """Last ``k`` main-chain events as (tag, body). One assistant entry can yield
+    several events (its text plus each tool_use); ``k`` bounds the output, not input.
+
+    Tool events use the lowercase tool name as the tag (``bash``, ``read``, ``edit``,
+    ``agent``, etc.) with a brief summary from the tool's input as the body.
+    """
     if k <= 0:
         return []
     events: list[tuple[str, str]] = []
@@ -228,10 +268,10 @@ def build_tail(entries: list[dict], k: int) -> list[tuple[str, str]]:
         elif kind == "assistant":
             text, _, _, _ = extract_text_content(content)
             if text:
-                events.append(("assistant", clip(text)))
+                events.append(("asst", clip(text)))
             if isinstance(content, list):
                 events.extend(
-                    ("tool", block.get("name", "?"))
+                    _tool_event(block)
                     for block in content
                     if isinstance(block, dict) and block.get("type") == "tool_use"
                 )
@@ -394,9 +434,8 @@ def emit(path: Path, k: int, full: bool = False) -> int:
     tail = build_tail(entries, k)
     if tail:
         print(f"TAIL (last {len(tail)} events):")
-        tags = {"user": "user", "assistant": "asst", "tool": "tool"}
-        for kind, body in tail:
-            print(f"  [{tags[kind]}] {body}")
+        for tag, body in tail:
+            print(f"  [{tag}] {body}")
         print()
 
     if not pending:

--- a/tests/test_session_tail.py
+++ b/tests/test_session_tail.py
@@ -4,10 +4,12 @@ import json
 import os
 
 from ccrecall.session_tail import (
+    _brief_path,
     _build_search_dirs,
     _emit_full,
     _last_event_timestamp,
     _resolve_across_dirs,
+    _tool_event,
     build_tail,
     emit,
     find_pending_question,
@@ -199,8 +201,8 @@ class TestBuildTail:
         ]
         tail = build_tail(entries, 8)
         assert tail[0] == ("user", "u1")
-        assert tail[1] == ("assistant", "a1")
-        assert ("tool", "AskUserQuestion") in tail
+        assert tail[1] == ("asst", "a1")
+        assert ("ask", "q?") in tail
 
     def test_respects_k(self):
         entries = [user_text(f"u{i}") for i in range(20)]
@@ -210,6 +212,82 @@ class TestBuildTail:
         entries = [user_text("u1"), assistant_text("a1")]
         assert build_tail(entries, 0) == []
         assert build_tail(entries, -1) == []
+
+
+class TestBriefPath:
+    def test_short_path_unchanged(self):
+        assert _brief_path("/a.py") == "/a.py"
+        assert _brief_path("a/b.py") == "a/b.py"
+
+    def test_long_path_truncated(self):
+        assert _brief_path("/home/user/src/project/file.py") == "…/project/file.py"
+
+    def test_three_components(self):
+        assert _brief_path("/a/b/c.py") == "…/b/c.py"
+
+
+class TestToolEvent:
+    def test_bash(self):
+        block = {"name": "Bash", "input": {"command": "git status"}}
+        assert _tool_event(block) == ("bash", "git status")
+
+    def test_bash_clipped(self):
+        block = {"name": "Bash", "input": {"command": "x" * 200}}
+        tag, body = _tool_event(block)
+        assert tag == "bash"
+        assert len(body) <= 85
+
+    def test_read(self):
+        block = {"name": "Read", "input": {"file_path": "/home/user/src/foo.py"}}
+        assert _tool_event(block) == ("read", "…/src/foo.py")
+
+    def test_edit(self):
+        block = {"name": "Edit", "input": {"file_path": "/a/b/c.py"}}
+        assert _tool_event(block) == ("edit", "…/b/c.py")
+
+    def test_write(self):
+        block = {"name": "Write", "input": {"file_path": "/a/b.py"}}
+        assert _tool_event(block) == ("write", "…/a/b.py")
+
+    def test_multiedit(self):
+        block = {"name": "MultiEdit", "input": {"file_path": "/a/b/c.py"}}
+        assert _tool_event(block) == ("multiedit", "…/b/c.py")
+
+    def test_agent_with_description(self):
+        block = {"name": "Agent", "input": {"description": "Code review", "prompt": "review"}}
+        assert _tool_event(block) == ("agent", "Code review")
+
+    def test_agent_falls_back_to_prompt(self):
+        block = {"name": "Agent", "input": {"prompt": "review the changes"}}
+        assert _tool_event(block) == ("agent", "review the changes")
+
+    def test_skill(self):
+        block = {"name": "Skill", "input": {"skill": "mine-ship"}}
+        assert _tool_event(block) == ("skill", "mine-ship")
+
+    def test_grep(self):
+        block = {"name": "Grep", "input": {"pattern": "TODO"}}
+        assert _tool_event(block) == ("grep", "TODO")
+
+    def test_glob(self):
+        block = {"name": "Glob", "input": {"pattern": "*.py"}}
+        assert _tool_event(block) == ("glob", "*.py")
+
+    def test_ask_user_question(self):
+        block = {"name": "AskUserQuestion", "input": {"questions": [{"question": "proceed?"}]}}
+        assert _tool_event(block) == ("ask", "proceed?")
+
+    def test_ask_no_questions(self):
+        block = {"name": "AskUserQuestion", "input": {"questions": []}}
+        assert _tool_event(block) == ("ask", "")
+
+    def test_unknown_tool(self):
+        block = {"name": "WebFetch", "input": {"url": "https://example.com"}}
+        assert _tool_event(block) == ("webfetch", "")
+
+    def test_missing_input(self):
+        block = {"name": "Bash", "input": {}}
+        assert _tool_event(block) == ("bash", "")
 
 
 class TestTranscriptDir:


### PR DESCRIPTION
### Tool detail in tail output

- `ccrecall tail` previously showed only the bare tool name (e.g. `[tool] Bash`), which told you a command ran but not what it did. `build_tail` now emits a `_tool_event()` summary per tool: `Bash` shows the command, `Read`/`Edit`/`Write`/`MultiEdit` show a brief two-component path (`…/project/file.py`, via `_brief_path()`), `Agent` shows its description (falling back to a clipped prompt), `Skill` shows the skill name, `Grep`/`Glob` show the search pattern, and `AskUserQuestion` shows the first question — with a bare `[ask]`/etc. tag for anything unmapped.
- The event tag scheme changed from a fixed `{user, assistant, tool}` lookup to per-event tags returned directly by `build_tail` (`asst` instead of `assistant`, and a lowercase tool name like `bash`/`read`/`edit` in place of the generic `tool` tag) — `emit()` now prints tags as-is instead of mapping through a dict.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced transcript tail entries with clearer labels for assistant messages and tool activity.
  * Added concise summaries for common tools, including shortened file paths, clipped commands, and brief prompts or questions.
  * Improved readability by reducing lengthy tool details while retaining the most relevant information.
* **Bug Fixes**
  * Corrected transcript tail labeling for interactive questions and assistant responses.
  * Improved handling of tools with missing or incomplete details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->