### PR TITLE
fix: backfill resilience, batched embedding, and coverage nudge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,9 @@
+---
+audience: open-source library
+developers: solo
+data-sensitivity: user-local Claude Code transcripts — content varies with what the user typed, so treat as potentially sensitive; stays on the user's machine, never transmitted
+---
+
 # CLAUDE.md
 
 Guidance for Claude Code (and humans) working in this repository.

--- a/ruff.toml
+++ b/ruff.toml
@@ -71,6 +71,7 @@ ignore = [
     # predicate — never user data, which always flows through ? params. The
     # check is pure false-positive noise for this parameterized-SQLite codebase.
     "S608",   # hardcoded-sql-expression
+    "PERF203", # try-except-in-loop — unavoidable in retry loops
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/ruff.toml
+++ b/ruff.toml
@@ -95,14 +95,6 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 ]
 "tools/*.py" = ["S603", "S607"]
 "scripts/**/*.py" = ["S101", "S105", "S310", "S603", "S607"]
-# PERF203 (try-except-in-loop) is unavoidable here: each of these files has a
-# legitimate retry/liveness loop where the try/except IS the mechanism, not
-# incidental control flow inside a loop.
-"src/ccrecall/db.py" = ["PERF203"]
-"src/ccrecall/hooks/backfill_summaries.py" = ["PERF203"]
-"src/ccrecall/hooks/backfill_tool_content.py" = ["PERF203"]
-"src/ccrecall/hooks/memory_setup.py" = ["PERF203"]
-"src/ccrecall/hooks/sync_current.py" = ["PERF203"]
 
 [format]
 quote-style = "double"

--- a/ruff.toml
+++ b/ruff.toml
@@ -71,7 +71,6 @@ ignore = [
     # predicate — never user data, which always flows through ? params. The
     # check is pure false-positive noise for this parameterized-SQLite codebase.
     "S608",   # hardcoded-sql-expression
-    "PERF203", # try-except-in-loop — unavoidable in retry loops
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
@@ -96,6 +95,14 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 ]
 "tools/*.py" = ["S603", "S607"]
 "scripts/**/*.py" = ["S101", "S105", "S310", "S603", "S607"]
+# PERF203 (try-except-in-loop) is unavoidable here: each of these files has a
+# legitimate retry/liveness loop where the try/except IS the mechanism, not
+# incidental control flow inside a loop.
+"src/ccrecall/db.py" = ["PERF203"]
+"src/ccrecall/hooks/backfill_summaries.py" = ["PERF203"]
+"src/ccrecall/hooks/backfill_tool_content.py" = ["PERF203"]
+"src/ccrecall/hooks/memory_setup.py" = ["PERF203"]
+"src/ccrecall/hooks/sync_current.py" = ["PERF203"]
 
 [format]
 quote-style = "double"

