### PR TITLE
fix: use branch-aware fallback in ccrecall tail for worktree sessions

### DIFF
--- a/skills/ccr-resume/SKILL.md
+++ b/skills/ccr-resume/SKILL.md
@@ -37,6 +37,7 @@ ccrecall tail
 Do **not** pass $ARGUMENTS here — it's a follow-up directive, not a session id (see Arguments).
 
 - Auto-detect picks the second-newest session (the newest is *this* one, live). If the wrong session comes up or you need to choose, run `ccrecall tail --list` and re-run with the right id substring.
+- **Cross-check against injected context:** The SessionStart hook may have already injected a "Session Origin" block at the top of context naming a specific prior session (look for `Session:` followed by a UUID). If `ccrecall tail` returns a *different* session ID, the injected context is more likely correct (it uses DB-backed cwd matching). Re-run with the injected session's ID: `ccrecall tail <id-substring>`.
 - If `ccrecall tail` finds nothing (no project dir, only the current session, or a moved cwd), fall back to `/ccr-recall` to retrieve the tail — never substitute disk artifacts for the transcript.
 - A clear/startup may already have surfaced an "Unresolved Decision From Prior Session" block at the top of context — if so, this confirms and expands it; reconcile and proceed to Phase 2.
 

--- a/src/ccrecall/session_tail.py
+++ b/src/ccrecall/session_tail.py
@@ -514,20 +514,23 @@ def _extract_branch(path: Path) -> str | None:
     Cheap head-read used to filter fallback candidates by branch — avoids
     parsing the full file.
     """
-    with open(path, encoding="utf-8", errors="replace") as fh:
-        for i, line in enumerate(fh):
-            if i >= _BRANCH_HEAD_LINES:
-                break
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                entry = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            branch = entry.get("gitBranch")
-            if branch:
-                return branch
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            for i, line in enumerate(fh):
+                if i >= _BRANCH_HEAD_LINES:
+                    break
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                branch = entry.get("gitBranch")
+                if branch:
+                    return branch
+    except OSError:
+        return None
     return None
 
 

--- a/src/ccrecall/session_tail.py
+++ b/src/ccrecall/session_tail.py
@@ -46,6 +46,7 @@ from ccrecall.parsing import (
 # sessions — enough to find a timestamp even if the trailing lines are a
 # no-timestamp tool-result burst, without reading a multi-MB file in full.
 _TIMESTAMP_TAIL_LINES = 20
+_BRANCH_HEAD_LINES = 20
 
 # Harness-injected user content that isn't a typed instruction. command/channel
 # wrappers, task-notifications, and <local-command-caveat> blocks are already
@@ -457,8 +458,11 @@ def _emit_full(entries: list[dict], pending: dict | None) -> int:
     return 0
 
 
-def _build_search_dirs(provided_cwd: str, *, real_cwd: str | None = None) -> list[Path]:
+def _build_search_dirs(provided_cwd: str, *, real_cwd: str | None = None) -> tuple[list[Path], str | None]:
     """Build ordered list of transcript dirs to search (worktree-specific first).
+
+    Returns ``(dirs, branch_hint)`` where *branch_hint* is the resolved worktree
+    name (used as a branch filter for fallback dirs), or None when not in a worktree.
 
     When the process is running inside a worktree but --cwd was passed pointing at
     the repo root, the worktree dir is still searched first and a warning is emitted.
@@ -470,7 +474,7 @@ def _build_search_dirs(provided_cwd: str, *, real_cwd: str | None = None) -> lis
     real_cwd_normalized = (real_cwd or str(Path.cwd())).replace("\\", "/")
     real_parts = split_worktree_path(real_cwd_normalized)
     if not real_parts:
-        return [transcript_dir(provided_cwd)]
+        return [transcript_dir(provided_cwd)], None
 
     repo_root, worktree_cwd = real_parts
 
@@ -478,7 +482,7 @@ def _build_search_dirs(provided_cwd: str, *, real_cwd: str | None = None) -> lis
     provided_base = provided_parts[0] if provided_parts else provided_cwd.replace("\\", "/")
 
     if provided_base.rstrip("/") != repo_root.rstrip("/"):
