### PR TITLE
fix: respect CLAUDE_CONFIG_DIR for transcript directory

### DIFF
--- a/src/ccrecall/config.py
+++ b/src/ccrecall/config.py
@@ -17,11 +17,17 @@ from pathlib import Path
 
 from ccrecall.models import LOGGER_NAME
 
+# Claude Code config directory — respects CLAUDE_CONFIG_DIR when set.
+CLAUDE_CONFIG_DIR = Path(os.environ.get("CLAUDE_CONFIG_DIR", Path.home() / ".claude"))
+
 # Default paths
 RUNTIME_DIR = Path.home() / ".ccrecall"
 DEFAULT_DB_PATH = RUNTIME_DIR / "conversations.db"
 DEFAULT_LOG_PATH = RUNTIME_DIR / "ccrecall.log"
 CONFIG_PATH = RUNTIME_DIR / "config.json"
+
+# Claude Code transcript directory
+DEFAULT_PROJECTS_DIR = CLAUDE_CONFIG_DIR / "projects"
 
 # Hook filenames/prefixes — writer and reader live in different modules and must agree.
 CLEAR_HANDOFF_FILENAME = "clear-handoff.json"

--- a/src/ccrecall/config.py
+++ b/src/ccrecall/config.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from ccrecall.models import LOGGER_NAME
 
 # Claude Code config directory — respects CLAUDE_CONFIG_DIR when set.
-CLAUDE_CONFIG_DIR = Path(os.environ.get("CLAUDE_CONFIG_DIR", Path.home() / ".claude"))
+CLAUDE_CONFIG_DIR = Path(os.environ.get("CLAUDE_CONFIG_DIR") or Path.home() / ".claude")
 
 # Default paths
 RUNTIME_DIR = Path.home() / ".ccrecall"

--- a/src/ccrecall/db.py
+++ b/src/ccrecall/db.py
@@ -12,12 +12,10 @@ from pathlib import Path
 import sqlite_vec
 
 from ccrecall.config import DEFAULT_DB_PATH, ensure_parent_dir, get_db_path
+from ccrecall.config import DEFAULT_PROJECTS_DIR as DEFAULT_PROJECTS_DIR
 from ccrecall.embeddings import EMBEDDING_DIM, EMBEDDING_MODEL, EMBEDDING_VERSION
 from ccrecall.models import BUSY_TIMEOUT_MS
 from ccrecall.schema import SCHEMA_CORE, SCHEMA_FTS4, SCHEMA_FTS5, detect_fts_support
-
-# Default paths
-DEFAULT_PROJECTS_DIR = Path.home() / ".claude" / "projects"
 
 # Current schema version. Bump when adding a migration and wire the new DDL
 # delta into _apply_migrations (see _migrate_to_v1 for the version-1 shape).

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,6 +1,7 @@
 """Tests for ccrecall.db — schema creation, settings, and vec operations."""
 
 import json
+import os
 import sqlite3
 import subprocess
 import sys
@@ -1440,3 +1441,55 @@ class TestTransitiveImportIsolation:
     def test_clear_handoff_does_not_import_heavy_deps(self):
         """clear_handoff.py imports only from config.py."""
         self._assert_no_heavy_imports("ccrecall.hooks.clear_handoff")
+
+
+class TestClaudeConfigDir:
+    """DEFAULT_PROJECTS_DIR must respect the CLAUDE_CONFIG_DIR env var."""
+
+    def test_default_projects_dir_uses_env_var(self, tmp_path):
+        code = (
+            "from ccrecall.config import DEFAULT_PROJECTS_DIR\n"
+            "from pathlib import Path\n"
+            f"assert DEFAULT_PROJECTS_DIR == Path({str(tmp_path)!r}) / 'projects', "
+            f"f'got {{DEFAULT_PROJECTS_DIR}}'\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env={**dict(os.environ), "CLAUDE_CONFIG_DIR": str(tmp_path)},
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_default_projects_dir_falls_back_to_dot_claude(self):
+        code = (
+            "from ccrecall.config import DEFAULT_PROJECTS_DIR\n"
+            "from pathlib import Path\n"
+            "assert DEFAULT_PROJECTS_DIR == Path.home() / '.claude' / 'projects', "
+            "f'got {DEFAULT_PROJECTS_DIR}'\n"
+        )
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDE_CONFIG_DIR"}
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_db_reexports_same_value(self, tmp_path):
+        code = (
+            "from ccrecall.config import DEFAULT_PROJECTS_DIR as from_config\n"
+            "from ccrecall.db import DEFAULT_PROJECTS_DIR as from_db\n"
+            "assert from_config == from_db, f'{from_config} != {from_db}'\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env={**dict(os.environ), "CLAUDE_CONFIG_DIR": str(tmp_path)},
+        )
+        assert result.returncode == 0, result.stderr

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1458,6 +1458,7 @@ class TestClaudeConfigDir:
             capture_output=True,
             text=True,
             timeout=10,
+            check=False,
             env={**dict(os.environ), "CLAUDE_CONFIG_DIR": str(tmp_path)},
         )
         assert result.returncode == 0, result.stderr
@@ -1475,7 +1476,25 @@ class TestClaudeConfigDir:
             capture_output=True,
             text=True,
             timeout=10,
+            check=False,
             env=env,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_empty_env_var_falls_back_to_dot_claude(self):
+        code = (
+            "from ccrecall.config import DEFAULT_PROJECTS_DIR\n"
+            "from pathlib import Path\n"
+            "assert DEFAULT_PROJECTS_DIR == Path.home() / '.claude' / 'projects', "
+            "f'got {DEFAULT_PROJECTS_DIR}'\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+            env={**dict(os.environ), "CLAUDE_CONFIG_DIR": ""},
         )
         assert result.returncode == 0, result.stderr
 
@@ -1490,6 +1509,7 @@ class TestClaudeConfigDir:
             capture_output=True,
             text=True,
             timeout=10,
+            check=False,
             env={**dict(os.environ), "CLAUDE_CONFIG_DIR": str(tmp_path)},
         )
         assert result.returncode == 0, result.stderr


### PR DESCRIPTION
### Respect `CLAUDE_CONFIG_DIR` for the transcript directory

- `DEFAULT_PROJECTS_DIR` was hardcoded to `~/.claude/projects`, so users running Claude Code with a custom `CLAUDE_CONFIG_DIR` had their transcripts silently missed by sync/import.
- `config.py` now resolves a `CLAUDE_CONFIG_DIR` constant (env var, falling back to `~/.claude`) and derives `DEFAULT_PROJECTS_DIR` from it, keeping the convention that `config.py` owns all path constants.
- `db.py` re-exports `DEFAULT_PROJECTS_DIR` from `config.py` for backward compatibility with downstream importers of that name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing the Claude configuration directory through an environment setting.
  * Project transcript paths now automatically follow the configured Claude directory.

* **Bug Fixes**
  * Ensured database project paths remain consistent with the active configuration.

* **Tests**
  * Added coverage for custom and default configuration directory behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->