### PR TITLE
refactor: apply mechanical tech-debt cleanup from #90 review

### DIFF
--- a/src/ccrecall/embeddings.py
+++ b/src/ccrecall/embeddings.py
@@ -42,6 +42,10 @@ EMBEDDING_MODEL_CACHE_SUBDIR = "models--" + EMBEDDING_MODEL_HF_SOURCE.replace("/
 EMBED_CHAR_BUDGET = 32_000
 MODEL_TOKEN_LIMIT = 8192
 
+# Marker spliced between the kept head and tail when the middle is dropped.
+# Both build sites in cap_for_embedding must agree, so the literal lives here once.
+_CAP_MARKER = "\n\n[...]\n\n"
+
 # fastembed defaults its inference parallelism to every CPU core, so each
 # inference call briefly saturates the whole machine. Interactive query/write
 # paths embed one or a few texts at a time; the opt-in backfill runs ~1.9k
@@ -293,12 +297,12 @@ def cap_for_embedding(text: str) -> tuple[str, bool]:
         head = max(len(text) * DENSE_SPLIT_NUMERATOR // DENSE_SPLIT_DENOMINATOR, 1)
         tail = max(len(text) * DENSE_SPLIT_NUMERATOR // DENSE_SPLIT_DENOMINATOR, 1)
 
-    capped = text[:head] + "\n\n[...]\n\n" + text[-tail:]
+    capped = text[:head] + _CAP_MARKER + text[-tail:]
 
     while model.token_count([capped]) > MODEL_TOKEN_LIMIT:
         head = max(head * SHRINK_NUMERATOR // SHRINK_DENOMINATOR, 1)
         tail = max(tail * SHRINK_NUMERATOR // SHRINK_DENOMINATOR, 1)
-        next_capped = text[:head] + "\n\n[...]\n\n" + text[-tail:]
+        next_capped = text[:head] + _CAP_MARKER + text[-tail:]
         if next_capped == capped:
             break  # no further reduction possible; pathological — let embed_text raise
         capped = next_capped

--- a/src/ccrecall/hooks/sync_current.py
+++ b/src/ccrecall/hooks/sync_current.py
@@ -46,6 +46,10 @@ PID_KEY = "ccrecall-sync-current"
 # warning isn't suppressed. Do not "normalize" the hyphen — it is load-bearing.
 COLD_MODEL_LOGGER_NAME = "ccrecall.cold-model"
 
+# Hook-contract payload printed at every early-return site, serialized once.
+# The success path is excluded: it may add suppressOutput before dumping.
+_CONTINUE_OUTPUT = json.dumps({"continue": True})
+
 
 def _warn_cold_model() -> None:
     """Best-effort warning when the embedding model is absent from the disk cache.
@@ -130,7 +134,7 @@ def run(input_file: Path | None = None) -> None:
     # accumulates a stuck process per Stop hook.
     if not try_acquire_pid_file(PID_KEY):
         # Another sync-current is alive — skip; recovered on the next Stop
-        print(json.dumps({"continue": True}))
+        print(_CONTINUE_OUTPUT)
         return
 
     try:
@@ -159,7 +163,7 @@ def run(input_file: Path | None = None) -> None:
 
         if not session_id or not validate_session_id(session_id):
             # No session ID or invalid format — exit silently
-            print(json.dumps({"continue": True}))
+            print(_CONTINUE_OUTPUT)
             return
 
         # Honor exclude_projects for the live session too — import applies it on the
@@ -174,13 +178,13 @@ def run(input_file: Path | None = None) -> None:
             project_name = extract_project_name(normalize_cwd(hook_input.cwd))
             if project_name in exclude_projects:
                 logger.info("Skipping sync — project %r is excluded", project_name)
-                print(json.dumps({"continue": True}))
+                print(_CONTINUE_OUTPUT)
                 return
 
         session_file = get_session_file(DEFAULT_PROJECTS_DIR, session_id)
 
         if not session_file:
-            print(json.dumps({"continue": True}))
+            print(_CONTINUE_OUTPUT)
             return
 
         # Warn best-effort if the model hasn't been warmed in this detached process:
@@ -235,7 +239,7 @@ def run(input_file: Path | None = None) -> None:
         except Exception as e:
             logger.error("Sync error: %s", e)
             # Don't block Claude on sync errors
-            print(json.dumps({"continue": True}))
+            print(_CONTINUE_OUTPUT)
             sys.exit(0)
 
     finally:

--- a/tests/test_backfill_embeddings.py
+++ b/tests/test_backfill_embeddings.py
@@ -252,7 +252,6 @@ class TestBackfillEmbedsFull:
         n_exchanges = MAX_WRITE_PATH_EMBEDS_PER_SYNC * 2 + 3  # well over the write-path cap
         bid = _insert_branch_with_messages(conn, num_exchanges=n_exchanges)
 
-        exit_code = None
         with (
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
             patch("ccrecall.embed_ops.embed_batch", side_effect=lambda texts: [_FIXED_VEC] * len(texts)),

--- a/tests/test_sync_hook.py
+++ b/tests/test_sync_hook.py
@@ -653,7 +653,7 @@ class TestSearchConversationsDbFlag:
 class TestSyncCurrentExcludeProjects:
     """sync_current.run honors exclude_projects for the live session (matches import)."""
 
-    def _run(self, tmp_path, monkeypatch, *, settings, cwd):
+    def _run_with_excludes(self, tmp_path, monkeypatch, *, settings, cwd):
         monkeypatch.setattr("ccrecall.config.pid_file_path", lambda key: tmp_path / f".pid-{key}")
         monkeypatch.setattr(sync_current, "remove_pid_file", lambda key: None)
         monkeypatch.setattr(sync_current, "load_settings", lambda: settings)
@@ -671,7 +671,7 @@ class TestSyncCurrentExcludeProjects:
         return synced, json.loads(captured.getvalue())
 
     def test_excluded_project_skips_before_sync(self, tmp_path, monkeypatch):
-        synced, out = self._run(
+        synced, out = self._run_with_excludes(
             tmp_path,
             monkeypatch,
             settings={"exclude_projects": ["secret-repo"], "logging_enabled": False},
@@ -681,7 +681,7 @@ class TestSyncCurrentExcludeProjects:
         assert synced == []  # neither get_session_file nor sync_session reached
 
     def test_non_excluded_project_proceeds_past_guard(self, tmp_path, monkeypatch):
-        synced, out = self._run(
+        synced, out = self._run_with_excludes(
             tmp_path,
             monkeypatch,
             settings={"exclude_projects": ["secret-repo"], "logging_enabled": False},
@@ -699,7 +699,7 @@ class TestSyncCurrentConcurrencyGuard:
         p.write_text(json.dumps({"session_id": session_id}))
         return p
 
-    def _run(self, tmp_path, monkeypatch, *, session_id=VALID_SYNC_UUID, extra_patches=None):
+    def _run_with_lock_path(self, tmp_path, monkeypatch, *, session_id=VALID_SYNC_UUID, extra_patches=None):
         monkeypatch.setattr("ccrecall.config.pid_file_path", lambda key: tmp_path / f".pid-{key}")
         monkeypatch.setattr(sync_current, "remove_pid_file", lambda key: None)
         monkeypatch.setattr(sync_current, "load_settings", lambda: {"exclude_projects": [], "logging_enabled": False})
@@ -780,7 +780,7 @@ class TestSyncCurrentConcurrencyGuard:
     def test_first_sync_completes_normally_without_lock(self, tmp_path, monkeypatch):
         """When no lock file exists, sync-current runs normally (no skip)."""
         reached = []
-        out = self._run(
+        out = self._run_with_lock_path(
             tmp_path,
             monkeypatch,
             extra_patches={"get_session_file": lambda *a, **k: reached.append(1) or None},
@@ -792,7 +792,7 @@ class TestSyncCurrentConcurrencyGuard:
         """Stop hook firing before ~/.ccrecall/ exists must not crash — run() creates it."""
         # runtime_dir is where the pid file lives; it does not exist yet (only
         # tmp_path does), so run() must create it before opening the lock.
-        # Can't reuse _run here: it pins pid_file_path to tmp_path, which always
+        # Can't reuse _run_with_lock_path here: it pins pid_file_path to tmp_path, which always
         # exists and so wouldn't exercise the missing-dir path.
         runtime_dir = tmp_path / "absent"
         monkeypatch.setattr("ccrecall.config.pid_file_path", lambda key: runtime_dir / f".pid-{key}")
@@ -911,7 +911,7 @@ class TestSyncEmbeddingStatusRecording:
     and are detected authoritatively by backfill_embeddings instead.
     """
 
-    def _run(
+    def _run_with_mock_conn(
         self,
         tmp_path,
         monkeypatch,
@@ -957,7 +957,7 @@ class TestSyncEmbeddingStatusRecording:
         """chunk_vec_queryable() → False in sync_current writes 'vec_unavailable' to sidecar."""
         sidecar = tmp_path / "embedding-status.json"
 
-        self._run(
+        self._run_with_mock_conn(
             tmp_path,
             monkeypatch,
             vec_queryable=False,
@@ -977,7 +977,7 @@ class TestSyncEmbeddingStatusRecording:
         # Pre-seed sidecar as if there was a prior failure
         sidecar.write_text(json.dumps({"reason": REASON_VEC_UNAVAILABLE, "since": "2026-01-01T00:00:00Z"}))
 
-        self._run(
+        self._run_with_mock_conn(
             tmp_path,
             monkeypatch,
             vec_queryable=True,
@@ -995,7 +995,7 @@ class TestSyncEmbeddingStatusRecording:
 
         clear_calls = []
 
-        self._run(
+        self._run_with_mock_conn(
             tmp_path,
             monkeypatch,
             vec_queryable=False,
@@ -1014,7 +1014,7 @@ class TestSyncEmbeddingStatusRecording:
         def raising_record(reason):
             raise OSError("disk full")
 
-        out = self._run(
+        out = self._run_with_mock_conn(
             tmp_path,
             monkeypatch,
             vec_queryable=False,


### PR DESCRIPTION
Mechanical tech-debt cleanup from the nitpicker pass on #90's ship review. No behavior changes — constants extraction, payload centralization, dead-code removal, and test-helper renames.

### Constant extraction

- `embeddings.py`: extract the duplicated `"\n\n[...]\n\n"` cap marker literal to the module constant `_CAP_MARKER`. Both build sites in `cap_for_embedding` must agree on the marker, so the literal now lives in exactly one place.
- `sync_current.py`: centralize the hook-contract payload as `_CONTINUE_OUTPUT` instead of six bare `json.dumps({"continue": True})` prints at the early-return sites. The success path keeps its own dict — it may add `suppressOutput` before dumping, so it is deliberately excluded from the shared constant.

### Test cleanup

- `test_sync_hook.py`: three unrelated helpers all named `_run` renamed by what each harness sets up (`_run_with_excludes`, `_run_with_lock_path`, `_run_with_mock_conn`), so a reader can tell the fixtures apart at the call site.
- `test_backfill_embeddings.py`: delete a dead `exit_code = None` init that was always overwritten before its only read.

### Findings evaluated and left as-is

- `_warn_cold_model` keeps its hand-rolled `RotatingFileHandler`: `setup_logging`'s `logging_enabled` gate would suppress exactly the warning that path exists to emit.
- The conftest import grouping matches ruff's isort arrangement — any regrouping gets reverted by the linter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when formatting truncated text for embeddings.
  * Standardized hook continuation responses across early-exit scenarios.

* **Tests**
  * Improved test helper clarity and coverage for synchronization, locking, exclusions, and embedding status handling.
  * Simplified test setup for full embedding backfill runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->