-        return [transcript_dir(provided_cwd)]
+        return [transcript_dir(provided_cwd)], None
 
     if provided_parts and provided_parts[1].rstrip("/") != worktree_cwd.rstrip("/"):
         primary = provided_parts[1]
@@ -498,15 +502,58 @@ def _build_search_dirs(provided_cwd: str, *, real_cwd: str | None = None) -> lis
     if root_dir not in dirs:
         dirs.append(root_dir)
 
-    return dirs
+    # Worktree dir name == branch for `claude --worktree <branch>`;
+    # won't match slash-containing branches — falls back to newest.
+    branch_hint = Path(primary).name
+    return dirs, branch_hint
 
 
-def _resolve_across_dirs(dirs: list[Path], selector: str | None) -> Path | None:
+def _extract_branch(path: Path) -> str | None:
+    """Read the first ~20 lines of a transcript to find its git branch.
+
+    Cheap head-read used to filter fallback candidates by branch — avoids
+    parsing the full file.
+    """
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        for i, line in enumerate(fh):
+            if i >= _BRANCH_HEAD_LINES:
+                break
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            branch = entry.get("gitBranch")
+            if branch:
+                return branch
+    return None
+
+
+def _pick_branch_match(sessions: list[Path], branch_hint: str | None) -> Path | None:
+    """From a recency-sorted list, prefer the newest session matching *branch_hint*.
+
+    Falls back to the overall newest if no branch match is found (or no hint).
+    """
+    if not sessions:
+        return None
+    if not branch_hint:
+        return sessions[0]
+    for path in sessions:
+        if _extract_branch(path) == branch_hint:
+            return path
+    return sessions[0]
+
+
+def _resolve_across_dirs(dirs: list[Path], selector: str | None, *, branch_hint: str | None = None) -> Path | None:
     """Search multiple transcript dirs for a target session.
 
     The first dir is the primary (contains the current live session when no
     selector is given), so resolve_target skips the newest file there.
-    Fallback dirs don't contain the current session, so their newest is fair game.
+    Fallback dirs don't contain the current session, so their newest is fair
+    game — but when a *branch_hint* is provided, the fallback prefers a
+    session on the same branch over the globally newest.
     """
     for i, pdir in enumerate(dirs):
         if selector:
@@ -515,7 +562,7 @@ def _resolve_across_dirs(dirs: list[Path], selector: str | None) -> Path | None:
             target = resolve_target(pdir, None)
         else:
             sessions = list_transcripts(pdir)
-            target = sessions[0] if sessions else None
+            target = _pick_branch_match(sessions, branch_hint)
         if target is not None:
             return target
     return None
@@ -540,7 +587,7 @@ def run(
             remediation="Pass a positive integer: ccrecall tail -n 8",
         )
 
-    search_dirs = _build_search_dirs(cwd)
+    search_dirs, branch_hint = _build_search_dirs(cwd)
     valid_dirs = [d for d in search_dirs if d.is_dir()]
 
     if not valid_dirs:
@@ -568,7 +615,7 @@ def run(
             remediation="Run a Claude Code session in this project first, then retry.",
         )
 
-    target = _resolve_across_dirs(valid_dirs, selector)
+    target = _resolve_across_dirs(valid_dirs, selector, branch_hint=branch_hint if not selector else None)
 
     if target is None and selector:
         target = resolve_target_global(selector)

