### PR TITLE
fix: use structural is_error field for pending question detection

### DIFF
--- a/src/ccrecall/session_tail.py
+++ b/src/ccrecall/session_tail.py
@@ -47,13 +47,6 @@ from ccrecall.parsing import (
 # no-timestamp tool-result burst, without reading a multi-MB file in full.
 _TIMESTAMP_TAIL_LINES = 20
 
-# A genuinely answered AskUserQuestion produces a tool_result whose text begins
-# "Your questions have been answered: …"; we match the stable substring. A
-# rejection ("The user doesn't want to proceed…"), an interrupt, or no result at
-# all all lack it, and all mean the decision is still open. Kept lowercase — the
-# call site lowercases the result text before matching.
-ANSWER_MARK = "have been answered"
-
 # Harness-injected user content that isn't a typed instruction. command/channel
 # wrappers, task-notifications, and <local-command-caveat> blocks are already
 # handled by extract_text_content / is_task_notification / the "<local-command-"
@@ -151,13 +144,12 @@ def find_pending_question(entries: list[dict]) -> dict | None:
     Returns the tool_use ``input`` payload (``{"questions": [...]}``) when the
     prior session ended on a decision the user never resolved.
     """
-    # Map every tool_use_id to its result *text*, to distinguish a real answer
-    # from a rejection / interrupt / missing result. We scan all entries (sidechain
-    # included) here — a tool_result resolves its id wherever it lives — but only
-    # main-chain questions are considered below. extract_text_content unwraps both
-    # string and list-of-blocks bodies (str(body) would match the marker only by
-    # accident).
-    results: dict[str, str] = {}
+    # Map every tool_use_id to the is_error flag on its tool_result block.
+    # Answered: tool_result with no is_error key. Rejected: is_error=true.
+    # No tool_result at all: the session ended before the harness delivered one.
+    # We scan all entries (sidechain included) — a tool_result resolves its id
+    # wherever it lives — but only main-chain questions are considered below.
+    result_is_error: dict[str, bool] = {}
     for entry in entries:
         if entry.get("type") != "user":
             continue
@@ -167,13 +159,12 @@ def find_pending_question(entries: list[dict]) -> dict | None:
         for block in content:
             if isinstance(block, dict) and block.get("type") == "tool_result":
                 tool_use_id = block.get("tool_use_id")
-                if not isinstance(tool_use_id, str):
-                    continue
-                text, _, _, _, _ = extract_text_content(block.get("content"))
-                results[tool_use_id] = text
+                if isinstance(tool_use_id, str):
+                    result_is_error[tool_use_id] = bool(block.get("is_error"))
 
     last = None
-    for entry in entries:
+    last_entry_idx = -1
+    for i, entry in enumerate(entries):
         if not _is_main_chain(entry) or entry.get("type") != "assistant":
             continue
         content = entry.get("message", {}).get("content")
@@ -182,14 +173,18 @@ def find_pending_question(entries: list[dict]) -> dict | None:
         for block in content:
             if isinstance(block, dict) and block.get("type") == "tool_use" and block.get("name") == "AskUserQuestion":
                 last = (block.get("id"), block.get("input", {}))
+                last_entry_idx = i
 
     if not last:
         return None
     tool_id, payload = last
-    # A non-str id can't index results; treat the question as unanswered and surface it.
     if not isinstance(tool_id, str):
         return payload
-    if ANSWER_MARK in results.get(tool_id, "").lower():
+    if result_is_error.get(tool_id) is False:
+        return None
+    # No result or is_error=true — only pending if the user didn't move on.
+    tail = entries[last_entry_idx + 1 :]
+    if any(typed_instruction(e) for e in tail if _is_main_chain(e)):
         return None
     return payload
 

--- a/tests/test_session_tail.py
+++ b/tests/test_session_tail.py
@@ -42,13 +42,13 @@ def user_text(text: str, sidechain: bool = False) -> dict:
     }
 
 
-def user_tool_result(tool_id: str, content) -> dict:
+def user_tool_result(tool_id: str, content, *, is_error: bool = False) -> dict:
+    block: dict = {"type": "tool_result", "tool_use_id": tool_id, "content": content}
+    if is_error:
+        block["is_error"] = True
     return {
         "type": "user",
-        "message": {
-            "role": "user",
-            "content": [{"type": "tool_result", "tool_use_id": tool_id, "content": content}],
-        },
+        "message": {"role": "user", "content": [block]},
         "uuid": _uuid(),
     }
 
@@ -99,14 +99,14 @@ class TestFindPendingQuestion:
     def test_asked_then_rejected_is_pending(self):
         entries = [
             ask_question("t1", "proceed?", OPTS),
-            user_tool_result("t1", REJECTED),
+            user_tool_result("t1", REJECTED, is_error=True),
         ]
         assert find_pending_question(entries) is not None
 
     def test_asked_then_interrupted_is_pending(self):
         entries = [
             ask_question("t1", "proceed?", OPTS),
-            user_tool_result("t1", INTERRUPT),
+            user_tool_result("t1", INTERRUPT, is_error=True),
         ]
         assert find_pending_question(entries) is not None
 
@@ -144,17 +144,51 @@ class TestFindPendingQuestion:
         ]
         assert find_pending_question(entries) is None
 
-    def test_result_as_list_content(self):
-        # Real transcripts sometimes store tool_result content as a list of blocks;
-        # the answer marker must be read from the extracted text, not str(list).
-        listed = [{"type": "text", "text": ANSWERED}]
-        entries = [ask_question("t1", "proceed?", OPTS), user_tool_result("t1", listed)]
+    def test_result_with_is_error_true_is_pending(self):
+        entries = [
+            ask_question("t1", "proceed?", OPTS),
+            user_tool_result("t1", "any text", is_error=True),
+        ]
+        assert find_pending_question(entries) is not None
+
+    def test_result_without_is_error_is_not_pending(self):
+        entries = [
+            ask_question("t1", "proceed?", OPTS),
+            user_tool_result("t1", "any text"),
+        ]
         assert find_pending_question(entries) is None
 
-    def test_list_result_without_marker_is_pending(self):
-        # A non-answer delivered as list-of-blocks must not be read as answered.
-        listed = [{"type": "text", "text": "user chose to stop"}]
-        entries = [ask_question("t1", "proceed?", OPTS), user_tool_result("t1", listed)]
+    def test_rejected_then_user_continued_is_not_pending(self):
+        entries = [
+            ask_question("t1", "proceed?", OPTS),
+            user_tool_result("t1", REJECTED, is_error=True),
+            user_text("do something else instead"),
+            assistant_text("OK, doing something else."),
+        ]
+        assert find_pending_question(entries) is None
+
+    def test_rejected_with_no_followup_is_pending(self):
+        entries = [
+            ask_question("t1", "proceed?", OPTS),
+            user_tool_result("t1", REJECTED, is_error=True),
+            assistant_text("OK, what would you like to do?"),
+        ]
+        assert find_pending_question(entries) is not None
+
+    def test_no_result_then_user_continued_is_not_pending(self):
+        entries = [
+            ask_question("t1", "proceed?", OPTS),
+            user_text("never mind, do this instead"),
+            assistant_text("OK, doing that."),
+        ]
+        assert find_pending_question(entries) is None
+
+    def test_sidechain_followup_does_not_supersede(self):
+        entries = [
+            ask_question("t1", "proceed?", OPTS),
+            user_tool_result("t1", REJECTED, is_error=True),
+            user_text("subagent instruction", sidechain=True),
+        ]
         assert find_pending_question(entries) is not None
 
 


### PR DESCRIPTION
### Fix false-positive pending-question detection

- `find_pending_question()` previously matched the substring `"have been
  answered"` in the `tool_result` text to decide whether an `AskUserQuestion`
  had been resolved. Claude Code has since introduced a newer answer format
  (`"The user answered: ..."`) that doesn't contain that substring, so answered
  questions were being falsely flagged as pending in `ccrecall tail` and the
  SessionStart hook.
- Replaced the text match with the structural `is_error` field on the
  `tool_result` block: no `is_error` key means answered, `is_error: true`
  means rejected, and no result block at all means abandoned. This is
  wording-agnostic and can't drift again as Claude Code's answer phrasing
  changes.
- Also fixes a pre-existing gap: a rejected or abandoned question followed by
  further user instructions is now treated as superseded rather than still
  pending, with sidechain (subagent) messages correctly excluded from that
  "did the user move on" check.
- Validated against 777 real transcripts across two machines with zero false
  positives.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of unresolved questions by using the actual success or error status of responses.
  - Prevented completed questions from appearing as pending when their responses contain unexpected formatting.
  - Correctly preserves pending status after rejected or interrupted responses until a valid follow-up instruction is provided.
  - Ensured activity in side conversations does not incorrectly resolve pending questions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->