--- a/src/ccrecall/cli/commands.py
+++ b/src/ccrecall/cli/commands.py
@@ -94,7 +94,7 @@ def cmd_import(
     import_mod.run(db=db, projects_dir=projects_dir, project=project, verbose=ctx.debug)
 
 
-def _count_multi_active_branch_sessions(db: Path) -> int:
+def count_multi_active_branch_sessions(db: Path) -> int:
     """Return the count of sessions with more than one active branch.
 
     Session-keyed branch identity (branch_ops.upsert_branch) should make this
@@ -122,7 +122,7 @@ def cmd_stats(
     # import.run(), so it can't disturb a concurrent background import.
     import_mod.print_stats(db=db)
 
-    violations = _count_multi_active_branch_sessions(db)
+    violations = count_multi_active_branch_sessions(db)
     print(f"Branch invariant violations: {violations} session(s) with multiple active branches")
     if violations:
         logging.getLogger(LOGGER_NAME).warning(

--- a/src/ccrecall/cli/commands.py
+++ b/src/ccrecall/cli/commands.py
@@ -154,7 +154,7 @@ def cmd_backfill_embeddings(
     progress_every: Annotated[
         int, Parameter(help="Print a progress line every N newly embedded branches.")
     ] = backfill_query_mod.DEFAULT_PROGRESS_EVERY,
-    threads: Annotated[int, Parameter(help="Inference threads.")] = DEFAULT_EMBED_THREADS,
+    threads: Annotated[int, Parameter(help="ONNX intra-op threads per inference call.")] = DEFAULT_EMBED_THREADS,
     ctx: CLIContextParam = DEFAULT_CLI_CONTEXT,
 ) -> None:
     """Seed historical embeddings for active-leaf branch summaries (opt-in)."""

--- a/src/ccrecall/db.py
+++ b/src/ccrecall/db.py
@@ -441,7 +441,7 @@ def _migrate_to_v3(conn: sqlite3.Connection) -> None:
     for column, decl in (("file_size", "INTEGER"), ("file_mtime", "REAL")):
         try:
             conn.execute(f"ALTER TABLE import_log ADD COLUMN {column} {decl}")
-        except sqlite3.OperationalError as e:  # noqa: PERF203 — 2-iteration loop, concurrency guard
+        except sqlite3.OperationalError as e:
             if "duplicate column name" not in str(e):
                 raise
 

--- a/src/ccrecall/db.py
+++ b/src/ccrecall/db.py
@@ -441,7 +441,7 @@ def _migrate_to_v3(conn: sqlite3.Connection) -> None:
     for column, decl in (("file_size", "INTEGER"), ("file_mtime", "REAL")):
         try:
             conn.execute(f"ALTER TABLE import_log ADD COLUMN {column} {decl}")
-        except sqlite3.OperationalError as e:
+        except sqlite3.OperationalError as e:  # noqa: PERF203 — per-column idempotent ALTER guard, not a retry; the exception IS the "already applied" signal
             if "duplicate column name" not in str(e):
                 raise
 

--- a/src/ccrecall/embed_ops.py
+++ b/src/ccrecall/embed_ops.py
@@ -184,14 +184,32 @@ def embed_branch_chunks(
     # backfill passes max_embeds=None to embed the whole branch in one call.
     needing_embed = needing_embed_full if max_embeds is None else needing_embed_full[:max_embeds]
 
-    # Step 6 — embed + write: upsert chunk rows, batch-embed all texts, then
-    # write vectors (order invariant: vector FIRST, bookkeeping LAST — so a
-    # mid-loop exception leaves the chunk eligible for backfill rather than
-    # marked done-without-vector).
+    # Step 6 — embed first, then write: batch-embed all texts BEFORE any DB
+    # write, then upsert each chunk row and its vector together. This shrinks
+    # the vector-loss window from "the whole branch" to "nothing": under the
+    # old upsert-then-embed order, a failed embed_batch call landed after the
+    # DELETE+INSERT had already cascaded away every previously-good chunk_vec
+    # row for this branch, so one failed batch destroyed all prior vectors.
+    # With embed_batch called first and no DB writes yet, a failure here
+    # leaves every existing chunk row and vector untouched. The per-chunk
+    # vector-FIRST/bookkeeping-LAST invariant inside write_chunk_embedding is
+    # unchanged: a mid-loop exception still leaves that chunk eligible for
+    # backfill rather than marked done-without-vector.
 
-    # 6a — upsert chunk rows and collect chunk_ids for the vector write pass.
-    chunk_ids: list[int] = []
-    for ed in needing_embed:
+    # 6a — batch embed: single model.embed() call for all texts.
+    # Trade-off: a content error in any text fails the whole batch (the
+    # per-exchange loop can't catch mid-batch). cap_for_embedding already
+    # bounds text length, so content errors should be rare; a failed batch
+    # leaves all chunks eligible for backfill per the clear-first protocol —
+    # and now leaves prior chunk rows/vectors intact too (nothing deleted yet).
+    texts = [ed["text"] for ed in needing_embed]
+    vecs = embed_batch(texts)
+
+    # 6b — per chunk: upsert the chunk row, then write its vector (order
+    # invariant: vector FIRST, bookkeeping LAST — so a mid-loop exception
+    # leaves that chunk eligible for backfill rather than marked
+    # done-without-vector).
+    for ed, vec in zip(needing_embed, vecs, strict=True):
         cursor.execute(
             "DELETE FROM chunks WHERE branch_id = ? AND exchange_index = ?",
             (branch_db_id, ed["index"]),
@@ -217,18 +235,6 @@ def embed_branch_chunks(
         )
         chunk_id = cursor.lastrowid
         assert chunk_id is not None  # noqa: S101 — lastrowid is non-None after a successful INSERT
-        chunk_ids.append(chunk_id)
-
-    # 6b — batch embed: single model.embed() call for all texts.
-    # Trade-off: a content error in any text fails the whole batch (the
-    # per-exchange loop can't catch mid-batch). cap_for_embedding already
-    # bounds text length, so content errors should be rare; a failed batch
-    # leaves all chunks eligible for backfill per the clear-first protocol.
-    texts = [ed["text"] for ed in needing_embed]
-    vecs = embed_batch(texts)
-
-    # 6c — write vectors (order invariant: vector FIRST, bookkeeping LAST).
-    for chunk_id, vec in zip(chunk_ids, vecs, strict=True):
         write_chunk_embedding(cursor, chunk_id, vec, EMBEDDING_VERSION, EMBEDDING_MODEL)
 
     # Step 7 — prune: delete chunks whose exchange_index no longer exists.

--- a/src/ccrecall/embed_ops.py
+++ b/src/ccrecall/embed_ops.py
@@ -10,7 +10,7 @@ import logging
 import sqlite3
 
 from ccrecall.db import write_chunk_embedding
-from ccrecall.embeddings import EMBEDDING_MODEL, EMBEDDING_VERSION, cap_for_embedding, embed_text
+from ccrecall.embeddings import EMBEDDING_MODEL, EMBEDDING_VERSION, cap_for_embedding, embed_batch
 from ccrecall.models import LOGGER_NAME
 from ccrecall.summarizer import SUMMARY_VERSION, build_exchange_pairs, compute_context_summary
 
@@ -184,12 +184,14 @@ def embed_branch_chunks(
     # backfill passes max_embeds=None to embed the whole branch in one call.
     needing_embed = needing_embed_full if max_embeds is None else needing_embed_full[:max_embeds]
 
-    # Step 6 — embed loop: for each needing-embed exchange, upsert the chunks row,
-    # embed the text, then write the vector (order invariant: vector FIRST,
-    # bookkeeping LAST — so a mid-loop exception leaves the chunk eligible for
-    # backfill rather than marked done-without-vector).
+    # Step 6 — embed + write: upsert chunk rows, batch-embed all texts, then
+    # write vectors (order invariant: vector FIRST, bookkeeping LAST — so a
+    # mid-loop exception leaves the chunk eligible for backfill rather than
+    # marked done-without-vector).
+
+    # 6a — upsert chunk rows and collect chunk_ids for the vector write pass.
+    chunk_ids: list[int] = []
     for ed in needing_embed:
-        # Upsert chunks row via DELETE+INSERT (vec0 rejects INSERT OR REPLACE)
         cursor.execute(
             "DELETE FROM chunks WHERE branch_id = ? AND exchange_index = ?",
             (branch_db_id, ed["index"]),
@@ -215,8 +217,18 @@ def embed_branch_chunks(
         )
         chunk_id = cursor.lastrowid
         assert chunk_id is not None  # noqa: S101 — lastrowid is non-None after a successful INSERT
-        # Vector FIRST (order invariant), bookkeeping LAST
-        vec = embed_text(ed["text"])
+        chunk_ids.append(chunk_id)
+
+    # 6b — batch embed: single model.embed() call for all texts.
+    # Trade-off: a content error in any text fails the whole batch (the
+    # per-exchange loop can't catch mid-batch). cap_for_embedding already
+    # bounds text length, so content errors should be rare; a failed batch
+    # leaves all chunks eligible for backfill per the clear-first protocol.
+    texts = [ed["text"] for ed in needing_embed]
+    vecs = embed_batch(texts)
+
+    # 6c — write vectors (order invariant: vector FIRST, bookkeeping LAST).
+    for chunk_id, vec in zip(chunk_ids, vecs, strict=True):
         write_chunk_embedding(cursor, chunk_id, vec, EMBEDDING_VERSION, EMBEDDING_MODEL)
 
     # Step 7 — prune: delete chunks whose exchange_index no longer exists.

--- a/src/ccrecall/embeddings.py
+++ b/src/ccrecall/embeddings.py
@@ -51,6 +51,15 @@ MODEL_TOKEN_LIMIT = 8192
 # on an idle machine; interactive write/query paths always use the default.
 DEFAULT_EMBED_THREADS = 1
 
+# cap_for_embedding tuning: dense-token texts start at DENSE_SPLIT_RATIO of
+# total length for head and tail each (40% + 40% = 80%, dropping the middle
+# 20%). The SHRINK_FACTOR tightens on each iteration when still over the token
+# limit, keeping 75% of the previous head/tail each pass.
+DENSE_SPLIT_NUMERATOR = 2
+DENSE_SPLIT_DENOMINATOR = 5
+SHRINK_NUMERATOR = 3
+SHRINK_DENOMINATOR = 4
+
 # Module-level singleton — lazily constructed, reused within a process.
 _model = None
 
@@ -149,18 +158,6 @@ def embed_text(text: str) -> list[float]:
     return embed_one(get_model(), text)
 
 
-def embed_texts(texts: list[str]) -> list[list[float]]:
-    """Embed texts sequentially (one inference call per text), reusing the model.
-
-    Not true batched inference — it loops, but avoids per-call model
-    construction and keeps batch results bit-identical to per-text calls (no
-    padding-dependent drift). Convenience batch wrapper. Raises on failure —
-    callers should wrap in their own guard.
-    """
-    model = get_model()
-    return [embed_one(model, text) for text in texts]
-
-
 def embed_batch(texts: list[str]) -> list[list[float]]:
     """Embed multiple texts in a single batched inference call.
 
@@ -211,14 +208,14 @@ def cap_for_embedding(text: str) -> tuple[str, bool]:
         head = EMBED_CHAR_BUDGET // 2
         tail = EMBED_CHAR_BUDGET // 2
     else:
-        head = max(len(text) * 2 // 5, 1)
-        tail = max(len(text) * 2 // 5, 1)
+        head = max(len(text) * DENSE_SPLIT_NUMERATOR // DENSE_SPLIT_DENOMINATOR, 1)
+        tail = max(len(text) * DENSE_SPLIT_NUMERATOR // DENSE_SPLIT_DENOMINATOR, 1)
 
     capped = text[:head] + "\n\n[...]\n\n" + text[-tail:]
 
     while model.token_count([capped]) > MODEL_TOKEN_LIMIT:
-        head = max(head * 3 // 4, 1)
-        tail = max(tail * 3 // 4, 1)
+        head = max(head * SHRINK_NUMERATOR // SHRINK_DENOMINATOR, 1)
+        tail = max(tail * SHRINK_NUMERATOR // SHRINK_DENOMINATOR, 1)
         next_capped = text[:head] + "\n\n[...]\n\n" + text[-tail:]
         if next_capped == capped:
             break  # no further reduction possible; pathological — let embed_text raise

--- a/src/ccrecall/embeddings.py
+++ b/src/ccrecall/embeddings.py
@@ -154,12 +154,25 @@ def embed_texts(texts: list[str]) -> list[list[float]]:
 
     Not true batched inference — it loops, but avoids per-call model
     construction and keeps batch results bit-identical to per-text calls (no
-    padding-dependent drift). Convenience batch wrapper; the backfill hot path
-    calls embed_text per-row directly. Raises on failure — callers should wrap
-    in their own guard.
+    padding-dependent drift). Convenience batch wrapper. Raises on failure —
+    callers should wrap in their own guard.
     """
     model = get_model()
     return [embed_one(model, text) for text in texts]
+
+
+def embed_batch(texts: list[str]) -> list[list[float]]:
+    """Embed multiple texts in a single batched inference call.
+
+    True batched inference: passes the full list to model.embed() so the
+    underlying onnxruntime processes them as one batch. Returns vectors in the
+    same order as the input texts. Raises on failure.
+    """
+    if not texts:
+        return []
+    model = get_model()
+    vecs = list(model.embed(texts))
+    return [normalize(v.astype(np.float32)).tolist() for v in vecs]
 
 
 def cap_for_embedding(text: str) -> tuple[str, bool]:

--- a/src/ccrecall/health.py
+++ b/src/ccrecall/health.py
@@ -42,6 +42,7 @@ RECALL_CAVEAT_COVERAGE_THRESHOLD = 0.95
 # Alert key constants — one per proactive alert class.
 ALERT_CANT_PERSIST = "cant_persist"
 ALERT_EMBEDDINGS_FAILING = "embeddings_failing"
+ALERT_TOOL_CONTENT_INCOMPLETE = "tool_content_incomplete"
 
 # Embedding-capability failure reason codes (the sub-protocol the detached embedding
 # process writes into the embedding-status sidecar; the SessionStart hook reads them back). Shared here
@@ -256,6 +257,11 @@ _ALERT_PROSE: dict[str, tuple[str, str, str]] = {
         "ccrecall's embedding pipeline is failing — semantic search is unavailable or degraded.",
         "the vector extension (sqlite-vec) or embedding model is unavailable",
         "verify sqlite-vec is installed and the embedding model is accessible, then restart the session",
+    ),
+    ALERT_TOOL_CONTENT_INCOMPLETE: (
+        "ccrecall's tool-content index is incomplete — tool_use content from older sessions is not yet searchable.",
+        "sessions synced before tool-content extraction was added have not been backfilled",
+        "run `ccrecall backfill tool-content` to index historical tool_use content (one-time, opt-in)",
     ),
 }
 

--- a/src/ccrecall/hooks/backfill_embeddings.py
+++ b/src/ccrecall/hooks/backfill_embeddings.py
@@ -25,6 +25,7 @@ import os
 import sqlite3
 import sys
 import time
+from collections import deque
 
 from ccrecall.config import load_settings, setup_logging
 from ccrecall.db import CONTENT_ERROR_VERSION, chunk_vec_queryable, fetch_branch_messages, get_connection
@@ -50,6 +51,8 @@ from ccrecall.hooks.backfill_status import format_duration, run_status
 _PRINT_PREFIX = "ccrecall backfill embeddings"
 _LOG_PREFIX = "Backfill embeddings"
 _SAVEPOINT_NAME = "row"
+_WARMUP_BRANCHES = 5
+_RATE_WINDOW = 30
 
 
 def run(
@@ -101,6 +104,8 @@ def run(
     total_inferences = 0
     last_progress = 0
     last_batch_ids: list[int] | None = None
+    work_done = 0
+    rate_samples: deque[tuple[float, int]] = deque(maxlen=_RATE_WINDOW)
     started = time.monotonic()
 
     where, params = build_selection(days)
@@ -128,6 +133,22 @@ def run(
             total_eligible = cursor.fetchone()[0]
             if limit is not None:
                 total_eligible = min(total_eligible, limit)
+
+            # Cost-proportional total: non-notification message count across
+            # eligible branches. Excludes notifications to match the
+            # include_notifications=False filter on fetch_branch_messages, so
+            # total_work and work_done are in the same units.
+            # When --limit is active, restrict to the first `limit` branches
+            # (by id) so the ETA reflects the limited run, not the full backlog.
+            limit_clause = f"ORDER BY id LIMIT {limit}" if limit is not None else ""
+            cursor.execute(
+                f"""SELECT COUNT(*) FROM branch_messages bm
+                    JOIN messages m ON m.id = bm.message_id
+                    WHERE bm.branch_id IN (SELECT id FROM branches {where} {limit_clause})
+                      AND COALESCE(m.is_notification, 0) = 0""",
+                params,
+            )
+            total_work = cursor.fetchone()[0]
 
             logger.info("%s: starting, %s branches to embed", _LOG_PREFIX, total_eligible)
             print(
@@ -221,11 +242,22 @@ def run(
                             )
                             logger.exception("%s: branch %s failed", _LOG_PREFIX, branch_id)
 
+                        work_done += len(branch_msgs)
+                        rate_samples.append((time.monotonic(), work_done))
+
                         if total_updated - last_progress >= progress_every:
                             elapsed = time.monotonic() - started
                             remaining = max(0, total_eligible - total_updated)
-                            rate = total_updated / elapsed if elapsed > 0 else 0.0
-                            eta = format_duration(remaining / rate) if rate > 0 else "?"
+                            if total_updated >= _WARMUP_BRANCHES and len(rate_samples) >= 2:
+                                t0, w0 = rate_samples[0]
+                                t1, w1 = rate_samples[-1]
+                                dt = t1 - t0
+                                dw = w1 - w0
+                                rate = dw / dt if dt > 0 else 0.0
+                                remaining_work = max(0, total_work - work_done)
+                                eta = format_duration(remaining_work / rate) if rate > 0 else "?"
+                            else:
+                                eta = "warming up"
                             msg = (
                                 f"{total_inferences} exchanges embedded across "
                                 f"{total_updated}/{total_eligible} branches, "

--- a/src/ccrecall/hooks/backfill_embeddings.py
+++ b/src/ccrecall/hooks/backfill_embeddings.py
@@ -248,7 +248,12 @@ def run(
                         if total_updated - last_progress >= progress_every:
                             elapsed = time.monotonic() - started
                             remaining = max(0, total_eligible - total_updated)
-                            if total_updated >= _WARMUP_BRANCHES and len(rate_samples) >= 2:
+                            # Gate on branches processed (success or content-error),
+                            # not total_updated (successes only) — a run with many
+                            # early content-errors would otherwise report "warming
+                            # up" indefinitely even though rate_samples has plenty
+                            # of data to compute a rate from.
+                            if len(rate_samples) >= _WARMUP_BRANCHES:
                                 t0, w0 = rate_samples[0]
                                 t1, w1 = rate_samples[-1]
                                 dt = t1 - t0

--- a/src/ccrecall/hooks/backfill_embeddings.py
+++ b/src/ccrecall/hooks/backfill_embeddings.py
@@ -101,6 +101,7 @@ def run(
         return EXIT_ABORT
 
     total_updated = 0
+    total_processed = 0
     total_inferences = 0
     last_progress = 0
     last_batch_ids: list[int] | None = None
@@ -242,10 +243,11 @@ def run(
                             )
                             logger.exception("%s: branch %s failed", _LOG_PREFIX, branch_id)
 
+                        total_processed += 1
                         work_done += len(branch_msgs)
                         rate_samples.append((time.monotonic(), work_done))
 
-                        if total_updated - last_progress >= progress_every:
+                        if total_processed - last_progress >= progress_every:
                             elapsed = time.monotonic() - started
                             remaining = max(0, total_eligible - total_updated)
                             # Gate on branches processed (success or content-error),
@@ -271,7 +273,7 @@ def run(
                             )
                             logger.info("%s: %s", _LOG_PREFIX, msg)
                             print(f"{_PRINT_PREFIX}: {msg}", file=sys.stderr)
-                            last_progress = total_updated
+                            last_progress = total_processed
                 except Exception:
                     # Infra/session failure (e.g. ONNX session crash, sqlite3.Error on
                     # fetch_branch_messages, OOM): abort without marking the content-error

--- a/src/ccrecall/hooks/backfill_query.py
+++ b/src/ccrecall/hooks/backfill_query.py
@@ -8,6 +8,7 @@ status reporter (`backfill_status`) need to agree on.
 from ccrecall.config import remove_pid_file
 from ccrecall.db import CHUNK_EMBEDDABLE_BRANCH_FILTER, CONTENT_ERROR_VERSION
 from ccrecall.embeddings import EMBEDDING_MODEL, EMBEDDING_VERSION
+from ccrecall.hooks.tool_content_eligibility import days_modifier
 
 BATCH_SIZE = 20
 BACKFILL_BATCH_DELAY_SECONDS = 0.05
@@ -27,15 +28,6 @@ PID_KEY = "ccrecall-backfill-embeddings"
 def cleanup_pid() -> None:
     """Remove the self-concurrency PID marker (no-op if absent)."""
     remove_pid_file(PID_KEY)
-
-
-def days_modifier(days: int) -> str:
-    """SQLite datetime() modifier for an N-day lookback (days=7 -> '-7 days').
-
-    Single source of truth for the --days recency bound so build_selection()
-    (eligibility) and count_status() (progress) can't construct it differently.
-    """
-    return f"-{days} days"
 
 
 def build_selection(days: int | None) -> tuple[str, list]:

--- a/src/ccrecall/hooks/backfill_summaries.py
+++ b/src/ccrecall/hooks/backfill_summaries.py
@@ -68,7 +68,7 @@ def _main(*, verbose: bool = False):
                                 (summary_md, summary_json, SUMMARY_VERSION, branch_id),
                             )
                             total_updated += 1
-                        except (ValueError, TypeError, KeyError) as e:
+                        except (ValueError, TypeError, KeyError) as e:  # noqa: PERF203 — per-row content-error isolation, not a retry; the exception marks one bad row without aborting the batch
                             # Per-row content error (malformed summary data): mark the
                             # sentinel so it isn't retried forever. Infra errors fall
                             # through to the outer handler instead of poisoning the row.

--- a/src/ccrecall/hooks/backfill_summaries.py
+++ b/src/ccrecall/hooks/backfill_summaries.py
@@ -68,7 +68,7 @@ def _main(*, verbose: bool = False):
                                 (summary_md, summary_json, SUMMARY_VERSION, branch_id),
                             )
                             total_updated += 1
-                        except (ValueError, TypeError, KeyError) as e:  # noqa: PERF203 — per-row error isolation
+                        except (ValueError, TypeError, KeyError) as e:
                             # Per-row content error (malformed summary data): mark the
                             # sentinel so it isn't retried forever. Infra errors fall
                             # through to the outer handler instead of poisoning the row.

--- a/src/ccrecall/hooks/backfill_tool_content.py
+++ b/src/ccrecall/hooks/backfill_tool_content.py
@@ -69,6 +69,7 @@ from ccrecall.hooks.backfill_query import (
 )
 from ccrecall.hooks.backfill_status import format_duration
 from ccrecall.message_ops import insert_new_messages
+from ccrecall.models import LOGGER_NAME
 from ccrecall.parsing import (
     build_aggregated_content,
     extract_session_uuid,
@@ -112,14 +113,20 @@ def backfill_with_retry(
     """Run backfill_session with bounded retry on transient DB locks.
 
     Returns the result of backfill_session on success. Raises LockExhaustedError
-    if all retries are exhausted. Other exceptions (OSError, content errors)
-    propagate unchanged.
+    if all retries are exhausted. Non-lock OperationalErrors (e.g. schema errors
+    like "no such column") are not transient, so they're re-raised immediately
+    instead of being retried and misreported as a DB-lock skip — they propagate
+    to the batch-level abort handler in run(). Other exceptions (OSError,
+    content errors) propagate unchanged.
     """
     for attempt in range(_LOCK_RETRIES):
         try:
             with savepoint(cursor):
                 return backfill_session(cursor, session_id, filepaths)
         except sqlite3.OperationalError as exc:
+            msg = str(exc).lower()
+            if "locked" not in msg and "busy" not in msg:
+                raise
             logger.warning(
                 "%s: session %s transient DB error (attempt %s/%s): %s",
                 _LOG_PREFIX,
@@ -174,6 +181,7 @@ def run(
     skipped_empty = 0
     skipped_content_error = 0
     skipped_db_lock = 0
+    skipped_stuck = 0
     last_progress = 0
     last_batch_ids: list[int] | None = None
     exclude_ids: set[int] = set()
@@ -206,12 +214,19 @@ def run(
 
                 current_ids = [r[0] for r in rows]
                 if current_ids == last_batch_ids:
+                    # Defense-in-depth: with Fix 1 (backfill_session unconditionally
+                    # stamping remaining NULL rows to '' before returning True), a
+                    # session should always leave the eligible set on its first
+                    # attempt, making this path nearly unreachable. Kept as a guard
+                    # against any future regression that reintroduces a re-selectable
+                    # no-op session.
                     logger.warning(
                         "%s: same batch re-selected (session ids: %s); excluding and continuing",
                         _LOG_PREFIX,
                         current_ids,
                     )
                     exclude_ids.update(current_ids)
+                    skipped_stuck += len(current_ids)
                     continue
                 last_batch_ids = current_ids
 
@@ -267,10 +282,12 @@ def run(
                             exclude_ids.add(session_id)
                             continue
                         total_updated += 1
-                        # No exclude_ids entry: all files for this session were
-                        # merged, so every row now has tool_content set — the
-                        # eligibility predicate (`tool_content IS NULL`) already
-                        # keeps it out of future batches.
+                        # No exclude_ids entry needed: backfill_session guarantees
+                        # (#81 Fix 1) that a True return means every messages row for
+                        # this session has left the eligibility predicate's NULL
+                        # set — either backfilled with real content or stamped '' for
+                        # a uuid absent from the surviving JSONL — so the session
+                        # cannot be re-selected in a later batch.
 
                         if total_updated - last_progress >= progress_every:
                             elapsed = time.monotonic() - started
@@ -304,13 +321,14 @@ def run(
     logger.info(
         "%s complete: %s sessions backfilled, %s skipped (missing JSONL), "
         "%s skipped (no usable branch), %s skipped (content error), "
-        "%s skipped (DB lock) in %s",
+        "%s skipped (DB lock), %s skipped (stuck) in %s",
         _LOG_PREFIX,
         total_updated,
         skipped_missing,
         skipped_empty,
         skipped_content_error,
         skipped_db_lock,
+        skipped_stuck,
         format_duration(elapsed),
     )
     if json_mode:
@@ -323,6 +341,7 @@ def run(
                     "skipped_empty": skipped_empty,
                     "skipped_content_error": skipped_content_error,
                     "skipped_db_lock": skipped_db_lock,
+                    "skipped_stuck": skipped_stuck,
                     "elapsed_seconds": round(elapsed, 1),
                 }
             )
@@ -332,7 +351,7 @@ def run(
             f"{_PRINT_PREFIX}: complete — {total_updated} sessions backfilled, "
             f"{skipped_missing} skipped (missing JSONL), {skipped_empty} skipped (no usable branch), "
             f"{skipped_content_error} skipped (content error), "
-            f"{skipped_db_lock} skipped (DB lock) in {format_duration(elapsed)}",
+            f"{skipped_db_lock} skipped (DB lock), {skipped_stuck} skipped (stuck) in {format_duration(elapsed)}",
             file=sys.stderr,
         )
     return EXIT_OK
@@ -426,8 +445,15 @@ def backfill_session(cursor: sqlite3.Cursor, session_id: int, filepaths: list[Pa
     Returns False (a no-op) when all files parse to no entries, no branch, or
     the session has no active branch row in the DB — in these cases nothing
     was written and ``messages.tool_content`` stays NULL, so the caller must
-    not count it as backfilled. Returns True once the write pipeline actually
-    ran.
+    not count it as backfilled.
+
+    Returns True once the write pipeline actually ran. A True return
+    guarantees the session has left the eligible set: any ``messages`` row
+    still NULL after the update/insert passes (a uuid absent from every
+    surviving JSONL file) is stamped to ``''`` before returning, so this
+    session's ``tool_content IS NULL`` count is always zero afterward — it
+    cannot be re-selected in a later batch, and it stops re-firing the
+    SessionStart tool-content alert (issue #81).
 
     Raises OSError if a file can no longer be opened (race with a concurrent
     delete) — the caller treats that like the missing-file case.
@@ -515,6 +541,29 @@ def backfill_session(cursor: sqlite3.Cursor, session_id: int, filepaths: list[Pa
         "UPDATE branches SET aggregated_content = ?, embedding_version = NULL, summary_version = NULL WHERE id = ?",
         (agg_content, branch_db_id),
     )
+
+    # Guarantee (#81 Fix 1): a session must leave the eligible set once this
+    # function returns True, or it gets re-selected and re-parsed forever and
+    # keeps re-firing the SessionStart alert. Any messages row still NULL here
+    # has a uuid absent from every surviving JSONL file for this session (the
+    # UPDATE pass above only touches uuids it finds in all_entries) — transcript
+    # files are append-only, so that uuid can never reappear in a later run.
+    # '' is the codebase's existing meaning for "no tool content"; stamping it
+    # structurally removes the row from both the backfill eligibility predicate
+    # and the alert's coverage check. This runs inside the caller's SAVEPOINT,
+    # so it's atomic with the rest of this session's writes.
+    cursor.execute(
+        "UPDATE messages SET tool_content = '' WHERE session_id = ? AND tool_content IS NULL",
+        (session_id,),
+    )
+    if cursor.rowcount > 0:
+        logging.getLogger(LOGGER_NAME).warning(
+            "%s: session id=%s had %s row(s) with uuids absent from the surviving JSONL; "
+            "marked tool_content='' (unrecoverable)",
+            _LOG_PREFIX,
+            session_id,
+            cursor.rowcount,
+        )
     return True
 
 

--- a/src/ccrecall/hooks/backfill_tool_content.py
+++ b/src/ccrecall/hooks/backfill_tool_content.py
@@ -29,10 +29,14 @@ Eligibility (a session "still needs tool_content backfill") is defined as
 having at least one ``messages`` row with ``tool_content IS NULL`` — the same
 condition the v4 migration leaves existing rows in and that forward-sync
 never produces (``extract_text_content`` always returns a string, never
-None). This module owns that selection predicate; it doesn't fit
-``backfill_query.build_selection`` (the chunk-embedding branch universe), so
-only the batch/no-progress-guard constants and ``--days`` helper are shared
-from there.
+None). ``tool_content_eligibility.py`` owns that selection predicate
+(``ELIGIBILITY_FROM``/``eligibility_clause``) — factored out into its own
+dependency-free module rather than defined here, so ``context_alerts.py``'s
+SessionStart sampling check can import it without pulling in this module's
+``ccrecall.db`` import chain (and therefore fastembed/onnxruntime) onto the
+hot path. It doesn't fit ``backfill_query.build_selection`` (the
+chunk-embedding branch universe) either, so only the batch/no-progress-guard
+constants are shared from there.
 
 For the same reason, ``--status`` here doesn't call
 ``backfill_status.run_status``/``count_status``: those are hard-wired to the
@@ -42,8 +46,7 @@ of which has a session-grain tool_content equivalent (there's no "errored"
 concept for a re-parse backfill, and the universe is sessions, not chunks).
 Only ``format_duration`` — the one grain-agnostic piece — is shared from
 ``backfill_status``; the counting and report shape are re-derived here from
-``_ELIGIBILITY_FROM``/``eligibility_clause``, this module's own single
-source of truth.
+``tool_content_eligibility``.
 """
 
 import contextlib
@@ -65,9 +68,14 @@ from ccrecall.hooks.backfill_query import (
     DEFAULT_PROGRESS_EVERY,
     EXIT_ABORT,
     EXIT_OK,
-    days_modifier,
 )
 from ccrecall.hooks.backfill_status import format_duration
+from ccrecall.hooks.tool_content_eligibility import (
+    ELIGIBILITY_FROM,
+    MAX_SQL_PARAMS,
+    days_modifier,
+    eligibility_clause,
+)
 from ccrecall.message_ops import insert_new_messages
 from ccrecall.models import LOGGER_NAME
 from ccrecall.parsing import (
@@ -81,7 +89,6 @@ from ccrecall.parsing import (
 _PRINT_PREFIX = "ccrecall backfill tool-content"
 _LOG_PREFIX = "Backfill tool-content"
 _SAVEPOINT_NAME = "session"
-_MAX_SQL_PARAMS = 900
 _LOCK_RETRIES = 3
 _LOCK_BACKOFF_SECONDS = 2.0
 
@@ -123,7 +130,7 @@ def backfill_with_retry(
         try:
             with savepoint(cursor):
                 return backfill_session(cursor, session_id, filepaths)
-        except sqlite3.OperationalError as exc:
+        except sqlite3.OperationalError as exc:  # noqa: PERF203 — retry loop; the try/except IS the mechanism, not incidental control flow
             msg = str(exc).lower()
             if "locked" not in msg and "busy" not in msg:
                 raise
@@ -138,16 +145,6 @@ def backfill_with_retry(
             if attempt < _LOCK_RETRIES - 1:
                 time.sleep(_LOCK_BACKOFF_SECONDS * (attempt + 1))
     raise LockExhaustedError(session_uuid)
-
-
-# Shared FROM clause for every "sessions needing tool_content backfill" query
-# (the eligible-count, the per-batch selection, and --status) so the join
-# shape can't drift between them.
-_ELIGIBILITY_FROM = """
-    FROM messages m
-    JOIN sessions s ON s.id = m.session_id
-    JOIN branches b ON b.session_id = s.id AND b.is_active = 1
-"""
 
 
 def run(
@@ -379,37 +376,9 @@ def build_filepath_index(cursor: sqlite3.Cursor, logger: logging.Logger) -> dict
     return mapping
 
 
-def eligibility_clause(days: int | None, exclude_ids: set[int] | None = None) -> tuple[str, list]:
-    """WHERE clause (+ params) for "sessions still needing tool_content backfill".
-
-    Single source of truth for the one-time eligible count and the per-batch
-    selection query, mirroring backfill_query.build_selection's pattern so the
-    two can't drift. ``exclude_ids`` removes sessions this run already
-    attempted (succeeded, errored, or had no on-disk file) so a stalled
-    session can't force the no-progress guard to fire on every batch.
-
-    The NOT IN clause is chunked to stay under SQLite's bound-parameter limit.
-    """
-    where = "WHERE m.tool_content IS NULL"
-    params: list = []
-    if exclude_ids:
-        ids = sorted(exclude_ids)
-        not_in_parts: list[str] = []
-        for i in range(0, len(ids), _MAX_SQL_PARAMS):
-            chunk = ids[i : i + _MAX_SQL_PARAMS]
-            placeholders = ",".join("?" * len(chunk))
-            not_in_parts.append(f"s.id NOT IN ({placeholders})")
-            params.extend(chunk)
-        where += " AND " + " AND ".join(not_in_parts)
-    if days is not None:
-        where += " AND b.ended_at > datetime('now', ?)"
-        params.append(days_modifier(days))
-    return where, params
-
-
 def count_eligible(cursor: sqlite3.Cursor, days: int | None) -> int:
     where, params = eligibility_clause(days)
-    return cursor.execute(f"SELECT COUNT(DISTINCT s.id) {_ELIGIBILITY_FROM} {where}", params).fetchone()[0]
+    return cursor.execute(f"SELECT COUNT(DISTINCT s.id) {ELIGIBILITY_FROM} {where}", params).fetchone()[0]
 
 
 def count_total_sessions(cursor: sqlite3.Cursor, days: int | None) -> int:
@@ -419,14 +388,14 @@ def count_total_sessions(cursor: sqlite3.Cursor, days: int | None) -> int:
     if days is not None:
         where += " AND b.ended_at > datetime('now', ?)"
         params.append(days_modifier(days))
-    return cursor.execute(f"SELECT COUNT(DISTINCT s.id) {_ELIGIBILITY_FROM} {where}", params).fetchone()[0]
+    return cursor.execute(f"SELECT COUNT(DISTINCT s.id) {ELIGIBILITY_FROM} {where}", params).fetchone()[0]
 
 
 def select_batch(cursor: sqlite3.Cursor, exclude_ids: set[int], days: int | None) -> list[tuple[int, str]]:
     """Return up to BATCH_SIZE (session_id, session_uuid) pairs still needing
     tool_content backfill, oldest session id first."""
     where, params = eligibility_clause(days, exclude_ids)
-    query = f"SELECT DISTINCT s.id, s.uuid {_ELIGIBILITY_FROM} {where} ORDER BY s.id LIMIT ?"
+    query = f"SELECT DISTINCT s.id, s.uuid {ELIGIBILITY_FROM} {where} ORDER BY s.id LIMIT ?"
     params = [*params, BATCH_SIZE]
     return cursor.execute(query, params).fetchall()
 
@@ -509,8 +478,8 @@ def backfill_session(cursor: sqlite3.Cursor, session_id: int, filepaths: list[Pa
         new_uuids_list = list(new_uuids)
         uuid_to_msg_id: dict[str, int] = {}
         # -1 reserves one slot for the session_id bound parameter
-        for i in range(0, len(new_uuids_list), _MAX_SQL_PARAMS - 1):
-            chunk = new_uuids_list[i : i + _MAX_SQL_PARAMS - 1]
+        for i in range(0, len(new_uuids_list), MAX_SQL_PARAMS - 1):
+            chunk = new_uuids_list[i : i + MAX_SQL_PARAMS - 1]
             placeholders = ",".join("?" * len(chunk))
             cursor.execute(
                 f"SELECT id, uuid FROM messages WHERE session_id = ? AND uuid IN ({placeholders})",

--- a/src/ccrecall/hooks/backfill_tool_content.py
+++ b/src/ccrecall/hooks/backfill_tool_content.py
@@ -42,7 +42,7 @@ of which has a session-grain tool_content equivalent (there's no "errored"
 concept for a re-parse backfill, and the universe is sessions, not chunks).
 Only ``format_duration`` — the one grain-agnostic piece — is shared from
 ``backfill_status``; the counting and report shape are re-derived here from
-``_ELIGIBILITY_FROM``/``_eligibility_clause``, this module's own single
+``_ELIGIBILITY_FROM``/``eligibility_clause``, this module's own single
 source of truth.
 """
 
@@ -86,7 +86,7 @@ _LOCK_BACKOFF_SECONDS = 2.0
 
 
 @contextlib.contextmanager
-def _savepoint(cursor: sqlite3.Cursor):
+def savepoint(cursor: sqlite3.Cursor):
     """SAVEPOINT wrapper: releases on success, rolls back + releases on error."""
     cursor.execute(f"SAVEPOINT {_SAVEPOINT_NAME}")
     try:
@@ -98,27 +98,27 @@ def _savepoint(cursor: sqlite3.Cursor):
     cursor.execute(f"RELEASE SAVEPOINT {_SAVEPOINT_NAME}")
 
 
-class _LockExhaustedError(Exception):
+class LockExhaustedError(Exception):
     """Raised when all retry attempts for a transient DB lock are exhausted."""
 
 
-def _backfill_with_retry(
+def backfill_with_retry(
     cursor: sqlite3.Cursor,
     session_id: int,
     session_uuid: str,
     filepaths: list[Path],
     logger: logging.Logger,
 ) -> bool:
-    """Run _backfill_session with bounded retry on transient DB locks.
+    """Run backfill_session with bounded retry on transient DB locks.
 
-    Returns the result of _backfill_session on success. Raises _LockExhaustedError
+    Returns the result of backfill_session on success. Raises LockExhaustedError
     if all retries are exhausted. Other exceptions (OSError, content errors)
     propagate unchanged.
     """
     for attempt in range(_LOCK_RETRIES):
         try:
-            with _savepoint(cursor):
-                return _backfill_session(cursor, session_id, filepaths)
+            with savepoint(cursor):
+                return backfill_session(cursor, session_id, filepaths)
         except sqlite3.OperationalError as exc:
             logger.warning(
                 "%s: session %s transient DB error (attempt %s/%s): %s",
@@ -130,7 +130,7 @@ def _backfill_with_retry(
             )
             if attempt < _LOCK_RETRIES - 1:
                 time.sleep(_LOCK_BACKOFF_SECONDS * (attempt + 1))
-    raise _LockExhaustedError(session_uuid)
+    raise LockExhaustedError(session_uuid)
 
 
 # Shared FROM clause for every "sessions needing tool_content backfill" query
@@ -162,7 +162,7 @@ def run(
     logger = setup_logging(settings, process_name="backfill-tool-content", verbose=verbose)
 
     if status:
-        return _run_status(days=days, json_mode=json_mode, settings=settings, logger=logger)
+        return run_status(days=days, json_mode=json_mode, settings=settings, logger=logger)
 
     # Background I/O-bound job: lower scheduling priority so interactive work
     # wins (machines.md thrash risk). Best-effort — os.nice is POSIX-only.
@@ -187,9 +187,9 @@ def run(
             conn.execute(f"PRAGMA busy_timeout = {VEC_BUSY_TIMEOUT_MS}")
             cursor = conn.cursor()
 
-            filepath_by_uuid = _build_filepath_index(cursor, logger)
+            filepath_by_uuid = build_filepath_index(cursor, logger)
 
-            total_eligible = _count_eligible(cursor, days)
+            total_eligible = count_eligible(cursor, days)
             if limit is not None:
                 total_eligible = min(total_eligible, limit)
 
@@ -200,7 +200,7 @@ def run(
                 if limit is not None and total_updated >= limit:
                     break
 
-                rows = _select_batch(cursor, exclude_ids, days)
+                rows = select_batch(cursor, exclude_ids, days)
                 if not rows:
                     break
 
@@ -228,8 +228,8 @@ def run(
                             continue
 
                         try:
-                            made_change = _backfill_with_retry(cursor, session_id, session_uuid, filepaths, logger)
-                        except _LockExhaustedError:
+                            made_change = backfill_with_retry(cursor, session_id, session_uuid, filepaths, logger)
+                        except LockExhaustedError:
                             logger.warning(
                                 "%s: session %s (id=%s) DB lock persisted after %s retries, skipping",
                                 _LOG_PREFIX,
@@ -338,14 +338,14 @@ def run(
     return EXIT_OK
 
 
-def _build_filepath_index(cursor: sqlite3.Cursor, logger: logging.Logger) -> dict[str, list[Path]]:
+def build_filepath_index(cursor: sqlite3.Cursor, logger: logging.Logger) -> dict[str, list[Path]]:
     """Map session_uuid -> list of file paths for every ``import_log`` entry
     whose JSONL still exists on disk.
 
     A session backed by the Agent tool produces N files (a parent ``.jsonl``
     plus one ``agent-*.jsonl`` per subagent invocation), all resolving to the
     same session_uuid via ``extract_session_uuid``.  Every file is kept so
-    ``_backfill_session`` can merge entries from the full set.
+    ``backfill_session`` can merge entries from the full set.
 
     A missing file is logged once here (not per re-selection); a session_uuid
     with zero surviving files gets no index entry, and the caller skips it.
@@ -360,7 +360,7 @@ def _build_filepath_index(cursor: sqlite3.Cursor, logger: logging.Logger) -> dic
     return mapping
 
 
-def _eligibility_clause(days: int | None, exclude_ids: set[int] | None = None) -> tuple[str, list]:
+def eligibility_clause(days: int | None, exclude_ids: set[int] | None = None) -> tuple[str, list]:
     """WHERE clause (+ params) for "sessions still needing tool_content backfill".
 
     Single source of truth for the one-time eligible count and the per-batch
@@ -388,12 +388,12 @@ def _eligibility_clause(days: int | None, exclude_ids: set[int] | None = None) -
     return where, params
 
 
-def _count_eligible(cursor: sqlite3.Cursor, days: int | None) -> int:
-    where, params = _eligibility_clause(days)
+def count_eligible(cursor: sqlite3.Cursor, days: int | None) -> int:
+    where, params = eligibility_clause(days)
     return cursor.execute(f"SELECT COUNT(DISTINCT s.id) {_ELIGIBILITY_FROM} {where}", params).fetchone()[0]
 
 
-def _count_total_sessions(cursor: sqlite3.Cursor, days: int | None) -> int:
+def count_total_sessions(cursor: sqlite3.Cursor, days: int | None) -> int:
     """Count every session with messages (the backfill's universe), for --status."""
     where = "WHERE 1=1"
     params: list = []
@@ -403,16 +403,16 @@ def _count_total_sessions(cursor: sqlite3.Cursor, days: int | None) -> int:
     return cursor.execute(f"SELECT COUNT(DISTINCT s.id) {_ELIGIBILITY_FROM} {where}", params).fetchone()[0]
 
 
-def _select_batch(cursor: sqlite3.Cursor, exclude_ids: set[int], days: int | None) -> list[tuple[int, str]]:
+def select_batch(cursor: sqlite3.Cursor, exclude_ids: set[int], days: int | None) -> list[tuple[int, str]]:
     """Return up to BATCH_SIZE (session_id, session_uuid) pairs still needing
     tool_content backfill, oldest session id first."""
-    where, params = _eligibility_clause(days, exclude_ids)
+    where, params = eligibility_clause(days, exclude_ids)
     query = f"SELECT DISTINCT s.id, s.uuid {_ELIGIBILITY_FROM} {where} ORDER BY s.id LIMIT ?"
     params = [*params, BATCH_SIZE]
     return cursor.execute(query, params).fetchall()
 
 
-def _backfill_session(cursor: sqlite3.Cursor, session_id: int, filepaths: list[Path]) -> bool:
+def backfill_session(cursor: sqlite3.Cursor, session_id: int, filepaths: list[Path]) -> bool:
     """Re-parse one session's JSONL file(s) and backfill tool_content.
 
     A session may be backed by multiple files (parent + subagent transcripts);
@@ -518,7 +518,7 @@ def _backfill_session(cursor: sqlite3.Cursor, session_id: int, filepaths: list[P
     return True
 
 
-def _run_status(
+def run_status(
     *,
     days: int | None,
     json_mode: bool,
@@ -529,8 +529,8 @@ def _run_status(
     try:
         with get_connection(settings, load_vec=False) as conn:
             cursor = conn.cursor()
-            pending = _count_eligible(cursor, days)
-            total = _count_total_sessions(cursor, days)
+            pending = count_eligible(cursor, days)
+            total = count_total_sessions(cursor, days)
     except (sqlite3.Error, OSError) as e:
         logger.exception("%s: status aborted", _LOG_PREFIX)
         print(f"{_PRINT_PREFIX}: aborted: {e}", file=sys.stderr)

--- a/src/ccrecall/hooks/backfill_tool_content.py
+++ b/src/ccrecall/hooks/backfill_tool_content.py
@@ -57,7 +57,7 @@ from pathlib import Path
 
 from ccrecall.config import load_settings, setup_logging
 from ccrecall.content import extract_text_content
-from ccrecall.db import get_connection
+from ccrecall.db import VEC_BUSY_TIMEOUT_MS, get_connection
 from ccrecall.hooks.backfill_query import (
     BACKFILL_BATCH_DELAY_SECONDS,
     BACKFILL_NICE_LEVEL,
@@ -81,6 +81,8 @@ _PRINT_PREFIX = "ccrecall backfill tool-content"
 _LOG_PREFIX = "Backfill tool-content"
 _SAVEPOINT_NAME = "session"
 _MAX_SQL_PARAMS = 900
+_LOCK_RETRIES = 3
+_LOCK_BACKOFF_SECONDS = 2.0
 
 
 @contextlib.contextmanager
@@ -94,6 +96,41 @@ def _savepoint(cursor: sqlite3.Cursor):
         cursor.execute(f"RELEASE SAVEPOINT {_SAVEPOINT_NAME}")
         raise
     cursor.execute(f"RELEASE SAVEPOINT {_SAVEPOINT_NAME}")
+
+
+class _LockExhaustedError(Exception):
+    """Raised when all retry attempts for a transient DB lock are exhausted."""
+
+
+def _backfill_with_retry(
+    cursor: sqlite3.Cursor,
+    session_id: int,
+    session_uuid: str,
+    filepaths: list[Path],
+    logger: logging.Logger,
+) -> bool:
+    """Run _backfill_session with bounded retry on transient DB locks.
+
+    Returns the result of _backfill_session on success. Raises _LockExhaustedError
+    if all retries are exhausted. Other exceptions (OSError, content errors)
+    propagate unchanged.
+    """
+    for attempt in range(_LOCK_RETRIES):
+        try:
+            with _savepoint(cursor):
+                return _backfill_session(cursor, session_id, filepaths)
+        except sqlite3.OperationalError as exc:
+            logger.warning(
+                "%s: session %s transient DB error (attempt %s/%s): %s",
+                _LOG_PREFIX,
+                session_uuid,
+                attempt + 1,
+                _LOCK_RETRIES,
+                exc,
+            )
+            if attempt < _LOCK_RETRIES - 1:
+                time.sleep(_LOCK_BACKOFF_SECONDS * (attempt + 1))
+    raise _LockExhaustedError(session_uuid)
 
 
 # Shared FROM clause for every "sessions needing tool_content backfill" query
@@ -136,6 +173,7 @@ def run(
     skipped_missing = 0
     skipped_empty = 0
     skipped_content_error = 0
+    skipped_db_lock = 0
     last_progress = 0
     last_batch_ids: list[int] | None = None
     exclude_ids: set[int] = set()
@@ -143,6 +181,10 @@ def run(
 
     try:
         with get_connection(settings, load_vec=False) as conn:
+            # Raise busy_timeout: this backfill contends with the sync hook the
+            # same way vec writers do. Reuses VEC_BUSY_TIMEOUT_MS (30s) rather
+            # than the base 5s that load_vec=False connections get.
+            conn.execute(f"PRAGMA busy_timeout = {VEC_BUSY_TIMEOUT_MS}")
             cursor = conn.cursor()
 
             filepath_by_uuid = _build_filepath_index(cursor, logger)
@@ -164,16 +206,13 @@ def run(
 
                 current_ids = [r[0] for r in rows]
                 if current_ids == last_batch_ids:
-                    logger.error(
-                        "%s: no progress — same batch re-selected (session ids: %s); aborting",
+                    logger.warning(
+                        "%s: same batch re-selected (session ids: %s); excluding and continuing",
                         _LOG_PREFIX,
                         current_ids,
                     )
-                    print(
-                        f"{_PRINT_PREFIX}: no progress — same batch re-selected (session ids: {current_ids}), aborting",
-                        file=sys.stderr,
-                    )
-                    return EXIT_ABORT
+                    exclude_ids.update(current_ids)
+                    continue
                 last_batch_ids = current_ids
 
                 try:
@@ -189,8 +228,18 @@ def run(
                             continue
 
                         try:
-                            with _savepoint(cursor):
-                                made_change = _backfill_session(cursor, session_id, filepaths)
+                            made_change = _backfill_with_retry(cursor, session_id, session_uuid, filepaths, logger)
+                        except _LockExhaustedError:
+                            logger.warning(
+                                "%s: session %s (id=%s) DB lock persisted after %s retries, skipping",
+                                _LOG_PREFIX,
+                                session_uuid,
+                                session_id,
+                                _LOCK_RETRIES,
+                            )
+                            skipped_db_lock += 1
+                            exclude_ids.add(session_id)
+                            continue
                         except OSError:
                             logger.warning("%s: session %s JSONL vanished mid-run, skipping", _LOG_PREFIX, session_uuid)
                             skipped_missing += 1
@@ -254,12 +303,14 @@ def run(
     elapsed = time.monotonic() - started
     logger.info(
         "%s complete: %s sessions backfilled, %s skipped (missing JSONL), "
-        "%s skipped (no usable branch), %s skipped (content error) in %s",
+        "%s skipped (no usable branch), %s skipped (content error), "
+        "%s skipped (DB lock) in %s",
         _LOG_PREFIX,
         total_updated,
         skipped_missing,
         skipped_empty,
         skipped_content_error,
+        skipped_db_lock,
         format_duration(elapsed),
     )
     if json_mode:
@@ -271,6 +322,7 @@ def run(
                     "skipped_missing": skipped_missing,
                     "skipped_empty": skipped_empty,
                     "skipped_content_error": skipped_content_error,
+                    "skipped_db_lock": skipped_db_lock,
                     "elapsed_seconds": round(elapsed, 1),
                 }
             )
@@ -279,7 +331,8 @@ def run(
         print(
             f"{_PRINT_PREFIX}: complete — {total_updated} sessions backfilled, "
             f"{skipped_missing} skipped (missing JSONL), {skipped_empty} skipped (no usable branch), "
-            f"{skipped_content_error} skipped (content error) in {format_duration(elapsed)}",
+            f"{skipped_content_error} skipped (content error), "
+            f"{skipped_db_lock} skipped (DB lock) in {format_duration(elapsed)}",
             file=sys.stderr,
         )
     return EXIT_OK

--- a/src/ccrecall/hooks/context_alerts.py
+++ b/src/ccrecall/hooks/context_alerts.py
@@ -87,7 +87,7 @@ def proactive_alert_block(
             # (the mapping lives in health.py beside the REASON_* constants).
             embedding_reason = embedding_status.get("reason", "")
 
-        if conn is not None and _has_backfillable_tool_content(conn):
+        if conn is not None and has_backfillable_tool_content(conn):
             active_keys.add(ALERT_TOOL_CONTENT_INCOMPLETE)
 
         # 5. Evaluate snooze ledger: fire / suppress / auto-clear.
@@ -115,7 +115,7 @@ def proactive_alert_block(
         return ""
 
 
-def _has_backfillable_tool_content(conn: sqlite3.Connection) -> bool:
+def has_backfillable_tool_content(conn: sqlite3.Connection) -> bool:
     """Check if there are sessions with NULL tool_content whose JSONL still exists.
 
     Two-phase cheap check for the hot path:
@@ -125,6 +125,14 @@ def _has_backfillable_tool_content(conn: sqlite3.Connection) -> bool:
 
     Returns False for fresh installs (no NULL-tool_content sessions) and for
     databases where all remaining NULL sessions have lost their JSONL on disk.
+
+    A completed `ccrecall backfill tool-content` run now guarantees quiescence
+    for every session it processes (backfill_session unconditionally stamps
+    any remaining NULL rows to '' before returning True — issue #81 Fix 1), so
+    this predicate no longer fires forever on a stuck session. The only
+    residual firing case is a session whose JSONL file still exists on disk
+    but re-parses to no usable entries/branch (backfill_session returns False,
+    a genuine no-op that leaves the row NULL).
     """
     rows = conn.execute(
         """SELECT DISTINCT s.uuid

--- a/src/ccrecall/hooks/context_alerts.py
+++ b/src/ccrecall/hooks/context_alerts.py
@@ -1,9 +1,9 @@
 """Proactive health-alert block builder for the SessionStart context hook.
 
-Evaluates the filesystem-writability probe, the embedding-status sidecar, and
-the DB write-lock probe, then builds a single combined alert block for
-whatever fires. Split out of memory_context.py so the alert-evaluation
-concern has its own module.
+Evaluates the filesystem-writability probe, the embedding-status sidecar, the
+DB write-lock probe, and the tool-content backfill coverage check, then builds
+a single combined alert block for whatever fires. Split out of
+memory_context.py so the alert-evaluation concern has its own module.
 """
 
 import logging
@@ -14,6 +14,7 @@ from ccrecall.config import DEFAULT_SETTINGS
 from ccrecall.health import (
     ALERT_CANT_PERSIST,
     ALERT_EMBEDDINGS_FAILING,
+    ALERT_TOOL_CONTENT_INCOMPLETE,
     build_alert_block,
     evaluate_alerts,
     probe_db,
@@ -21,6 +22,8 @@ from ccrecall.health import (
     read_embedding_status,
 )
 from ccrecall.models import LOGGER_NAME
+
+_TOOL_CONTENT_SAMPLE_SIZE = 5
 
 
 def proactive_alert_block(
@@ -84,6 +87,9 @@ def proactive_alert_block(
             # (the mapping lives in health.py beside the REASON_* constants).
             embedding_reason = embedding_status.get("reason", "")
 
+        if conn is not None and _has_backfillable_tool_content(conn):
+            active_keys.add(ALERT_TOOL_CONTENT_INCOMPLETE)
+
         # 5. Evaluate snooze ledger: fire / suppress / auto-clear.
         # load_settings() always carries alert_snooze_hours from DEFAULT_SETTINGS;
         # fall back to the canonical default only for sparse (test) settings dicts.
@@ -107,3 +113,38 @@ def proactive_alert_block(
         # logging_enabled) so the failure isn't silently lost.
         logging.getLogger(LOGGER_NAME).exception("proactive alert block failed")
         return ""
+
+
+def _has_backfillable_tool_content(conn: sqlite3.Connection) -> bool:
+    """Check if there are sessions with NULL tool_content whose JSONL still exists.
+
+    Two-phase cheap check for the hot path:
+    1. SQL: sample a few session UUIDs with tool_content IS NULL.
+    2. For each, LIKE-match import_log for a file containing that UUID and
+       check Path.exists() — caps at _TOOL_CONTENT_SAMPLE_SIZE queries + stat calls.
+
+    Returns False for fresh installs (no NULL-tool_content sessions) and for
+    databases where all remaining NULL sessions have lost their JSONL on disk.
+    """
+    rows = conn.execute(
+        """SELECT DISTINCT s.uuid
+           FROM sessions s
+           JOIN messages m ON m.session_id = s.id
+           JOIN branches b ON b.session_id = s.id AND b.is_active = 1
+           WHERE m.tool_content IS NULL
+           LIMIT ?""",
+        (_TOOL_CONTENT_SAMPLE_SIZE,),
+    ).fetchall()
+    if not rows:
+        return False
+
+    for (uuid,) in rows:
+        # Mirrors the agent- prefix convention in parsing.extract_session_uuid.
+        file_rows = conn.execute(
+            "SELECT file_path FROM import_log WHERE file_path LIKE ? OR file_path LIKE ?",
+            (f"%/{uuid}.jsonl", f"%/agent-{uuid}.jsonl"),
+        ).fetchall()
+        if any(Path(r[0]).exists() for r in file_rows):
+            return True
+
+    return False

--- a/src/ccrecall/hooks/context_alerts.py
+++ b/src/ccrecall/hooks/context_alerts.py
@@ -21,6 +21,7 @@ from ccrecall.health import (
     probe_filesystem,
     read_embedding_status,
 )
+from ccrecall.hooks.tool_content_eligibility import eligibility_clause
 from ccrecall.models import LOGGER_NAME
 
 _TOOL_CONTENT_SAMPLE_SIZE = 5
@@ -119,9 +120,16 @@ def has_backfillable_tool_content(conn: sqlite3.Connection) -> bool:
     """Check if there are sessions with NULL tool_content whose JSONL still exists.
 
     Two-phase cheap check for the hot path:
-    1. SQL: sample a few session UUIDs with tool_content IS NULL.
-    2. For each, LIKE-match import_log for a file containing that UUID and
-       check Path.exists() — caps at _TOOL_CONTENT_SAMPLE_SIZE queries + stat calls.
+    1. SQL: sample a few session UUIDs still eligible for tool_content backfill
+       (eligibility_clause is tool_content_eligibility's single source of truth
+       for this predicate, shared with backfill_tool_content.py so the two
+       can't drift — imported from that dependency-free module, not from
+       backfill_tool_content.py itself, so this hot-path hook never pulls in
+       ccrecall.db's fastembed/onnxruntime import chain).
+    2. One batched LIKE query across all sampled uuids against import_log,
+       then Path.exists() — caps at _TOOL_CONTENT_SAMPLE_SIZE session lookups
+       but only ONE query against import_log (leading-wildcard LIKE is
+       unindexable, so a per-uuid query would mean N full scans on the hot path).
 
     Returns False for fresh installs (no NULL-tool_content sessions) and for
     databases where all remaining NULL sessions have lost their JSONL on disk.
@@ -134,25 +142,23 @@ def has_backfillable_tool_content(conn: sqlite3.Connection) -> bool:
     but re-parses to no usable entries/branch (backfill_session returns False,
     a genuine no-op that leaves the row NULL).
     """
+    where, params = eligibility_clause(days=None)
     rows = conn.execute(
-        """SELECT DISTINCT s.uuid
+        f"""SELECT DISTINCT s.uuid
            FROM sessions s
            JOIN messages m ON m.session_id = s.id
            JOIN branches b ON b.session_id = s.id AND b.is_active = 1
-           WHERE m.tool_content IS NULL
+           {where}
            LIMIT ?""",
-        (_TOOL_CONTENT_SAMPLE_SIZE,),
+        (*params, _TOOL_CONTENT_SAMPLE_SIZE),
     ).fetchall()
     if not rows:
         return False
 
-    for (uuid,) in rows:
-        # Mirrors the agent- prefix convention in parsing.extract_session_uuid.
-        file_rows = conn.execute(
-            "SELECT file_path FROM import_log WHERE file_path LIKE ? OR file_path LIKE ?",
-            (f"%/{uuid}.jsonl", f"%/agent-{uuid}.jsonl"),
-        ).fetchall()
-        if any(Path(r[0]).exists() for r in file_rows):
-            return True
-
-    return False
+    # Mirrors the agent- prefix convention in parsing.extract_session_uuid.
+    # One scan for every sampled uuid: the leading-wildcard LIKE is unindexable,
+    # so a per-uuid query would mean N full scans of import_log on the hot path.
+    patterns = [p for (uuid,) in rows for p in (f"%/{uuid}.jsonl", f"%/agent-{uuid}.jsonl")]
+    clause = " OR ".join(["file_path LIKE ?"] * len(patterns))
+    file_rows = conn.execute(f"SELECT file_path FROM import_log WHERE {clause}", patterns).fetchall()
+    return any(Path(file_path).exists() for (file_path,) in file_rows)

--- a/src/ccrecall/hooks/memory_setup.py
+++ b/src/ccrecall/hooks/memory_setup.py
@@ -45,7 +45,7 @@ def _spawn_background(argv: list[str], pid_key: str) -> None:
         try:
             # Atomic create — fails with FileExistsError if file already exists
             fd = os.open(str(pid_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, PID_FILE_MODE)
-        except FileExistsError:
+        except FileExistsError:  # noqa: PERF203 — PID-file liveness/retry loop; the try/except IS the mechanism, not incidental control flow
             # File exists — check if the owning process is alive
             try:
                 existing_pid = int(pid_path.read_text().strip())

--- a/src/ccrecall/hooks/memory_setup.py
+++ b/src/ccrecall/hooks/memory_setup.py
@@ -124,9 +124,6 @@ def _reap_stale_temp_files() -> None:
 
 
 def main():
-    # Initialized before the try so the output block below always runs, even if
-    # the body raises — the hook must print a valid response, never crash start.
-    additional_context: str | None = None
     try:
         ensure_parent_dir(DEFAULT_DB_PATH)
 
@@ -159,13 +156,7 @@ def main():
         # best-effort (no-op unless logging_enabled) so the failure isn't silent.
         log_hook_exception("setup")
 
-    output: dict = {"continue": True}
-    if additional_context is not None:
-        output["hookSpecificOutput"] = {
-            "hookEventName": "SessionStart",
-            "additionalContext": additional_context,
-        }
-    print(json.dumps(output))
+    print(json.dumps({"continue": True}))
 
 
 if __name__ == "__main__":

--- a/src/ccrecall/hooks/memory_setup.py
+++ b/src/ccrecall/hooks/memory_setup.py
@@ -45,7 +45,7 @@ def _spawn_background(argv: list[str], pid_key: str) -> None:
         try:
             # Atomic create — fails with FileExistsError if file already exists
             fd = os.open(str(pid_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, PID_FILE_MODE)
-        except FileExistsError:  # noqa: PERF203 — the try/except IS the retry mechanism for atomic PID-file creation
+        except FileExistsError:
             # File exists — check if the owning process is alive
             try:
                 existing_pid = int(pid_path.read_text().strip())

--- a/src/ccrecall/hooks/sync_current.py
+++ b/src/ccrecall/hooks/sync_current.py
@@ -135,7 +135,7 @@ def run(input_file: Path | None = None) -> None:
         try:
             # Atomic create — fails with FileExistsError if file already exists
             lock_fd = os.open(str(pid_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, PID_FILE_MODE)
-        except FileExistsError:  # noqa: PERF203 — try/except IS the retry mechanism
+        except FileExistsError:
             try:
                 existing_pid = int(pid_path.read_text().strip())
                 os.kill(existing_pid, 0)  # signal 0: liveness probe, no signal sent

--- a/src/ccrecall/hooks/sync_current.py
+++ b/src/ccrecall/hooks/sync_current.py
@@ -135,7 +135,7 @@ def run(input_file: Path | None = None) -> None:
         try:
             # Atomic create — fails with FileExistsError if file already exists
             lock_fd = os.open(str(pid_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, PID_FILE_MODE)
-        except FileExistsError:
+        except FileExistsError:  # noqa: PERF203 — PID-file liveness/retry loop; the try/except IS the mechanism, not incidental control flow
             try:
                 existing_pid = int(pid_path.read_text().strip())
                 os.kill(existing_pid, 0)  # signal 0: liveness probe, no signal sent

--- a/src/ccrecall/hooks/sync_current.py
+++ b/src/ccrecall/hooks/sync_current.py
@@ -235,8 +235,8 @@ def run(input_file: Path | None = None) -> None:
                 # detected authoritatively by backfill_embeddings instead.
                 # Both calls are best-effort: a sidecar write failure must never affect
                 # the hook's output or exit behavior.
-                _vec_ok = chunk_vec_queryable(conn)
-                if not _vec_ok:
+                vec_ok = chunk_vec_queryable(conn)
+                if not vec_ok:
                     with contextlib.suppress(Exception):  # best-effort; must not affect hook behavior
                         record_embedding_failure(reason=REASON_VEC_UNAVAILABLE)
 
@@ -253,7 +253,7 @@ def run(input_file: Path | None = None) -> None:
             # Clear the embedding failure sidecar on a clean sync pass.
             # Only when vec was available — if it wasn't, we already recorded above
             # and must not clear until the next run where embedding can actually run.
-            if _vec_ok:
+            if vec_ok:
                 with contextlib.suppress(Exception):  # best-effort; must not affect hook behavior
                     clear_embedding_failure()
 

--- a/src/ccrecall/hooks/tool_content_eligibility.py
+++ b/src/ccrecall/hooks/tool_content_eligibility.py
@@ -1,0 +1,71 @@
+"""Shared "still needs tool_content backfill" predicate.
+
+Single source of truth for the eligibility predicate used by both
+backfill_tool_content.py (the actual backfill CLI: count_eligible,
+select_batch, count_total_sessions) and context_alerts.py (the SessionStart
+proactive-alert sampling check), so the two can't drift.
+
+Deliberately dependency-free (no ccrecall.db / ccrecall.embeddings) — safe to
+import on the SessionStart hot path. context_alerts.py imports
+eligibility_clause directly; importing it from backfill_tool_content.py
+instead would drag in that module's ccrecall.db import chain (which reaches
+fastembed/onnxruntime via ccrecall.embeddings), violating the hot-path
+invariant documented in this repo's CLAUDE.md.
+
+days_modifier lives here too (rather than backfill_query.py, which has heavy
+imports) since it's dependency-free and eligibility_clause needs it;
+backfill_query.py imports it back for its own --days handling so the
+chunk-embedding and tool-content domains still share one recency-bound
+formatter without either pulling in the other's heavy deps.
+"""
+
+# SQLite's default bound-parameter limit is 999; leave headroom.
+MAX_SQL_PARAMS = 900
+
+# Shared FROM clause for every "sessions needing tool_content backfill" query
+# (the eligible-count, the per-batch selection, --status, and the SessionStart
+# sampling check) so the join shape can't drift between them.
+ELIGIBILITY_FROM = """
+    FROM messages m
+    JOIN sessions s ON s.id = m.session_id
+    JOIN branches b ON b.session_id = s.id AND b.is_active = 1
+"""
+
+
+def days_modifier(days: int) -> str:
+    """SQLite datetime() modifier for an N-day lookback (days=7 -> '-7 days').
+
+    Single source of truth for the --days recency bound so build_selection()
+    (chunk-embedding eligibility), eligibility_clause() (tool-content
+    eligibility), and count_status() (progress) can't construct it differently.
+    """
+    return f"-{days} days"
+
+
+def eligibility_clause(days: int | None, exclude_ids: set[int] | None = None) -> tuple[str, list]:
+    """WHERE clause (+ params) for "sessions still needing tool_content backfill".
+
+    Single source of truth for the one-time eligible count, the per-batch
+    selection query, and the SessionStart sampling check, mirroring
+    backfill_query.build_selection's pattern so none of them can drift.
+    ``exclude_ids`` removes sessions this run already attempted (succeeded,
+    errored, or had no on-disk file) so a stalled session can't force the
+    no-progress guard to fire on every batch.
+
+    The NOT IN clause is chunked to stay under SQLite's bound-parameter limit.
+    """
+    where = "WHERE m.tool_content IS NULL"
+    params: list = []
+    if exclude_ids:
+        ids = sorted(exclude_ids)
+        not_in_parts: list[str] = []
+        for i in range(0, len(ids), MAX_SQL_PARAMS):
+            chunk = ids[i : i + MAX_SQL_PARAMS]
+            placeholders = ",".join("?" * len(chunk))
+            not_in_parts.append(f"s.id NOT IN ({placeholders})")
+            params.extend(chunk)
+        where += " AND " + " AND ".join(not_in_parts)
+    if days is not None:
+        where += " AND b.ended_at > datetime('now', ?)"
+        params.append(days_modifier(days))
+    return where, params

--- a/src/ccrecall/schema.py
+++ b/src/ccrecall/schema.py
@@ -79,6 +79,7 @@ CREATE TABLE IF NOT EXISTS messages (
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id);
 CREATE INDEX IF NOT EXISTS idx_messages_timestamp ON messages(timestamp);
 CREATE INDEX IF NOT EXISTS idx_messages_session_uuid ON messages(session_id, uuid);
+CREATE INDEX IF NOT EXISTS idx_messages_tool_content_null ON messages(session_id) WHERE tool_content IS NULL;
 
 -- Branch-messages mapping (many-to-many)
 CREATE TABLE IF NOT EXISTS branch_messages (

--- a/tests/test_backfill_embeddings.py
+++ b/tests/test_backfill_embeddings.py
@@ -206,7 +206,7 @@ def _run_backfill_with_stub(conn: sqlite3.Connection, *, days=None, limit=None):
     """Run run() with embed_text stubbed via session_ops to _FIXED_VEC."""
     with (
         patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
-        patch("ccrecall.embed_ops.embed_text", return_value=_FIXED_VEC),
+        patch("ccrecall.embed_ops.embed_batch", side_effect=lambda texts: [_FIXED_VEC] * len(texts)),
         patch(
             "ccrecall.hooks.backfill_embeddings.get_connection",
             return_value=_NoCloseConn(conn),
@@ -252,7 +252,7 @@ class TestBackfillEmbedsFull:
         exit_code = None
         with (
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
-            patch("ccrecall.embed_ops.embed_text", return_value=_FIXED_VEC),
+            patch("ccrecall.embed_ops.embed_batch", side_effect=lambda texts: [_FIXED_VEC] * len(texts)),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
             patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
             patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
@@ -336,14 +336,14 @@ class TestBackfillResume:
 
         call_count = [0]
 
-        def counting_embed(text: str) -> list[float]:
-            call_count[0] += 1
-            return _FIXED_VEC[:]
+        def counting_embed(texts: list[str]) -> list[list[float]]:
+            call_count[0] += len(texts)
+            return [_FIXED_VEC[:]] * len(texts)
 
         def _run_counting(conn):
             with (
                 patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
-                patch("ccrecall.embed_ops.embed_text", side_effect=counting_embed),
+                patch("ccrecall.embed_ops.embed_batch", side_effect=counting_embed),
                 patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
                 patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
                 patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
@@ -545,15 +545,15 @@ class TestBackfillFailureModes:
         # Raise on the second call (bad_id was inserted second)
         call_no = [0]
 
-        def counting_embed(text: str) -> list[float]:
+        def counting_embed(texts: list[str]) -> list[list[float]]:
             call_no[0] += 1
             if call_no[0] == 2:  # second branch's embed raises
                 raise ValueError("simulated tokenizer overflow")
-            return _FIXED_VEC
+            return [_FIXED_VEC] * len(texts)
 
         with (
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
-            patch("ccrecall.embed_ops.embed_text", side_effect=counting_embed),
+            patch("ccrecall.embed_ops.embed_batch", side_effect=counting_embed),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
             patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
             patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
@@ -575,12 +575,12 @@ class TestBackfillFailureModes:
         conn = make_vec_conn()
         ids = [_insert_branch_with_messages(conn) for _ in range(3)]
 
-        def infra_fail(text: str) -> list[float]:
+        def infra_fail(texts: list[str]) -> list[list[float]]:
             raise RuntimeError("ONNX session crashed")
 
         with (
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
-            patch("ccrecall.embed_ops.embed_text", side_effect=infra_fail),
+            patch("ccrecall.embed_ops.embed_batch", side_effect=infra_fail),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
             patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
             patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
@@ -601,13 +601,13 @@ class TestBackfillFailureModes:
 
         call_count = [0]
 
-        def counting_embed(text: str) -> list[float]:
-            call_count[0] += 1
-            return _FIXED_VEC
+        def counting_embed(texts: list[str]) -> list[list[float]]:
+            call_count[0] += len(texts)
+            return [_FIXED_VEC] * len(texts)
 
         with (
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
-            patch("ccrecall.embed_ops.embed_text", side_effect=counting_embed),
+            patch("ccrecall.embed_ops.embed_batch", side_effect=counting_embed),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
             patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
             patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
@@ -864,7 +864,7 @@ class TestBackfillInferencesCounter:
 
         with (
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
-            patch("ccrecall.embed_ops.embed_text", return_value=_FIXED_VEC),
+            patch("ccrecall.embed_ops.embed_batch", side_effect=lambda texts: [_FIXED_VEC] * len(texts)),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
             patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
             patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
@@ -946,7 +946,7 @@ class TestBackfillEmbeddingStatusRecording:
 
         with (
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
-            patch("ccrecall.embed_ops.embed_text", return_value=_FIXED_VEC),
+            patch("ccrecall.embed_ops.embed_batch", side_effect=lambda texts: [_FIXED_VEC] * len(texts)),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
             patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
             patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
@@ -985,3 +985,54 @@ class TestBackfillEmbeddingStatusRecording:
         assert record_calls == [], (
             f"run_status() (--status path) must never call record_embedding_failure; got calls: {record_calls}"
         )
+
+
+class TestBackfillETAProgress:
+    """#84: ETA uses message-proportional work units and windowed rate."""
+
+    def test_progress_shows_warming_up_for_initial_branches(self, capsys):
+        """During the first few branches, ETA shows 'warming up' instead of
+        a misleading extrapolation from warm-up throughput."""
+        conn = make_vec_conn()
+        # Create 3 branches — below the warmup threshold
+        for _ in range(3):
+            _insert_branch_with_messages(conn, num_exchanges=2)
+
+        with (
+            patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
+            patch("ccrecall.embed_ops.embed_batch", side_effect=lambda texts: [_FIXED_VEC] * len(texts)),
+            patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
+            patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
+            patch("ccrecall.hooks.backfill_embeddings.clear_embedding_failure"),
+        ):
+            code = run(progress_every=1)
+
+        assert code == EXIT_OK
+        captured = capsys.readouterr()
+        # First progress lines should say "warming up" since < _WARMUP_BRANCHES
+        lines = [line for line in captured.err.splitlines() if "ETA" in line]
+        assert any("warming up" in line for line in lines)
+
+    def test_progress_shows_numeric_eta_after_warmup(self, capsys):
+        """After enough branches, ETA switches from 'warming up' to a numeric estimate."""
+        conn = make_vec_conn()
+        for _ in range(10):
+            _insert_branch_with_messages(conn, num_exchanges=2)
+
+        with (
+            patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
+            patch("ccrecall.embed_ops.embed_batch", side_effect=lambda texts: [_FIXED_VEC] * len(texts)),
+            patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
+            patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
+            patch("ccrecall.hooks.backfill_embeddings.clear_embedding_failure"),
+        ):
+            code = run(progress_every=1)
+
+        assert code == EXIT_OK
+        captured = capsys.readouterr()
+        lines = [line for line in captured.err.splitlines() if "ETA" in line]
+        # After warmup, at least some lines should have a numeric ETA (not "warming up")
+        numeric_eta_lines = [line for line in lines if "warming up" not in line]
+        assert len(numeric_eta_lines) > 0

--- a/tests/test_backfill_embeddings.py
+++ b/tests/test_backfill_embeddings.py
@@ -1036,3 +1036,33 @@ class TestBackfillETAProgress:
         # After warmup, at least some lines should have a numeric ETA (not "warming up")
         numeric_eta_lines = [line for line in lines if "warming up" not in line]
         assert len(numeric_eta_lines) > 0
+
+    def test_progress_reported_despite_all_content_errors(self, capsys):
+        """A run where every branch hits a content error still emits progress
+        lines, because the gate counts branches processed (success or
+        content-error), not total_updated (successes only)."""
+        conn = make_vec_conn()
+        ids = [_insert_branch_with_messages(conn, num_exchanges=2) for _ in range(3)]
+
+        def always_fail(texts: list[str]) -> list[list[float]]:
+            raise ValueError("simulated tokenizer overflow")
+
+        with (
+            patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
+            patch("ccrecall.embed_ops.embed_batch", side_effect=always_fail),
+            patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
+            patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
+            patch("ccrecall.hooks.backfill_embeddings.clear_embedding_failure"),
+        ):
+            code = run(progress_every=1)
+
+        assert code == EXIT_OK
+        # Every branch content-errored — total_updated (successes) stayed 0.
+        for bid in ids:
+            assert _branch_embedding_version(conn, bid) == CONTENT_ERROR_VERSION
+        assert _chunk_count(conn) == 0
+
+        captured = capsys.readouterr()
+        eta_lines = [line for line in captured.err.splitlines() if "ETA" in line]
+        assert len(eta_lines) > 0, "progress line should print even though every branch content-errored"

--- a/tests/test_backfill_tool_content.py
+++ b/tests/test_backfill_tool_content.py
@@ -18,7 +18,7 @@ from conftest import make_jsonl_entry as _entry
 from conftest import write_jsonl as _write_jsonl
 
 from ccrecall.hooks.backfill_query import BATCH_SIZE, EXIT_OK
-from ccrecall.hooks.backfill_tool_content import _backfill_session, _select_batch, run
+from ccrecall.hooks.backfill_tool_content import backfill_session, run, select_batch
 from ccrecall.schema import SCHEMA
 
 pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
@@ -687,7 +687,7 @@ class TestTransientDbLock:
             existing_messages=[("u1", "user", "hello", "2026-01-01T10:00:00Z")],
         )
 
-        real_backfill = _backfill_session
+        real_backfill = backfill_session
         call_count = 0
 
         def _bombing_backfill(cursor, session_id, filepaths):
@@ -701,7 +701,7 @@ class TestTransientDbLock:
             patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
             patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
             patch("ccrecall.hooks.backfill_tool_content.time.sleep"),
-            patch("ccrecall.hooks.backfill_tool_content._backfill_session", side_effect=_bombing_backfill),
+            patch("ccrecall.hooks.backfill_tool_content.backfill_session", side_effect=_bombing_backfill),
         ):
             code = run()
 
@@ -747,13 +747,13 @@ class TestTransientDbLock:
             attempt_count += 1
             if attempt_count == 1:
                 raise sqlite3.OperationalError("database is locked")
-            return _backfill_session(cursor, session_id, filepaths)
+            return backfill_session(cursor, session_id, filepaths)
 
         with (
             patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
             patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
             patch("ccrecall.hooks.backfill_tool_content.time.sleep"),
-            patch("ccrecall.hooks.backfill_tool_content._backfill_session", side_effect=_flaky_backfill),
+            patch("ccrecall.hooks.backfill_tool_content.backfill_session", side_effect=_flaky_backfill),
         ):
             code = run()
 
@@ -794,19 +794,19 @@ class TestStuckSessionExclusion:
             batch_call += 1
             if batch_call <= 2 and stuck_sid not in exclude_ids:
                 return [(stuck_sid, stuck_path.stem)]
-            return _select_batch(cursor, exclude_ids, days)
+            return select_batch(cursor, exclude_ids, days)
 
         def _noop_backfill(cursor, session_id, filepaths):
             if session_id == stuck_sid:
                 return False
-            return _backfill_session(cursor, session_id, filepaths)
+            return backfill_session(cursor, session_id, filepaths)
 
         with (
             patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
             patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
             patch("ccrecall.hooks.backfill_tool_content.time.sleep"),
-            patch("ccrecall.hooks.backfill_tool_content._select_batch", side_effect=_rigged_select),
-            patch("ccrecall.hooks.backfill_tool_content._backfill_session", side_effect=_noop_backfill),
+            patch("ccrecall.hooks.backfill_tool_content.select_batch", side_effect=_rigged_select),
+            patch("ccrecall.hooks.backfill_tool_content.backfill_session", side_effect=_noop_backfill),
         ):
             code = run()
 

--- a/tests/test_backfill_tool_content.py
+++ b/tests/test_backfill_tool_content.py
@@ -662,3 +662,164 @@ class TestBackfillMultiFile:
         ).fetchone()
         assert a2_row is not None, "INSERT pass must run even when leaf_uuid mismatches"
         assert "[Read: /tmp/x]" in a2_row[0]
+
+
+class TestTransientDbLock:
+    """#81: transient sqlite3.OperationalError no longer aborts the entire run."""
+
+    def test_operational_error_retries_and_skips_session(self, tmp_path):
+        """A transient DB lock on one session retries, then skips that session
+        and continues processing the rest of the batch."""
+        good_path = tmp_path / "sess-good.jsonl"
+        bad_path = tmp_path / "sess-bad.jsonl"
+        _write_jsonl(good_path, [_entry("u1", None, "2026-01-01T10:00:00Z", "user", "hello")])
+        _write_jsonl(bad_path, [_entry("u2", None, "2026-01-01T10:00:00Z", "user", "world")])
+
+        conn = _make_conn()
+        _seed_session(
+            conn,
+            filepath=bad_path,
+            existing_messages=[("u2", "user", "world", "2026-01-01T10:00:00Z")],
+        )
+        _seed_session(
+            conn,
+            filepath=good_path,
+            existing_messages=[("u1", "user", "hello", "2026-01-01T10:00:00Z")],
+        )
+
+        from ccrecall.hooks.backfill_tool_content import _backfill_session
+
+        real_backfill = _backfill_session
+        call_count = 0
+
+        def _bombing_backfill(cursor, session_id, filepaths):
+            nonlocal call_count
+            if session_id == 1:
+                call_count += 1
+                raise sqlite3.OperationalError("database is locked")
+            return real_backfill(cursor, session_id, filepaths)
+
+        with (
+            patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
+            patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_tool_content.time.sleep"),
+            patch("ccrecall.hooks.backfill_tool_content._backfill_session", side_effect=_bombing_backfill),
+        ):
+            code = run()
+
+        assert code == EXIT_OK
+        assert call_count == 3  # 3 retries on the bad session
+
+        # Good session still got backfilled
+        good_tc = conn.execute("SELECT tool_content FROM messages WHERE uuid = 'u1'").fetchone()[0]
+        assert good_tc is not None
+
+    def test_operational_error_succeeds_on_retry(self, tmp_path):
+        """A transient lock that clears on the second attempt succeeds without skipping."""
+        filepath = tmp_path / "sess-retry.jsonl"
+        _write_jsonl(
+            filepath,
+            [
+                _entry("u1", None, "2026-01-01T10:00:00Z", "user", "hi"),
+                _entry(
+                    "a1",
+                    "u1",
+                    "2026-01-01T10:00:05Z",
+                    "assistant",
+                    [{"type": "tool_use", "name": "Bash", "input": {"command": "ls"}}],
+                ),
+            ],
+        )
+
+        conn = _make_conn()
+        _seed_session(
+            conn,
+            filepath=filepath,
+            existing_messages=[
+                ("u1", "user", "hi", "2026-01-01T10:00:00Z"),
+                ("a1", "assistant", "", "2026-01-01T10:00:05Z"),
+            ],
+            leaf_uuid="a1",
+        )
+
+        from ccrecall.hooks.backfill_tool_content import _backfill_session as real_bf
+
+        attempt_count = 0
+
+        def _flaky_backfill(cursor, session_id, filepaths):
+            nonlocal attempt_count
+            attempt_count += 1
+            if attempt_count == 1:
+                raise sqlite3.OperationalError("database is locked")
+            return real_bf(cursor, session_id, filepaths)
+
+        with (
+            patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
+            patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_tool_content.time.sleep"),
+            patch("ccrecall.hooks.backfill_tool_content._backfill_session", side_effect=_flaky_backfill),
+        ):
+            code = run()
+
+        assert code == EXIT_OK
+        assert attempt_count == 2
+
+        a1_tc = conn.execute("SELECT tool_content FROM messages WHERE uuid = 'a1'").fetchone()[0]
+        assert "[Bash: ls]" in a1_tc
+
+
+class TestStuckSessionExclusion:
+    """#81: a stuck session no longer aborts the run via the no-progress guard."""
+
+    def test_same_batch_reselected_excludes_and_continues(self, tmp_path):
+        """When the same batch is re-selected (stuck session), the IDs are
+        excluded and the run continues rather than aborting."""
+        stuck_path = tmp_path / "sess-stuck.jsonl"
+        good_path = tmp_path / "sess-ok.jsonl"
+        _write_jsonl(stuck_path, [_entry("u1", None, "2026-01-01T10:00:00Z", "user", "stuck")])
+        _write_jsonl(good_path, [_entry("u2", None, "2026-01-01T10:00:00Z", "user", "fine")])
+
+        conn = _make_conn()
+        stuck_sid, _ = _seed_session(
+            conn,
+            filepath=stuck_path,
+            existing_messages=[("u1", "user", "stuck", "2026-01-01T10:00:00Z")],
+        )
+        _seed_session(
+            conn,
+            filepath=good_path,
+            existing_messages=[("u2", "user", "fine", "2026-01-01T10:00:00Z")],
+        )
+
+        from ccrecall.hooks.backfill_tool_content import (
+            _backfill_session as real_bs,
+        )
+        from ccrecall.hooks.backfill_tool_content import (
+            _select_batch as real_select,
+        )
+
+        batch_call = 0
+
+        def _rigged_select(cursor, exclude_ids, days):
+            nonlocal batch_call
+            batch_call += 1
+            if batch_call <= 2 and stuck_sid not in exclude_ids:
+                return [(stuck_sid, stuck_path.stem)]
+            return real_select(cursor, exclude_ids, days)
+
+        def _noop_backfill(cursor, session_id, filepaths):
+            if session_id == stuck_sid:
+                return False
+            return real_bs(cursor, session_id, filepaths)
+
+        with (
+            patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
+            patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_tool_content.time.sleep"),
+            patch("ccrecall.hooks.backfill_tool_content._select_batch", side_effect=_rigged_select),
+            patch("ccrecall.hooks.backfill_tool_content._backfill_session", side_effect=_noop_backfill),
+        ):
+            code = run()
+
+        # Must NOT abort — continues past the stuck session
+        assert code == EXIT_OK

--- a/tests/test_backfill_tool_content.py
+++ b/tests/test_backfill_tool_content.py
@@ -8,6 +8,7 @@ touched branch. Sessions whose JSONL file is missing are logged and skipped.
 """
 
 import json
+import logging
 import sqlite3
 from pathlib import Path
 from unittest.mock import patch
@@ -17,7 +18,7 @@ from conftest import NoCloseConn
 from conftest import make_jsonl_entry as _entry
 from conftest import write_jsonl as _write_jsonl
 
-from ccrecall.hooks.backfill_query import BATCH_SIZE, EXIT_OK
+from ccrecall.hooks.backfill_query import BATCH_SIZE, EXIT_ABORT, EXIT_OK
 from ccrecall.hooks.backfill_tool_content import backfill_session, run, select_batch
 from ccrecall.schema import SCHEMA
 
@@ -812,3 +813,150 @@ class TestStuckSessionExclusion:
 
         # Must NOT abort — continues past the stuck session
         assert code == EXIT_OK
+
+    def test_json_payload_reports_stuck_count(self, tmp_path, capsys):
+        """The same-batch-reselected path must count its excluded ids toward
+        skipped_stuck in the JSON summary, not drop them from every counter.
+
+        Simulates the pre-Fix-1 bug directly: backfill_session reports success
+        (True) without ever making the session ineligible, so select_batch
+        returns the identical batch on the very next call."""
+        stuck_path = tmp_path / "sess-stuck.jsonl"
+        _write_jsonl(stuck_path, [_entry("u1", None, "2026-01-01T10:00:00Z", "user", "stuck")])
+
+        conn = _make_conn()
+        stuck_sid, _ = _seed_session(
+            conn,
+            filepath=stuck_path,
+            existing_messages=[("u1", "user", "stuck", "2026-01-01T10:00:00Z")],
+        )
+
+        batch_call = 0
+
+        def _rigged_select(cursor, exclude_ids, days):
+            nonlocal batch_call
+            batch_call += 1
+            if batch_call <= 2:
+                return [(stuck_sid, stuck_path.stem)]
+            return []
+
+        def _fake_backfill(cursor, session_id, filepaths):
+            # Reports success without clearing the NULL row -- the exact bug
+            # Fix 1 closes off in the real backfill_session.
+            return True
+
+        with (
+            patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
+            patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_tool_content.time.sleep"),
+            patch("ccrecall.hooks.backfill_tool_content.select_batch", side_effect=_rigged_select),
+            patch("ccrecall.hooks.backfill_tool_content.backfill_session", side_effect=_fake_backfill),
+        ):
+            code = run(json_mode=True)
+
+        assert code == EXIT_OK
+        summary = json.loads(capsys.readouterr().out)
+        assert summary["skipped_stuck"] == 1
+
+
+class TestOrphanedUuidQuiescence:
+    """#81 Fix 1: backfill_session must guarantee a session leaves the eligible
+    set, even when a messages row's uuid is absent from the surviving JSONL."""
+
+    def test_orphaned_uuid_stamped_empty_and_session_leaves_eligible_set(self, tmp_path, capsys, caplog):
+        """A session with one row whose uuid IS in the JSONL (gets real
+        tool_content) and one row whose uuid is NOT in the JSONL (unrecoverable
+        -- transcripts are append-only) must have the orphan stamped to '' (not
+        left NULL), and the session must not be re-selected on a later run."""
+        filepath = tmp_path / "sess-orphan.jsonl"
+        _write_jsonl(
+            filepath,
+            [
+                _entry(
+                    "u1",
+                    None,
+                    "2026-01-01T10:00:00Z",
+                    "assistant",
+                    [{"type": "tool_use", "name": "Bash", "input": {"command": "ls"}}],
+                ),
+            ],
+        )
+
+        conn = _make_conn()
+        session_id, _ = _seed_session(
+            conn,
+            filepath=filepath,
+            existing_messages=[
+                ("u1", "assistant", "", "2026-01-01T10:00:00Z"),
+                # "orphan1" is a uuid recorded in the DB (e.g. from a since-truncated
+                # transcript) with no matching entry in any surviving JSONL file.
+                ("orphan1", "user", "ghost content", "2025-12-31T09:00:00Z"),
+            ],
+            leaf_uuid="u1",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="ccrecall"):
+            code = _run_backfill(conn)
+        assert code == EXIT_OK
+
+        present_row = conn.execute(
+            "SELECT tool_content FROM messages WHERE session_id = ? AND uuid = ?", (session_id, "u1")
+        ).fetchone()
+        assert present_row[0] == "[Bash: ls]", "the row present in the JSONL gets real tool_content"
+
+        orphan_row = conn.execute(
+            "SELECT tool_content FROM messages WHERE session_id = ? AND uuid = ?", (session_id, "orphan1")
+        ).fetchone()
+        assert orphan_row[0] == "", "uuid absent from the surviving JSONL must be stamped '' , not left NULL"
+
+        assert "marked tool_content=''" in caplog.text, "an unrecoverable orphaned uuid must log a WARNING"
+
+        # Session has left the eligible set: no NULL rows remain, and a second
+        # run makes no further changes / reports 0 pending.
+        no_null_remaining = conn.execute(
+            "SELECT COUNT(*) FROM messages WHERE session_id = ? AND tool_content IS NULL", (session_id,)
+        ).fetchone()[0]
+        assert no_null_remaining == 0
+
+        second_code = _run_backfill(conn, json_mode=True)
+        assert second_code == EXIT_OK
+        summary = json.loads(capsys.readouterr().out)
+        assert summary["backfilled"] == 0, "an already-quiesced session must not be re-processed"
+
+        with (
+            patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
+            patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
+        ):
+            run(status=True, json_mode=True)
+        status = json.loads(capsys.readouterr().out)
+        assert status["pending_sessions"] == 0
+
+
+class TestNonLockOperationalErrorFailsFast:
+    """#81 Fix 2: only genuine lock/busy errors get retried; schema errors abort
+    immediately instead of being retried 3x and misreported as a DB-lock skip."""
+
+    def test_schema_error_aborts_without_retry(self, tmp_path):
+        filepath = tmp_path / "sess.jsonl"
+        _write_jsonl(filepath, [_entry("u1", None, "2026-01-01T10:00:00Z", "user", "hi")])
+
+        conn = _make_conn()
+        _seed_session(conn, filepath=filepath, existing_messages=[("u1", "user", "hi", "2026-01-01T10:00:00Z")])
+
+        call_count = 0
+
+        def _raise_schema_error(cursor, session_id, filepaths):
+            nonlocal call_count
+            call_count += 1
+            raise sqlite3.OperationalError("no such column: nope")
+
+        with (
+            patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
+            patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_tool_content.time.sleep"),
+            patch("ccrecall.hooks.backfill_tool_content.backfill_session", side_effect=_raise_schema_error),
+        ):
+            code = run()
+
+        assert code == EXIT_ABORT
+        assert call_count == 1, "a non-lock OperationalError must fail fast, not be retried"

--- a/tests/test_backfill_tool_content.py
+++ b/tests/test_backfill_tool_content.py
@@ -18,7 +18,7 @@ from conftest import make_jsonl_entry as _entry
 from conftest import write_jsonl as _write_jsonl
 
 from ccrecall.hooks.backfill_query import BATCH_SIZE, EXIT_OK
-from ccrecall.hooks.backfill_tool_content import run
+from ccrecall.hooks.backfill_tool_content import _backfill_session, _select_batch, run
 from ccrecall.schema import SCHEMA
 
 pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
@@ -687,8 +687,6 @@ class TestTransientDbLock:
             existing_messages=[("u1", "user", "hello", "2026-01-01T10:00:00Z")],
         )
 
-        from ccrecall.hooks.backfill_tool_content import _backfill_session
-
         real_backfill = _backfill_session
         call_count = 0
 
@@ -742,8 +740,6 @@ class TestTransientDbLock:
             leaf_uuid="a1",
         )
 
-        from ccrecall.hooks.backfill_tool_content import _backfill_session as real_bf
-
         attempt_count = 0
 
         def _flaky_backfill(cursor, session_id, filepaths):
@@ -751,7 +747,7 @@ class TestTransientDbLock:
             attempt_count += 1
             if attempt_count == 1:
                 raise sqlite3.OperationalError("database is locked")
-            return real_bf(cursor, session_id, filepaths)
+            return _backfill_session(cursor, session_id, filepaths)
 
         with (
             patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
@@ -791,13 +787,6 @@ class TestStuckSessionExclusion:
             existing_messages=[("u2", "user", "fine", "2026-01-01T10:00:00Z")],
         )
 
-        from ccrecall.hooks.backfill_tool_content import (
-            _backfill_session as real_bs,
-        )
-        from ccrecall.hooks.backfill_tool_content import (
-            _select_batch as real_select,
-        )
-
         batch_call = 0
 
         def _rigged_select(cursor, exclude_ids, days):
@@ -805,12 +794,12 @@ class TestStuckSessionExclusion:
             batch_call += 1
             if batch_call <= 2 and stuck_sid not in exclude_ids:
                 return [(stuck_sid, stuck_path.stem)]
-            return real_select(cursor, exclude_ids, days)
+            return _select_batch(cursor, exclude_ids, days)
 
         def _noop_backfill(cursor, session_id, filepaths):
             if session_id == stuck_sid:
                 return False
-            return real_bs(cursor, session_id, filepaths)
+            return _backfill_session(cursor, session_id, filepaths)
 
         with (
             patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),

--- a/tests/test_backfill_tool_content.py
+++ b/tests/test_backfill_tool_content.py
@@ -677,7 +677,7 @@ class TestTransientDbLock:
         _write_jsonl(bad_path, [_entry("u2", None, "2026-01-01T10:00:00Z", "user", "world")])
 
         conn = _make_conn()
-        _seed_session(
+        bad_sid, _ = _seed_session(
             conn,
             filepath=bad_path,
             existing_messages=[("u2", "user", "world", "2026-01-01T10:00:00Z")],
@@ -693,7 +693,7 @@ class TestTransientDbLock:
 
         def _bombing_backfill(cursor, session_id, filepaths):
             nonlocal call_count
-            if session_id == 1:
+            if session_id == bad_sid:
                 call_count += 1
                 raise sqlite3.OperationalError("database is locked")
             return real_backfill(cursor, session_id, filepaths)
@@ -793,13 +793,15 @@ class TestStuckSessionExclusion:
         def _rigged_select(cursor, exclude_ids, days):
             nonlocal batch_call
             batch_call += 1
-            if batch_call <= 2 and stuck_sid not in exclude_ids:
+            if batch_call <= 2:
                 return [(stuck_sid, stuck_path.stem)]
             return select_batch(cursor, exclude_ids, days)
 
         def _noop_backfill(cursor, session_id, filepaths):
             if session_id == stuck_sid:
-                return False
+                # Reports success without leaving eligibility, so the identical
+                # batch comes back and the re-selection guard fires.
+                return True
             return backfill_session(cursor, session_id, filepaths)
 
         with (

--- a/tests/test_context_alerts.py
+++ b/tests/test_context_alerts.py
@@ -1,6 +1,6 @@
 """Tests for context_alerts — the SessionStart proactive alert builder.
 
-Covers the tool-content backfill coverage predicate (_has_backfillable_tool_content)
+Covers the tool-content backfill coverage predicate (has_backfillable_tool_content)
 and its wiring into the proactive_alert_block.
 """
 
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from ccrecall.hooks.context_alerts import _has_backfillable_tool_content, proactive_alert_block
+from ccrecall.hooks.context_alerts import has_backfillable_tool_content, proactive_alert_block
 from ccrecall.schema import SCHEMA
 
 pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
@@ -68,7 +68,7 @@ class TestHasBackfillableToolContent:
         filepath.touch()
         _seed_session(conn, session_uuid="sess-a", filepath=filepath, tool_content="[Bash: ls]")
 
-        assert _has_backfillable_tool_content(conn) is False
+        assert has_backfillable_tool_content(conn) is False
 
     def test_pending_with_existing_jsonl_returns_true(self, tmp_path):
         """A session with NULL tool_content whose JSONL exists → alert fires."""
@@ -77,7 +77,7 @@ class TestHasBackfillableToolContent:
         filepath.touch()
         _seed_session(conn, session_uuid="sess-b", filepath=filepath, tool_content=None)
 
-        assert _has_backfillable_tool_content(conn) is True
+        assert has_backfillable_tool_content(conn) is True
 
     def test_pending_with_missing_jsonl_returns_false(self, tmp_path):
         """A session with NULL tool_content whose JSONL is gone → no alert."""
@@ -86,7 +86,7 @@ class TestHasBackfillableToolContent:
         # Don't create the file — it's missing on disk
         _seed_session(conn, session_uuid="sess-c", filepath=filepath, tool_content=None)
 
-        assert _has_backfillable_tool_content(conn) is False
+        assert has_backfillable_tool_content(conn) is False
 
     def test_mixed_pending_some_exist_returns_true(self, tmp_path):
         """Multiple pending: some with missing JSONL, one with existing → alert fires."""
@@ -98,7 +98,7 @@ class TestHasBackfillableToolContent:
         existing.touch()
         _seed_session(conn, session_uuid="sess-here", filepath=existing, tool_content=None)
 
-        assert _has_backfillable_tool_content(conn) is True
+        assert has_backfillable_tool_content(conn) is True
 
     def test_agent_prefixed_file_detected(self, tmp_path):
         """A session whose import_log entry is agent-{uuid}.jsonl is still found."""
@@ -107,12 +107,12 @@ class TestHasBackfillableToolContent:
         filepath.touch()
         _seed_session(conn, session_uuid="sess-d", filepath=filepath, tool_content=None)
 
-        assert _has_backfillable_tool_content(conn) is True
+        assert has_backfillable_tool_content(conn) is True
 
     def test_empty_database_returns_false(self):
         """Fresh install with no sessions → no alert."""
         conn = _make_conn()
-        assert _has_backfillable_tool_content(conn) is False
+        assert has_backfillable_tool_content(conn) is False
 
 
 class TestToolContentAlertWiring:

--- a/tests/test_context_alerts.py
+++ b/tests/test_context_alerts.py
@@ -1,0 +1,182 @@
+"""Tests for context_alerts — the SessionStart proactive alert builder.
+
+Covers the tool-content backfill coverage predicate (_has_backfillable_tool_content)
+and its wiring into the proactive_alert_block.
+"""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from ccrecall.hooks.context_alerts import _has_backfillable_tool_content, proactive_alert_block
+from ccrecall.schema import SCHEMA
+
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
+
+def _make_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.executescript(SCHEMA)
+    conn.commit()
+    return conn
+
+
+def _seed_session(
+    conn: sqlite3.Connection,
+    *,
+    session_uuid: str,
+    filepath: Path,
+    tool_content: str | None = None,
+) -> int:
+    """Seed a minimal session with one message. Returns session_id."""
+    conn.execute("INSERT INTO sessions (uuid) VALUES (?)", (session_uuid,))
+    session_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+    conn.execute(
+        "INSERT INTO messages (session_id, uuid, role, content, timestamp, tool_content)"
+        " VALUES (?, ?, 'user', 'hello', '2026-01-01T10:00:00Z', ?)",
+        (session_id, f"msg-{session_uuid}", tool_content),
+    )
+    msg_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+    conn.execute(
+        "INSERT INTO branches (session_id, leaf_uuid, is_active, ended_at) VALUES (?, ?, 1, '2026-01-01T10:00:00Z')",
+        (session_id, f"leaf-{session_uuid}"),
+    )
+    branch_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+    conn.execute(
+        "INSERT INTO branch_messages (branch_id, message_id) VALUES (?, ?)",
+        (branch_id, msg_id),
+    )
+
+    conn.execute(
+        "INSERT INTO import_log (file_path, file_hash, messages_imported) VALUES (?, ?, 1)",
+        (str(filepath), "deadbeef"),
+    )
+    conn.commit()
+    return session_id
+
+
+class TestHasBackfillableToolContent:
+    def test_no_pending_sessions_returns_false(self, tmp_path):
+        """All sessions already have tool_content → no alert."""
+        conn = _make_conn()
+        filepath = tmp_path / "sess-a.jsonl"
+        filepath.touch()
+        _seed_session(conn, session_uuid="sess-a", filepath=filepath, tool_content="[Bash: ls]")
+
+        assert _has_backfillable_tool_content(conn) is False
+
+    def test_pending_with_existing_jsonl_returns_true(self, tmp_path):
+        """A session with NULL tool_content whose JSONL exists → alert fires."""
+        conn = _make_conn()
+        filepath = tmp_path / "sess-b.jsonl"
+        filepath.touch()
+        _seed_session(conn, session_uuid="sess-b", filepath=filepath, tool_content=None)
+
+        assert _has_backfillable_tool_content(conn) is True
+
+    def test_pending_with_missing_jsonl_returns_false(self, tmp_path):
+        """A session with NULL tool_content whose JSONL is gone → no alert."""
+        conn = _make_conn()
+        filepath = tmp_path / "sess-c.jsonl"
+        # Don't create the file — it's missing on disk
+        _seed_session(conn, session_uuid="sess-c", filepath=filepath, tool_content=None)
+
+        assert _has_backfillable_tool_content(conn) is False
+
+    def test_mixed_pending_some_exist_returns_true(self, tmp_path):
+        """Multiple pending: some with missing JSONL, one with existing → alert fires."""
+        conn = _make_conn()
+        missing = tmp_path / "sess-gone.jsonl"
+        _seed_session(conn, session_uuid="sess-gone", filepath=missing, tool_content=None)
+
+        existing = tmp_path / "sess-here.jsonl"
+        existing.touch()
+        _seed_session(conn, session_uuid="sess-here", filepath=existing, tool_content=None)
+
+        assert _has_backfillable_tool_content(conn) is True
+
+    def test_agent_prefixed_file_detected(self, tmp_path):
+        """A session whose import_log entry is agent-{uuid}.jsonl is still found."""
+        conn = _make_conn()
+        filepath = tmp_path / "agent-sess-d.jsonl"
+        filepath.touch()
+        _seed_session(conn, session_uuid="sess-d", filepath=filepath, tool_content=None)
+
+        assert _has_backfillable_tool_content(conn) is True
+
+    def test_empty_database_returns_false(self):
+        """Fresh install with no sessions → no alert."""
+        conn = _make_conn()
+        assert _has_backfillable_tool_content(conn) is False
+
+
+class TestToolContentAlertWiring:
+    def test_alert_fires_in_proactive_block(self, tmp_path):
+        """The tool-content alert appears in the proactive block when backfillable."""
+        conn = _make_conn()
+        filepath = tmp_path / "sess-e.jsonl"
+        filepath.touch()
+        _seed_session(conn, session_uuid="sess-e", filepath=filepath, tool_content=None)
+
+        snooze = tmp_path / "snooze.json"
+        marker = tmp_path / ".write-probe"
+        block = proactive_alert_block(
+            {"alert_snooze_hours": 0},
+            conn,
+            db_available=True,
+            _marker_path=marker,
+            _snooze_path=snooze,
+        )
+        assert "ccrecall backfill tool-content" in block
+
+    def test_alert_suppressed_when_no_backfillable(self, tmp_path):
+        """No pending sessions → no tool-content mention in the block."""
+        conn = _make_conn()
+        filepath = tmp_path / "sess-f.jsonl"
+        filepath.touch()
+        _seed_session(conn, session_uuid="sess-f", filepath=filepath, tool_content="done")
+
+        snooze = tmp_path / "snooze.json"
+        marker = tmp_path / ".write-probe"
+        block = proactive_alert_block(
+            {"alert_snooze_hours": 0},
+            conn,
+            db_available=True,
+            _marker_path=marker,
+            _snooze_path=snooze,
+        )
+        assert "tool-content" not in block
+
+    def test_snooze_suppresses_repeat_firing(self, tmp_path):
+        """After firing once, the alert is snoozed and doesn't fire again."""
+        conn = _make_conn()
+        filepath = tmp_path / "sess-g.jsonl"
+        filepath.touch()
+        _seed_session(conn, session_uuid="sess-g", filepath=filepath, tool_content=None)
+
+        snooze = tmp_path / "snooze.json"
+        marker = tmp_path / ".write-probe"
+        settings = {"alert_snooze_hours": 24}
+
+        block1 = proactive_alert_block(
+            settings,
+            conn,
+            db_available=True,
+            _marker_path=marker,
+            _snooze_path=snooze,
+        )
+        assert "ccrecall backfill tool-content" in block1
+
+        block2 = proactive_alert_block(
+            settings,
+            conn,
+            db_available=True,
+            _marker_path=marker,
+            _snooze_path=snooze,
+        )
+        assert "tool-content" not in block2

--- a/tests/test_context_alerts.py
+++ b/tests/test_context_alerts.py
@@ -9,7 +9,11 @@ from pathlib import Path
 
 import pytest
 
-from ccrecall.hooks.context_alerts import has_backfillable_tool_content, proactive_alert_block
+from ccrecall.hooks.context_alerts import (
+    _TOOL_CONTENT_SAMPLE_SIZE,
+    has_backfillable_tool_content,
+    proactive_alert_block,
+)
 from ccrecall.schema import SCHEMA
 
 pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
@@ -114,6 +118,32 @@ class TestHasBackfillableToolContent:
         conn = _make_conn()
         assert has_backfillable_tool_content(conn) is False
 
+    def test_sample_cap_misses_later_existing_jsonl(self, tmp_path):
+        """Documents the intentional sampling-cap tradeoff, not a bug.
+
+        has_backfillable_tool_content only samples the first
+        _TOOL_CONTENT_SAMPLE_SIZE pending session uuids (see its docstring:
+        "caps at _TOOL_CONTENT_SAMPLE_SIZE queries + stat calls"). When more
+        than that many sessions are pending and only a session beyond the
+        sample window has a surviving on-disk JSONL, the function returns
+        False even though real backfillable work exists — the sample never
+        reaches that session. This test pins that behavior so it isn't
+        "fixed" by accident, and so anyone surprised by it in production can
+        find the test that explains it.
+        """
+        conn = _make_conn()
+        for i in range(_TOOL_CONTENT_SAMPLE_SIZE + 1):
+            session_uuid = f"sess-{i}"
+            filepath = tmp_path / f"{session_uuid}.jsonl"
+            # Only the last-seeded session's JSONL exists on disk; the rest
+            # (the first _TOOL_CONTENT_SAMPLE_SIZE, which is what gets
+            # sampled) are missing.
+            if i == _TOOL_CONTENT_SAMPLE_SIZE:
+                filepath.touch()
+            _seed_session(conn, session_uuid=session_uuid, filepath=filepath, tool_content=None)
+
+        assert has_backfillable_tool_content(conn) is False
+
 
 class TestToolContentAlertWiring:
     def test_alert_fires_in_proactive_block(self, tmp_path):
@@ -125,12 +155,14 @@ class TestToolContentAlertWiring:
 
         snooze = tmp_path / "snooze.json"
         marker = tmp_path / ".write-probe"
+        status = tmp_path / "embedding-status.json"
         block = proactive_alert_block(
             {"alert_snooze_hours": 0},
             conn,
             db_available=True,
             _marker_path=marker,
             _snooze_path=snooze,
+            _status_path=status,
         )
         assert "ccrecall backfill tool-content" in block
 
@@ -143,14 +175,16 @@ class TestToolContentAlertWiring:
 
         snooze = tmp_path / "snooze.json"
         marker = tmp_path / ".write-probe"
+        status = tmp_path / "embedding-status.json"
         block = proactive_alert_block(
             {"alert_snooze_hours": 0},
             conn,
             db_available=True,
             _marker_path=marker,
             _snooze_path=snooze,
+            _status_path=status,
         )
-        assert "tool-content" not in block
+        assert block == ""
 
     def test_snooze_suppresses_repeat_firing(self, tmp_path):
         """After firing once, the alert is snoozed and doesn't fire again."""
@@ -161,6 +195,7 @@ class TestToolContentAlertWiring:
 
         snooze = tmp_path / "snooze.json"
         marker = tmp_path / ".write-probe"
+        status = tmp_path / "embedding-status.json"
         settings = {"alert_snooze_hours": 24}
 
         block1 = proactive_alert_block(
@@ -169,6 +204,7 @@ class TestToolContentAlertWiring:
             db_available=True,
             _marker_path=marker,
             _snooze_path=snooze,
+            _status_path=status,
         )
         assert "ccrecall backfill tool-content" in block1
 
@@ -178,5 +214,6 @@ class TestToolContentAlertWiring:
             db_available=True,
             _marker_path=marker,
             _snooze_path=snooze,
+            _status_path=status,
         )
-        assert "tool-content" not in block2
+        assert block2 == ""

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1433,7 +1433,8 @@ class TestFetchBranchMessagesToolContent:
 
 
 class TestTransitiveImportIsolation:
-    """config.py, health.py, and hooks/memory_sync.py must stay free of the heavy
+    """config.py, health.py, hooks/memory_sync.py, hooks/context_alerts.py, and
+    hooks/tool_content_eligibility.py must stay free of the heavy
     fastembed/onnxruntime/sqlite_vec stack.
 
     Each module is imported in a fresh subprocess (not the test process, which
@@ -1473,6 +1474,20 @@ class TestTransitiveImportIsolation:
     def test_clear_handoff_does_not_import_heavy_deps(self):
         """clear_handoff.py imports only from config.py."""
         self._assert_no_heavy_imports("ccrecall.hooks.clear_handoff")
+
+    def test_context_alerts_does_not_import_heavy_deps(self):
+        """context_alerts.py is imported on the SessionStart hot path (via
+        memory_context.py) — its eligibility_clause import must come from the
+        dependency-free tool_content_eligibility.py, never from
+        backfill_tool_content.py (which pulls in ccrecall.db -> ccrecall.embeddings
+        -> fastembed/onnxruntime)."""
+        self._assert_no_heavy_imports("ccrecall.hooks.context_alerts")
+
+    def test_tool_content_eligibility_does_not_import_heavy_deps(self):
+        """tool_content_eligibility.py is the shared eligibility predicate consumed
+        by both context_alerts.py (hot path) and backfill_tool_content.py (opt-in
+        backfill) — it must have zero imports beyond stdlib."""
+        self._assert_no_heavy_imports("ccrecall.hooks.tool_content_eligibility")
 
 
 class TestClaudeConfigDir:

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -12,6 +12,7 @@ from ccrecall.embeddings import (
     EMBEDDING_MODEL,
     EMBEDDING_VERSION,
     cap_for_embedding,
+    embed_batch,
     embed_text,
     embed_texts,
     model_available,
@@ -197,3 +198,14 @@ class TestEmbedRealModel:
     def test_different_texts_differ(self):
         """Different texts produce different vectors."""
         assert embed_text("cat") != embed_text("quantum mechanics")
+
+    def test_embed_batch_matches_single(self):
+        """embed_batch produces the same vectors as calling embed_text individually."""
+        texts = ["alpha", "beta", "gamma"]
+        batch_results = embed_batch(texts)
+        single_results = [embed_text(t) for t in texts]
+        assert batch_results == single_results
+
+    def test_embed_batch_empty(self):
+        """embed_batch with empty list returns empty list."""
+        assert embed_batch([]) == []

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -14,7 +14,6 @@ from ccrecall.embeddings import (
     cap_for_embedding,
     embed_batch,
     embed_text,
-    embed_texts,
     model_available,
     resolve_thread_count,
 )
@@ -179,21 +178,6 @@ class TestEmbedRealModel:
         v = embed_text("normalization check")
         magnitude = math.sqrt(sum(x * x for x in v))
         assert abs(magnitude - 1.0) < 1e-4
-
-    def test_batch(self):
-        """embed_texts returns one vector per input, each EMBEDDING_DIM and normalized."""
-        texts = ["first text", "second text", "third text"]
-        results = embed_texts(texts)
-        assert len(results) == len(texts)
-        for v in results:
-            assert len(v) == EMBEDDING_DIM
-            magnitude = math.sqrt(sum(x * x for x in v))
-            assert abs(magnitude - 1.0) < 1e-4
-
-    def test_batch_matches_single(self):
-        """embed_texts produces the same vectors as calling embed_text individually."""
-        texts = ["alpha", "beta"]
-        assert embed_texts(texts) == [embed_text(t) for t in texts]
 
     def test_different_texts_differ(self):
         """Different texts produce different vectors."""

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -8,6 +8,7 @@ from whenever import Instant
 from ccrecall.health import (
     ALERT_CANT_PERSIST,
     ALERT_EMBEDDINGS_FAILING,
+    ALERT_TOOL_CONTENT_INCOMPLETE,
     RECALL_CAVEAT_COVERAGE_THRESHOLD,
     ProbeResult,
     _read_snooze_ledger,
@@ -412,6 +413,17 @@ class TestBlockBuilder:
         lower = result.lower()
         assert "disk" in lower or "permission" in lower or "unavailable" in lower
 
+    def test_tool_content_block_mentions_backfill_command(self):
+        """tool_content_incomplete block names the backfill command."""
+        result = build_alert_block([ALERT_TOOL_CONTENT_INCOMPLETE])
+        assert "ccrecall backfill tool-content" in result
+
+    def test_tool_content_block_has_relay_instruction(self):
+        """tool_content_incomplete block instructs relay without hard-coded prominence."""
+        result = build_alert_block([ALERT_TOOL_CONTENT_INCOMPLETE])
+        lower = result.lower()
+        assert "surface" in lower
+
 
 class TestConstants:
     """Module-level constants are correct."""
@@ -420,11 +432,9 @@ class TestConstants:
         assert RECALL_CAVEAT_COVERAGE_THRESHOLD == 0.95
 
     def test_alert_keys_are_distinct_nonempty_strings(self):
-        assert isinstance(ALERT_CANT_PERSIST, str)
-        assert isinstance(ALERT_EMBEDDINGS_FAILING, str)
-        assert ALERT_CANT_PERSIST != ALERT_EMBEDDINGS_FAILING
-        assert ALERT_CANT_PERSIST
-        assert ALERT_EMBEDDINGS_FAILING
+        keys = {ALERT_CANT_PERSIST, ALERT_EMBEDDINGS_FAILING, ALERT_TOOL_CONTENT_INCOMPLETE}
+        assert all(isinstance(k, str) and k for k in keys)
+        assert len(keys) == 3
 
     def test_probe_result_frozen_dataclass(self):
         """ProbeResult is frozen and carries ok + reason fields."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -495,7 +495,7 @@ class TestSearchMessagesToolContentMatch:
         )
 
         fake_vec = [1.0 / EMBEDDING_DIM**0.5] * EMBEDDING_DIM
-        with patch("ccrecall.embed_ops.embed_text", return_value=fake_vec):
+        with patch("ccrecall.embed_ops.embed_batch", side_effect=lambda texts: [fake_vec] * len(texts)):
             sync_session(conn, filepath, tmp_path)
 
         with (

--- a/tests/test_session_ops.py
+++ b/tests/test_session_ops.py
@@ -590,10 +590,11 @@ class TestEmbedBranchChunks:
         msgs_2 = _make_msgs(("Hello", "Hi there"), ("How are you?", "Fine thanks"))
         fake_vec = [0.1] * EMBEDDING_DIM
 
-        with patch("ccrecall.embed_ops.embed_text", return_value=fake_vec) as mock_embed:
+        with patch("ccrecall.embed_ops.embed_batch", side_effect=lambda texts: [fake_vec] * len(texts)) as mock_embed:
             embed_branch_chunks(cursor, branch_id, msgs_2, is_active=True, vec_writable=True)
 
-        assert mock_embed.call_count == 2, "first sync should embed 2 exchanges"
+        total = sum(len(c.args[0]) for c in mock_embed.call_args_list)
+        assert total == 2, "first sync should embed 2 exchanges"
 
         cursor.execute("SELECT COUNT(*) FROM chunks WHERE branch_id = ?", (branch_id,))
         assert cursor.fetchone()[0] == 2
@@ -601,10 +602,11 @@ class TestEmbedBranchChunks:
         # Now add a 3rd exchange
         msgs_3 = _make_msgs(("Hello", "Hi there"), ("How are you?", "Fine thanks"), ("New q?", "New a"))
 
-        with patch("ccrecall.embed_ops.embed_text", return_value=fake_vec) as mock_embed2:
+        with patch("ccrecall.embed_ops.embed_batch", side_effect=lambda texts: [fake_vec] * len(texts)) as mock_embed2:
             embed_branch_chunks(cursor, branch_id, msgs_3, is_active=True, vec_writable=True)
 
-        assert mock_embed2.call_count == 1, "re-sync should embed only the 1 new exchange"
+        total2 = sum(len(c.args[0]) for c in mock_embed2.call_args_list)
+        assert total2 == 1, "re-sync should embed only the 1 new exchange"
 
         cursor.execute("SELECT COUNT(*) FROM chunks WHERE branch_id = ?", (branch_id,))
         assert cursor.fetchone()[0] == 3
@@ -627,11 +629,11 @@ class TestEmbedBranchChunks:
         msgs = _make_msgs(("Hello", "Hi"), ("What's up?", "Nothing much"))
         fake_vec = [0.1] * EMBEDDING_DIM
 
-        with patch("ccrecall.embed_ops.embed_text", return_value=fake_vec):
+        with patch("ccrecall.embed_ops.embed_batch", side_effect=lambda texts: [fake_vec] * len(texts)):
             embed_branch_chunks(cursor, branch_id, msgs, is_active=True, vec_writable=True)
 
         # Re-sync with exactly the same messages
-        with patch("ccrecall.embed_ops.embed_text", return_value=fake_vec) as mock_embed:
+        with patch("ccrecall.embed_ops.embed_batch", side_effect=lambda texts: [fake_vec] * len(texts)) as mock_embed:
             embed_branch_chunks(cursor, branch_id, msgs, is_active=True, vec_writable=True)
 
         assert mock_embed.call_count == 0, "unchanged content must not trigger re-embedding"
@@ -653,7 +655,7 @@ class TestEmbedBranchChunks:
         # Assistant-only messages form no user->assistant exchange pair.
         msgs = [{"role": "assistant", "content": "sidechain output", "timestamp": "2024-01-01T00:00:30", "uuid": None}]
 
-        with patch("ccrecall.embed_ops.embed_text") as mock_embed:
+        with patch("ccrecall.embed_ops.embed_batch") as mock_embed:
             returned = embed_branch_chunks(cursor, branch_id, msgs, is_active=True, vec_writable=True)
 
         assert returned == 0
@@ -698,7 +700,7 @@ class TestEmbedBranchChunks:
         msgs_3 = _make_msgs(("q1", "a1"), ("q2", "a2"), ("q3", "a3"))
         fake_vec = [0.1] * EMBEDDING_DIM
 
-        with patch("ccrecall.embed_ops.embed_text", return_value=fake_vec):
+        with patch("ccrecall.embed_ops.embed_batch", side_effect=lambda texts: [fake_vec] * len(texts)):
             embed_branch_chunks(cursor, branch_id, msgs_3, is_active=True, vec_writable=True)
 
         cursor.execute("SELECT COUNT(*) FROM chunks WHERE branch_id = ?", (branch_id,))
@@ -707,7 +709,7 @@ class TestEmbedBranchChunks:
         # Shrink: remove the 3rd exchange
         msgs_2 = _make_msgs(("q1", "a1"), ("q2", "a2"))
 
-        with patch("ccrecall.embed_ops.embed_text", return_value=fake_vec):
+        with patch("ccrecall.embed_ops.embed_batch", side_effect=lambda texts: [fake_vec] * len(texts)):
             embed_branch_chunks(cursor, branch_id, msgs_2, is_active=True, vec_writable=True)
 
         cursor.execute("SELECT COUNT(*) FROM chunks WHERE branch_id = ?", (branch_id,))
@@ -733,7 +735,7 @@ class TestEmbedBranchChunks:
 
         # Simulate sync_branch's contextlib.suppress wrapper
         with (
-            patch("ccrecall.embed_ops.embed_text", side_effect=RuntimeError("embed failed")),
+            patch("ccrecall.embed_ops.embed_batch", side_effect=RuntimeError("embed failed")),
             contextlib.suppress(Exception),
         ):
             embed_branch_chunks(cursor, branch_id, msgs, is_active=True, vec_writable=True)
@@ -760,11 +762,12 @@ class TestEmbedBranchChunks:
         msgs = _make_msgs(*[(f"question {i}", f"answer {i}") for i in range(n_exchanges)])
         fake_vec = [0.1] * EMBEDDING_DIM
 
-        with patch("ccrecall.embed_ops.embed_text", return_value=fake_vec) as mock_embed:
+        with patch("ccrecall.embed_ops.embed_batch", side_effect=lambda texts: [fake_vec] * len(texts)) as mock_embed:
             embed_branch_chunks(cursor, branch_id, msgs, is_active=True, vec_writable=True)
 
-        assert mock_embed.call_count <= MAX_WRITE_PATH_EMBEDS_PER_SYNC, (
-            f"write path must embed at most {MAX_WRITE_PATH_EMBEDS_PER_SYNC} per sync, got {mock_embed.call_count}"
+        total_embedded = sum(len(c.args[0]) for c in mock_embed.call_args_list)
+        assert total_embedded <= MAX_WRITE_PATH_EMBEDS_PER_SYNC, (
+            f"write path must embed at most {MAX_WRITE_PATH_EMBEDS_PER_SYNC} per sync, got {total_embedded}"
         )
 
         cursor.execute("SELECT COUNT(*) FROM chunk_vec")
@@ -795,7 +798,7 @@ class TestEmbedOnWriteModelUnavailable:
         conn.commit()
 
         with (
-            patch("ccrecall.embed_ops.embed_text", side_effect=RuntimeError("no model")),
+            patch("ccrecall.embed_ops.embed_batch", side_effect=RuntimeError("no model")),
             tempfile.TemporaryDirectory() as tmpdir,
         ):
             result = sync_session(conn, fixture_path, Path(tmpdir))
@@ -841,7 +844,7 @@ class TestEmbedOnWriteOrderingInvariant:
         # embed_text succeeds, but the vec upsert (called first by write_chunk_embedding)
         # raises — simulating a vec-write failure after a successful embed.
         with (
-            patch("ccrecall.embed_ops.embed_text", return_value=fake_vec),
+            patch("ccrecall.embed_ops.embed_batch", side_effect=lambda texts: [fake_vec] * len(texts)),
             patch("ccrecall.db.upsert_chunk_vec", side_effect=RuntimeError("vec write failed")),
             contextlib.suppress(Exception),
         ):
@@ -886,7 +889,7 @@ class TestEmbedOnWriteSuccess:
         fake_vec = [0.1] * EMBEDDING_DIM
 
         with (
-            patch("ccrecall.embed_ops.embed_text", return_value=fake_vec),
+            patch("ccrecall.embed_ops.embed_batch", side_effect=lambda texts: [fake_vec] * len(texts)),
             tempfile.TemporaryDirectory() as tmpdir,
         ):
             result = sync_session(conn, fixture_path, Path(tmpdir))


### PR DESCRIPTION
### Backfill resilience (#81)

`ccrecall backfill tool-content` used to abort the **entire run** on a single transient `sqlite3.OperationalError: database is locked`, silently leaving the database partially backfilled. A real run hit this at 911/2310 sessions, contending with the `ccrecall-sync` Stop hook, and required three manual re-runs to finish.

- Wrap per-session backfill in bounded retry with backoff (`backfill_with_retry`, 3 attempts) so a transient lock no longer kills the run.
- Raise the connection's `busy_timeout` to `VEC_BUSY_TIMEOUT_MS` (30s) instead of the base 5s — this backfill contends with the sync hook the same way vec writers do, but previously got the shortest timeout of any writer.
- Replace the "same batch re-selected" abort with exclude-and-continue: a genuinely stuck session (parses fine but never clears its own `tool_content IS NULL` eligibility) is now skipped instead of blocking every remaining session behind it.
- Track and report `skipped_db_lock` separately from the other skip reasons so a lock-exhausted session is distinguishable in the summary.

**Follow-up hardening (review pass on top of the above):**

- `backfill_session` now guarantees quiescence: any `messages` row still NULL after the update/insert passes gets stamped to `''` (a uuid absent from every surviving JSONL file is unrecoverable — transcripts are append-only). A `True` return therefore guarantees the session has left the eligible set for good, instead of staying re-selectable and re-firing the SessionStart tool-content alert every snooze period forever.
- `backfill_with_retry` now re-raises non-lock/busy `OperationalError`s immediately instead of retrying them — a genuine schema error (e.g. "no such column") used to be retried 3x per session and then miscounted as a DB-lock skip.
- The same-batch-reselected guard's exclusions are now counted as `skipped_stuck` in the log/stderr/JSON summaries instead of silently dropping those sessions from every counter. Kept as defense-in-depth — the quiescence guarantee above should make this path nearly unreachable.

### Batched embedding inference (#83)

`embed_branch_chunks` called `embed_text` once per exchange — a Python-level loop, not true batched inference. Switched to `model.embed()` over the full text list for a given branch, so onnxruntime batches the matrix ops instead of running one inference call per exchange. A single batch call embeds all texts, then chunk rows are upserted and vectors written together per-chunk — the existing vector-first/bookkeeping-last ordering invariant (mid-loop exception leaves a chunk eligible for backfill) is preserved. Trade-off: a content error anywhere in the batch now fails the whole batch rather than just one exchange; `cap_for_embedding` already bounds text length, so this should be rare, and a failed batch still leaves every chunk eligible for retry under the clear-first protocol.

**Follow-up:** reordered so batch-embedding happens *before* any chunk DELETE+INSERT. Previously a failed `embed_batch` call landed after the DELETE+INSERT had already cascaded away every previously-good vector for the branch, so one failed batch destroyed all prior vectors, not just the ones in that batch. With embedding called first and no writes yet, a failure now leaves every existing chunk row and vector untouched.

### Cost-proportional backfill ETA (#84)

The embedding backfill's ETA was computed from `remaining branches / (branches done / elapsed)` — misleading because branches vary wildly in message count, so a rate measured against a run of small branches badly underestimates the time for a run that turns to larger ones (or vice versa). Replaced with:

- A work unit of non-notification message count (matching the `include_notifications=False` filter already used by `fetch_branch_messages`, so `total_work` and `work_done` stay in the same units).
- A windowed rate over the last 30 samples (`_RATE_WINDOW`) instead of a cumulative average since start, so the estimate adapts as branch size mix changes mid-run.
- A "warming up" placeholder for the first 5 branches (`_WARMUP_BRANCHES`) instead of extrapolating from a tiny, noisy initial sample.
- Follow-up: the warm-up gate now counts branches processed (success or content-error), not successes only, so an error-heavy run doesn't report "warming up" indefinitely even once it has enough samples to compute a rate.

### SessionStart nudge for tool-content coverage (#82)

Sessions synced before tool-content extraction shipped have no `tool_content` and are invisible to that half of search until backfilled — but nothing told the user this backfill existed or was incomplete. Added `ALERT_TOOL_CONTENT_INCOMPLETE` to the existing proactive-alert machinery in `context_alerts.py`: a cheap two-phase check (sample a few `tool_content IS NULL` session UUIDs, confirm at least one still has its JSONL on disk) fires the alert only when there's something the backfill command could actually fix, and the existing snooze ledger keeps it from repeating every session start.

### Housekeeping

- Add a partial index (`idx_messages_tool_content_null`) on `messages(session_id) WHERE tool_content IS NULL` so the coverage check and backfill selection queries don't scan the full table.
- Scope the `PERF203` (try/except-in-loop) ruff ignore to the five files with genuine retry/liveness loops (`db.py`, `backfill_summaries.py`, `backfill_tool_content.py`, `memory_setup.py`, `sync_current.py`) instead of suppressing it globally, and drop the per-line `noqa` comments it was papering over.
- Move a test's lazy imports to top-level, per repo convention.
- Clean-code pass: remove dead code (unused `additional_context` output path in `memory_setup.main`), replace magic numbers in `cap_for_embedding` with named constants (`DENSE_SPLIT_NUMERATOR`/`DENOMINATOR`, `SHRINK_NUMERATOR`/`DENOMINATOR`), and drop underscore prefixes from module-internal functions in `backfill_tool_content.py`, `cli/commands.py`, and `context_alerts.py` (`has_backfillable_tool_content`) that have no concrete reason to be marked private.

Closes #81
Closes #82
Closes #83
Closes #84


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batched embedding support to improve embedding efficiency and reduce partial-update risk.
  * Added health alerts when historical tool content needs backfilling, with guidance for resolving it.
  * Added resilient tool-content backfill handling for database locks and stuck sessions.
* **Bug Fixes**
  * Improved backfill progress reporting with work-based estimates and warm-up messaging.
  * Ensured successfully processed sessions do not remain eligible for repeated backfills.
* **Documentation**
  * Clarified the meaning of embedding thread settings in CLI help.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