--- a/tests/test_session_tail.py
+++ b/tests/test_session_tail.py
@@ -7,7 +7,9 @@ from ccrecall.session_tail import (
     _brief_path,
     _build_search_dirs,
     _emit_full,
+    _extract_branch,
     _last_event_timestamp,
+    _pick_branch_match,
     _resolve_across_dirs,
     _tool_event,
     build_tail,
@@ -518,46 +520,54 @@ class TestFormatPendingBlock:
 
 class TestBuildSearchDirs:
     def test_not_in_worktree_returns_provided_cwd(self):
-        dirs = _build_search_dirs("/home/user/repo", real_cwd="/home/user/repo")
+        dirs, hint = _build_search_dirs("/home/user/repo", real_cwd="/home/user/repo")
         assert len(dirs) == 1
         assert dirs[0] == transcript_dir("/home/user/repo")
+        assert hint is None
 
     def test_in_worktree_returns_worktree_first(self):
         wt = "/home/user/repo/.claude/worktrees/billing"
-        dirs = _build_search_dirs(wt, real_cwd=wt)
+        dirs, hint = _build_search_dirs(wt, real_cwd=wt)
         assert len(dirs) == 2
         assert dirs[0] == transcript_dir(wt)
         assert dirs[1] == transcript_dir("/home/user/repo")
+        assert hint == "billing"
 
     def test_cwd_is_repo_root_but_in_worktree(self, capsys):
         wt = "/home/user/repo/.claude/worktrees/billing"
-        dirs = _build_search_dirs("/home/user/repo", real_cwd=wt)
+        dirs, hint = _build_search_dirs("/home/user/repo", real_cwd=wt)
         assert len(dirs) == 2
         assert dirs[0] == transcript_dir(wt)
         assert dirs[1] == transcript_dir("/home/user/repo")
+        assert hint == "billing"
         err = capsys.readouterr().err
         assert "running in worktree" in err
 
     def test_unrelated_cwd_skips_worktree_logic(self):
         wt = "/home/user/repo/.claude/worktrees/billing"
-        dirs = _build_search_dirs("/other/project", real_cwd=wt)
+        dirs, hint = _build_search_dirs("/other/project", real_cwd=wt)
         assert len(dirs) == 1
         assert dirs[0] == transcript_dir("/other/project")
+        assert hint is None
 
     def test_sibling_worktree_cwd_searched_first(self):
         wt_a = "/home/user/repo/.claude/worktrees/billing"
         wt_b = "/home/user/repo/.claude/worktrees/genie"
-        dirs = _build_search_dirs(wt_b, real_cwd=wt_a)
+        dirs, hint = _build_search_dirs(wt_b, real_cwd=wt_a)
         assert dirs[0] == transcript_dir(wt_b)
         assert dirs[1] == transcript_dir("/home/user/repo")
         assert len(dirs) == 2
+        assert hint == "genie"
 
 
 class TestResolveAcrossDirs:
-    def _write_transcript(self, pdir, stem, ts):
+    def _write_transcript(self, pdir, stem, ts, branch=None):
         pdir.mkdir(parents=True, exist_ok=True)
         path = pdir / f"{stem}.jsonl"
-        path.write_text(json.dumps({"timestamp": ts}) + "\n")
+        entry = {"timestamp": ts}
+        if branch:
+            entry["gitBranch"] = branch
+        path.write_text(json.dumps(entry) + "\n")
         return path
 
     def test_skips_newest_in_first_dir_only(self, tmp_path):
@@ -586,3 +596,92 @@ class TestResolveAcrossDirs:
 
         result = _resolve_across_dirs([dir1, dir2], "abc12345")
         assert result == target
+
+    def test_fallback_prefers_branch_match(self, tmp_path):
+        dir1 = tmp_path / "primary"
+        dir2 = tmp_path / "fallback"
+        dir1.mkdir(parents=True)
+        self._write_transcript(dir2, "wrong-branch", "2026-07-13T10:00:00Z", branch="main")
+        right = self._write_transcript(dir2, "right-branch", "2026-07-13T09:00:00Z", branch="clydesdales")
+
+        result = _resolve_across_dirs([dir1, dir2], None, branch_hint="clydesdales")
+        assert result == right
+
+    def test_fallback_without_hint_picks_newest(self, tmp_path):
+        dir1 = tmp_path / "primary"
+        dir2 = tmp_path / "fallback"
+        dir1.mkdir(parents=True)
+        newest = self._write_transcript(dir2, "newer", "2026-07-13T10:00:00Z")
+        self._write_transcript(dir2, "older", "2026-07-13T09:00:00Z")
+
+        result = _resolve_across_dirs([dir1, dir2], None, branch_hint=None)
+        assert result == newest
+
+    def test_fallback_no_branch_match_picks_newest(self, tmp_path):
+        dir1 = tmp_path / "primary"
+        dir2 = tmp_path / "fallback"
+        dir1.mkdir(parents=True)
+        newest = self._write_transcript(dir2, "a", "2026-07-13T10:00:00Z", branch="main")
+        self._write_transcript(dir2, "b", "2026-07-13T09:00:00Z", branch="billing")
+
+        result = _resolve_across_dirs([dir1, dir2], None, branch_hint="nonexistent")
+        assert result == newest
+
+
+class TestExtractBranch:
+    def test_finds_branch_in_early_entries(self, tmp_path):
+        path = tmp_path / "s.jsonl"
+        lines = [
+            json.dumps({"type": "custom-title", "sessionId": "abc"}),
+            json.dumps({"type": "mode"}),
+            json.dumps({"type": "attachment", "gitBranch": "clydesdales", "cwd": "/repo"}),
+        ]
+        path.write_text("\n".join(lines) + "\n")
+        assert _extract_branch(path) == "clydesdales"
+
+    def test_returns_none_when_no_branch(self, tmp_path):
+        path = tmp_path / "s.jsonl"
+        lines = [json.dumps({"type": "user", "message": {}})] * 5
+        path.write_text("\n".join(lines) + "\n")
+        assert _extract_branch(path) is None
+
+    def test_stops_after_20_lines(self, tmp_path):
+        path = tmp_path / "s.jsonl"
+        lines = [json.dumps({"type": "filler"})] * 25
+        lines.append(json.dumps({"gitBranch": "late-branch"}))
+        path.write_text("\n".join(lines) + "\n")
+        assert _extract_branch(path) is None
+
+    def test_handles_corrupt_json(self, tmp_path):
+        path = tmp_path / "s.jsonl"
+        path.write_text("not json\n{bad\n" + json.dumps({"gitBranch": "ok"}) + "\n")
+        assert _extract_branch(path) == "ok"
+
+
+class TestPickBranchMatch:
+    def _write(self, pdir, stem, branch=None):
+        pdir.mkdir(parents=True, exist_ok=True)
+        path = pdir / f"{stem}.jsonl"
+        entry = {"type": "user", "timestamp": "2026-01-01T00:00:00Z"}
+        if branch:
+            entry["gitBranch"] = branch
+        path.write_text(json.dumps(entry) + "\n")
+        return path
+
+    def test_returns_none_for_empty_list(self):
+        assert _pick_branch_match([], "main") is None
+
+    def test_returns_first_when_no_hint(self, tmp_path):
+        a = self._write(tmp_path, "a")
+        self._write(tmp_path, "b")
+        assert _pick_branch_match([a, tmp_path / "b.jsonl"], None) == a
+
+    def test_prefers_matching_branch(self, tmp_path):
+        a = self._write(tmp_path, "a", branch="main")
+        b = self._write(tmp_path, "b", branch="feature")
+        assert _pick_branch_match([a, b], "feature") == b
+
+    def test_falls_back_to_first_when_no_match(self, tmp_path):
+        a = self._write(tmp_path, "a", branch="main")
+        b = self._write(tmp_path, "b", branch="other")
+        assert _pick_branch_match([a, b], "nonexistent") == a


### PR DESCRIPTION
### Worktree tail fallback

- `ccrecall tail` falling back from a worktree-specific transcript directory to the repo-root directory now prefers the session matching the current branch instead of blindly grabbing the newest transcript. Previously, if a prior worktree session's transcript ended up stored under the repo-root project dir (due to a Claude Code slug change), the fallback could return an unrelated session from a different worktree/branch.
- `_build_search_dirs` now returns `(dirs, branch_hint)` — the worktree directory name doubles as the branch hint (works for `claude --worktree <branch>`; won't match slash-containing branch names, which fall back to newest-wins as before).
- New `_extract_branch` reads only the first 20 lines of a transcript to pull `gitBranch`, avoiding a full-file parse just to filter fallback candidates.
- `_pick_branch_match` picks the newest session matching the branch hint, falling back to the overall newest when there's no hint or no match — so behavior is unchanged outside the worktree-fallback case.
- Added a cross-check bullet to the `ccr-resume` skill: if the SessionStart-injected "Session Origin" block names a different session than what `ccrecall tail` picks, prefer the injected one (it uses DB-backed cwd matching) and re-run `ccrecall tail` with that session's ID.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved session selection across worktrees by prioritizing transcripts associated with the current branch.
  * Added guidance to verify recalled sessions against the active session context and retry when they differ.

* **Bug Fixes**
  * Session lookup now falls back to the newest available transcript when no branch match is found.

* **Tests**
  * Added coverage for branch detection, matching, fallback behavior, and worktree directory selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->