### PR TITLE
feat: add consolidated ingestion status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-07-30
+
+### Features
+
+* add consolidated ingestion status ([#93](https://github.com/NodeJSmith/claude-code-recall/issues/93))
+
 ## [0.19.4](https://github.com/NodeJSmith/claude-code-recall/compare/v0.19.3...v0.19.4) (2026-07-28)
 
 

--- a/src/ccrecall/cli/__init__.py
+++ b/src/ccrecall/cli/__init__.py
@@ -33,9 +33,9 @@ app = App(
     help_epilogue=(
         "Examples:\n"
         "  ccrecall recent --n 5\n"
+        "  ccrecall status --check-ingestion\n"
         "  ccrecall --json search -q 'auth bug'\n"
-        "  ccrecall tail <session-id>\n"
-        "  ccrecall backfill embeddings --status"
+        "  ccrecall tail <session-id>"
     ),
 )
 

--- a/src/ccrecall/cli/commands.py
+++ b/src/ccrecall/cli/commands.py
@@ -6,7 +6,6 @@ PID-file lifecycle are preserved from the former cm-* entry points; only the
 argument-parsing layer changed (argparse -> cyclopts).
 """
 
-import logging
 import sys
 from pathlib import Path
 from typing import Annotated, Literal
@@ -17,10 +16,11 @@ from cyclopts.validators import Number
 from ccrecall import recent_chats as recent_chats_mod
 from ccrecall import search_cli as search_mod
 from ccrecall import session_tail as session_tail_mod
+from ccrecall import status as status_mod
 from ccrecall.cli import app, backfill_app
 from ccrecall.cli.context import DEFAULT_CLI_CONTEXT, CLIContextParam
-from ccrecall.config import DEFAULT_DB_PATH, load_settings, try_acquire_pid_file
-from ccrecall.db import DEFAULT_PROJECTS_DIR, get_connection
+from ccrecall.config import DEFAULT_DB_PATH, try_acquire_pid_file
+from ccrecall.db import DEFAULT_PROJECTS_DIR
 from ccrecall.embeddings import DEFAULT_EMBED_THREADS
 from ccrecall.hooks import backfill_embeddings as backfill_embeddings_mod
 from ccrecall.hooks import backfill_query as backfill_query_mod
@@ -28,7 +28,6 @@ from ccrecall.hooks import backfill_summaries as backfill_summaries_mod
 from ccrecall.hooks import backfill_tool_content as backfill_tool_content_mod
 from ccrecall.hooks import import_conversations as import_mod
 from ccrecall.hooks import sync_current as sync_current_mod
-from ccrecall.models import LOGGER_NAME
 
 # store_true flags carry no --no-<flag> negation, matching the former argparse.
 _FLAG = Parameter(negative=[])
@@ -95,24 +94,6 @@ def cmd_import(
     import_mod.run(db=db, projects_dir=projects_dir, project=project, verbose=ctx.debug)
 
 
-def count_multi_active_branch_sessions(db: Path) -> int:
-    """Return the count of sessions with more than one active branch.
-
-    Session-keyed branch identity (branch_ops.upsert_branch) should make this
-    always zero going forward — this is a standing invariant check, not an
-    expected condition. Read-only: shares no PID lifecycle with import.run().
-    """
-    settings = load_settings()
-    if db != DEFAULT_DB_PATH:
-        settings["db_path"] = str(db)
-    with get_connection(settings, load_vec=False) as conn:
-        cursor = conn.cursor()
-        cursor.execute(
-            "SELECT session_id, COUNT(*) as cnt FROM branches WHERE is_active = 1 GROUP BY session_id HAVING cnt > 1"
-        )
-        return len(cursor.fetchall())
-
-
 @app.command(name="stats")
 def cmd_stats(
     *,
@@ -123,12 +104,24 @@ def cmd_stats(
     # import.run(), so it can't disturb a concurrent background import.
     import_mod.print_stats(db=db)
 
-    violations = count_multi_active_branch_sessions(db)
-    print(f"Branch invariant violations: {violations} session(s) with multiple active branches")
-    if violations:
-        logging.getLogger(LOGGER_NAME).warning(
-            "branch invariant violated: %d session(s) have more than one active branch", violations
-        )
+
+@app.command(name="status")
+def cmd_status(
+    *,
+    db: Annotated[Path, Parameter(help="Database path.")] = DEFAULT_DB_PATH,
+    days: Annotated[
+        int | None,
+        Parameter(validator=Number(gte=1), help="Only scope tool-content and embedding status to the last N days."),
+    ] = None,
+    check_ingestion: Annotated[
+        bool,
+        _FLAG,
+        Parameter(help="Deep-check JSONL transcripts against DB rows to classify ingestion gaps."),
+    ] = False,
+    ctx: CLIContextParam = DEFAULT_CLI_CONTEXT,
+) -> None:
+    """Show consolidated read-only health and backfill status."""
+    status_mod.run(db=db, days=days, check_ingestion=check_ingestion, output_format=ctx.output_format)
 
 
 @backfill_app.command(name="summaries")
@@ -143,7 +136,11 @@ def cmd_backfill_summaries(
 @backfill_app.command(name="embeddings")
 def cmd_backfill_embeddings(
     *,
-    status: Annotated[bool, _FLAG, Parameter(help="Report progress and exit without embedding (read-only).")] = False,
+    status: Annotated[
+        bool,
+        _FLAG,
+        Parameter(help="Report legacy embedding-only progress and exit; prefer `ccrecall status`."),
+    ] = False,
     days: Annotated[
         int | None,
         Parameter(validator=Number(gte=1), help="Only embed branches ended within the last N days (>= 1)."),

--- a/src/ccrecall/hooks/backfill_tool_content.py
+++ b/src/ccrecall/hooks/backfill_tool_content.py
@@ -70,21 +70,17 @@ from ccrecall.hooks.backfill_query import (
     EXIT_OK,
 )
 from ccrecall.hooks.backfill_status import format_duration
-from ccrecall.hooks.tool_content_eligibility import (
-    ELIGIBILITY_FROM,
-    MAX_SQL_PARAMS,
-    days_modifier,
-    eligibility_clause,
-)
+from ccrecall.hooks.tool_content_eligibility import ELIGIBILITY_FROM, MAX_SQL_PARAMS, eligibility_clause
+from ccrecall.import_log_ops import import_log_source_index
 from ccrecall.message_ops import insert_new_messages
 from ccrecall.models import LOGGER_NAME
 from ccrecall.parsing import (
     build_aggregated_content,
-    extract_session_uuid,
     find_all_branches,
     is_insertable_message,
     parse_all_with_uuids,
 )
+from ccrecall.tool_content_status import count_eligible, count_pending_missing_jsonl, count_total_sessions
 
 _PRINT_PREFIX = "ccrecall backfill tool-content"
 _LOG_PREFIX = "Backfill tool-content"
@@ -367,28 +363,12 @@ def build_filepath_index(cursor: sqlite3.Cursor, logger: logging.Logger) -> dict
     with zero surviving files gets no index entry, and the caller skips it.
     """
     mapping: dict[str, list[Path]] = {}
-    for (file_path,) in cursor.execute("SELECT file_path FROM import_log").fetchall():
-        path = Path(file_path)
-        if path.exists():
-            mapping.setdefault(extract_session_uuid(path), []).append(path)
-        else:
-            logger.warning("%s: JSONL missing on disk: %s", _LOG_PREFIX, file_path)
+    for session_uuid, paths in import_log_source_index(cursor).items():
+        if paths["existing"]:
+            mapping[session_uuid] = paths["existing"]
+        for path in paths["missing"]:
+            logger.warning("%s: JSONL missing on disk: %s", _LOG_PREFIX, path)
     return mapping
-
-
-def count_eligible(cursor: sqlite3.Cursor, days: int | None) -> int:
-    where, params = eligibility_clause(days)
-    return cursor.execute(f"SELECT COUNT(DISTINCT s.id) {ELIGIBILITY_FROM} {where}", params).fetchone()[0]
-
-
-def count_total_sessions(cursor: sqlite3.Cursor, days: int | None) -> int:
-    """Count every session with messages (the backfill's universe), for --status."""
-    where = "WHERE 1=1"
-    params: list = []
-    if days is not None:
-        where += " AND b.ended_at > datetime('now', ?)"
-        params.append(days_modifier(days))
-    return cursor.execute(f"SELECT COUNT(DISTINCT s.id) {ELIGIBILITY_FROM} {where}", params).fetchone()[0]
 
 
 def select_batch(cursor: sqlite3.Cursor, exclude_ids: set[int], days: int | None) -> list[tuple[int, str]]:
@@ -548,6 +528,7 @@ def run_status(
         with get_connection(settings, load_vec=False) as conn:
             cursor = conn.cursor()
             pending = count_eligible(cursor, days)
+            pending_missing = count_pending_missing_jsonl(cursor, days)
             total = count_total_sessions(cursor, days)
     except (sqlite3.Error, OSError) as e:
         logger.exception("%s: status aborted", _LOG_PREFIX)
@@ -555,8 +536,20 @@ def run_status(
         return EXIT_ABORT
 
     done = total - pending
+    pending_backfillable = pending - pending_missing
     if json_mode:
-        print(json.dumps({"total_sessions": total, "pending_sessions": pending, "done_sessions": done, "days": days}))
+        print(
+            json.dumps(
+                {
+                    "total_sessions": total,
+                    "pending_sessions": pending,
+                    "pending_backfillable_sessions": pending_backfillable,
+                    "pending_missing_jsonl_sessions": pending_missing,
+                    "done_sessions": done,
+                    "days": days,
+                }
+            )
+        )
         return EXIT_OK
 
     pct = (done / total * 100) if total else 0.0
@@ -564,4 +557,8 @@ def run_status(
     print(f"{_PRINT_PREFIX} status{scope}:")
     print(f"  sessions:  {done} / {total} backfilled  ({pct:.0f}%)")
     print(f"  remaining: {pending} sessions")
+    if pending:
+        print(f"  backfillable: {pending_backfillable} sessions")
+    if pending_missing:
+        print(f"  missing JSONL: {pending_missing} sessions  (some or all source files missing)")
     return EXIT_OK

--- a/src/ccrecall/hooks/backfill_tool_content.py
+++ b/src/ccrecall/hooks/backfill_tool_content.py
@@ -528,7 +528,7 @@ def run_status(
         with get_connection(settings, load_vec=False) as conn:
             cursor = conn.cursor()
             pending = count_eligible(cursor, days)
-            pending_missing = count_pending_missing_jsonl(cursor, days)
+            pending_missing = count_pending_missing_jsonl(cursor, days) if pending else 0
             total = count_total_sessions(cursor, days)
     except (sqlite3.Error, OSError) as e:
         logger.exception("%s: status aborted", _LOG_PREFIX)

--- a/src/ccrecall/hooks/import_conversations.py
+++ b/src/ccrecall/hooks/import_conversations.py
@@ -22,15 +22,16 @@ from ccrecall.config import DEFAULT_DB_PATH, get_db_path, load_settings, remove_
 from ccrecall.db import (
     DEFAULT_PROJECTS_DIR,
     TRIGGER_CHUNKS_VEC_AD,
-    branch_embedding_coverage,
     get_connection,
     vec_available,
 )
 from ccrecall.formatting import extract_project_name, normalize_project_key
+from ccrecall.import_log_ops import has_pending_tool_content
 from ccrecall.models import LOGGER_NAME
 from ccrecall.parsing import extract_session_uuid
 from ccrecall.project_ops import upsert_project
 from ccrecall.session_ops import sync_session
+from ccrecall.status import run as run_status
 
 # Chunk size for streaming a file through the change-detection hash (bounded memory).
 HASH_CHUNK_SIZE = 8192
@@ -89,13 +90,23 @@ def import_session(
         (str(filepath),),
     )
     log_row = cursor.fetchone()
-    if log_row and log_row[2] == file_size and log_row[3] == file_mtime:
+    if (
+        log_row
+        and log_row[2] == file_size
+        and log_row[3] == file_mtime
+        and not has_pending_tool_content(cursor, filepath)
+    ):
         log.debug("skip %s (%.1f MB, stat match)", filepath.name, file_size / BYTES_PER_MB)
         return -1, 0
 
     # Stat changed or no prior record — fall back to full hash comparison.
     file_hash = get_file_hash(filepath)
-    if log_row and log_row[1] is not None and log_row[1] == file_hash:
+    if (
+        log_row
+        and log_row[1] is not None
+        and log_row[1] == file_hash
+        and not has_pending_tool_content(cursor, filepath)
+    ):
         # Content unchanged despite stat difference (e.g. touch without edit).
         # Update stored stat so the fast path works next time.
         cursor.execute(
@@ -246,46 +257,8 @@ def import_project(
 
 
 def print_stats(db: Path = DEFAULT_DB_PATH) -> None:
-    """Print row counts and on-disk size for the memory DB to stdout.
-
-    Read-only: deliberately does NOT touch the import PID file (it shares no
-    lifecycle with run()), so `ccrecall stats` can't delete a live background
-    import's PID sentinel and let the session hook spawn a duplicate import.
-    load_vec=False keeps it genuinely read-only — the counts never query
-    chunk_vec, so there's no reason to create and commit the vec schema here.
-    """
-    settings = load_settings()
-    if db != DEFAULT_DB_PATH:
-        settings["db_path"] = str(db)
-    db_path = get_db_path(settings)
-
-    with get_connection(settings, load_vec=False) as conn:
-        cursor = conn.cursor()
-        cursor.execute("SELECT COUNT(*) FROM projects")
-        projects = cursor.fetchone()[0]
-        cursor.execute("SELECT COUNT(*) FROM sessions")
-        sessions = cursor.fetchone()[0]
-        cursor.execute("SELECT COUNT(*) FROM messages")
-        messages = cursor.fetchone()[0]
-        cursor.execute("SELECT COUNT(*) FROM branches")
-        total_branches = cursor.fetchone()[0]
-        cursor.execute("SELECT COUNT(*) FROM branches WHERE is_active = 1")
-        active = cursor.fetchone()[0]
-        # Branch-grain embedding coverage (vec-free watermark count).
-        embedded, embeddable = branch_embedding_coverage(conn)
-
-    db_size = db_path.stat().st_size if db_path.exists() else 0
-
-    print(f"Database: {db_path}")
-    print(f"Size: {db_size / BYTES_PER_MB:.2f} MB")
-    print(f"Projects: {projects}")
-    print(f"Sessions: {sessions}")
-    print(f"Branches: {total_branches} ({active} active)")
-    print(f"Messages: {messages}")
-    if embeddable:
-        print(f"Embeddings: {embedded}/{embeddable} branches ({embedded / embeddable * 100:.0f}%)")
-    else:
-        print("Embeddings: 0/0 branches")
+    """Print consolidated read-only status for backward-compatible ``stats`` callers."""
+    run_status(db=db)
 
 
 def run(

--- a/src/ccrecall/hooks/import_conversations.py
+++ b/src/ccrecall/hooks/import_conversations.py
@@ -28,7 +28,7 @@ from ccrecall.db import (
 from ccrecall.formatting import extract_project_name, normalize_project_key
 from ccrecall.import_log_ops import has_pending_tool_content
 from ccrecall.models import LOGGER_NAME
-from ccrecall.parsing import extract_session_uuid
+from ccrecall.parsing import extract_session_uuid, sort_session_files
 from ccrecall.project_ops import upsert_project
 from ccrecall.session_ops import sync_session
 from ccrecall.status import run as run_status
@@ -68,6 +68,8 @@ def import_session(
     conn: sqlite3.Connection,
     filepath: Path,
     project_id: int,
+    *,
+    force: bool = False,
 ) -> tuple[int, int]:
     """
     Import a single session JSONL file with v3 schema.
@@ -94,6 +96,7 @@ def import_session(
         log_row
         and log_row[2] == file_size
         and log_row[3] == file_mtime
+        and not force
         and not has_pending_tool_content(cursor, filepath)
     ):
         log.debug("skip %s (%.1f MB, stat match)", filepath.name, file_size / BYTES_PER_MB)
@@ -105,6 +108,7 @@ def import_session(
         log_row
         and log_row[1] is not None
         and log_row[1] == file_hash
+        and not force
         and not has_pending_tool_content(cursor, filepath)
     ):
         # Content unchanged despite stat difference (e.g. touch without edit).
@@ -128,6 +132,7 @@ def import_session(
         embed=False,
         file_size=file_size,
         file_mtime=file_mtime,
+        force=force,
     )
 
     if new_messages == -1:
@@ -202,6 +207,10 @@ def _noop() -> None:
     pass
 
 
+def _project_file_order(filepath: Path) -> tuple[str, bool, str]:
+    return extract_session_uuid(filepath), filepath.name.startswith("agent-"), filepath.name
+
+
 def import_project(
     conn: sqlite3.Connection,
     project_dir: Path,
@@ -230,18 +239,33 @@ def import_project(
     sessions_imported = 0
     messages_imported = 0
     sessions_skipped = 0
-
-    for jsonl_file in sorted(project_dir.glob("*.jsonl")):
+    jsonl_files_by_session: dict[str, list[Path]] = {}
+    for jsonl_file in sorted(project_dir.glob("*.jsonl"), key=_project_file_order):
         if jsonl_file.name.startswith("."):
             continue
+        jsonl_files_by_session.setdefault(extract_session_uuid(jsonl_file), []).append(jsonl_file)
 
-        branches_count, msg_count = import_session(conn, jsonl_file, project_id)
-        if branches_count == -1:
-            sessions_skipped += 1
-        else:
-            sessions_imported += branches_count
-            messages_imported += msg_count
-            reclaim_memory()
+    processed: set[Path] = set()
+    for jsonl_file in [path for files in jsonl_files_by_session.values() for path in files]:
+        if jsonl_file in processed:
+            continue
+
+        repair_group = has_pending_tool_content(cursor, jsonl_file)
+        targets = (
+            sort_session_files(jsonl_files_by_session[extract_session_uuid(jsonl_file)])
+            if repair_group
+            else [jsonl_file]
+        )
+        targets = [target for target in targets if target not in processed]
+        for target in targets:
+            branches_count, msg_count = import_session(conn, target, project_id, force=repair_group)
+            processed.add(target)
+            if branches_count == -1:
+                sessions_skipped += 1
+            else:
+                sessions_imported += branches_count
+                messages_imported += msg_count
+                reclaim_memory()
 
     if sessions_imported or sessions_skipped:
         log.debug(

--- a/src/ccrecall/import_log_ops.py
+++ b/src/ccrecall/import_log_ops.py
@@ -10,8 +10,39 @@ import sqlite3
 from pathlib import Path
 
 from ccrecall.models import LOGGER_NAME
+from ccrecall.parsing import extract_session_uuid, parse_all_with_uuids
 
 log = logging.getLogger(LOGGER_NAME)
+
+
+def has_pending_tool_content(cursor: sqlite3.Cursor, filepath: Path) -> bool:
+    """Return True when this transcript file can repair pending tool_content rows."""
+    session_uuid = extract_session_uuid(filepath)
+    cursor.execute(
+        """
+        SELECT m.uuid
+        FROM sessions s
+        JOIN messages m ON m.session_id = s.id
+        WHERE s.uuid = ? AND m.tool_content IS NULL
+        """,
+        (session_uuid,),
+    )
+    pending_uuids = {row[0] for row in cursor.fetchall() if row[0]}
+    if not pending_uuids:
+        return False
+    file_uuids = {entry["uuid"] for entry in parse_all_with_uuids(filepath) if entry.get("uuid")}
+    return bool(pending_uuids & file_uuids)
+
+
+def import_log_source_index(cursor: sqlite3.Cursor) -> dict[str, dict[str, list[Path]]]:
+    """Group import_log paths by session UUID and whether each path still exists."""
+    sources: dict[str, dict[str, list[Path]]] = {}
+    for (file_path,) in cursor.execute("SELECT file_path FROM import_log").fetchall():
+        path = Path(file_path)
+        session_uuid = extract_session_uuid(path)
+        bucket = sources.setdefault(session_uuid, {"existing": [], "missing": []})
+        bucket["existing" if path.exists() else "missing"].append(path)
+    return sources
 
 
 def import_log_skip_check(
@@ -31,7 +62,12 @@ def import_log_skip_check(
         (str(filepath),),
     )
     log_row = cursor.fetchone()
-    if log_row and log_row[1] is not None and log_row[1] == file_hash:
+    if (
+        log_row
+        and log_row[1] is not None
+        and log_row[1] == file_hash
+        and not has_pending_tool_content(cursor, filepath)
+    ):
         return log_row, True
     return log_row, False
 

--- a/src/ccrecall/import_log_ops.py
+++ b/src/ccrecall/import_log_ops.py
@@ -18,6 +18,11 @@ log = logging.getLogger(LOGGER_NAME)
 def has_pending_tool_content(cursor: sqlite3.Cursor, filepath: Path) -> bool:
     """Return True when this transcript file can repair pending tool_content rows."""
     session_uuid = extract_session_uuid(filepath)
+    return transcript_contains_pending_tool_content(cursor, session_uuid, filepath)
+
+
+def pending_tool_content_uuids(cursor: sqlite3.Cursor, session_uuid: str) -> set[str]:
+    """Return message UUIDs whose tool_content is still NULL for one session."""
     cursor.execute(
         """
         SELECT m.uuid
@@ -27,11 +32,20 @@ def has_pending_tool_content(cursor: sqlite3.Cursor, filepath: Path) -> bool:
         """,
         (session_uuid,),
     )
-    pending_uuids = {row[0] for row in cursor.fetchall() if row[0]}
+    return {row[0] for row in cursor.fetchall() if row[0]}
+
+
+def transcript_contains_pending_tool_content(cursor: sqlite3.Cursor, session_uuid: str, filepath: Path) -> bool:
+    """Return True when ``filepath`` contains any pending tool_content UUID for ``session_uuid``."""
+    return bool(transcript_pending_tool_content_uuids(filepath, pending_tool_content_uuids(cursor, session_uuid)))
+
+
+def transcript_pending_tool_content_uuids(filepath: Path, pending_uuids: set[str]) -> set[str]:
+    """Return pending tool_content UUIDs present in one transcript file."""
     if not pending_uuids:
-        return False
+        return set()
     file_uuids = {entry["uuid"] for entry in parse_all_with_uuids(filepath) if entry.get("uuid")}
-    return bool(pending_uuids & file_uuids)
+    return pending_uuids & file_uuids
 
 
 def import_log_source_index(cursor: sqlite3.Cursor) -> dict[str, dict[str, list[Path]]]:
@@ -49,11 +63,14 @@ def import_log_skip_check(
     cursor: sqlite3.Cursor,
     filepath: Path,
     file_hash: str | None,
+    *,
+    force: bool = False,
 ) -> tuple[tuple | None, bool]:
     """Probe import_log for an existing row; return (log_row, should_skip).
 
     Returns (log_row, True) when file_hash is provided and the stored hash is
-    non-NULL and matches — caller should return -1.
+    non-NULL and matches, no pending tool_content can be repaired from this
+    file, and force is false — caller should return -1.
     Returns (log_row, False) otherwise (NULL-hash stale or no row).
     Preserves the NULL-hash-stale asymmetry: a stored NULL is never a match.
     """
@@ -62,6 +79,8 @@ def import_log_skip_check(
         (str(filepath),),
     )
     log_row = cursor.fetchone()
+    if force:
+        return log_row, False
     if (
         log_row
         and log_row[1] is not None

--- a/src/ccrecall/ingestion_status.py
+++ b/src/ccrecall/ingestion_status.py
@@ -1,25 +1,20 @@
 """Read-only transcript-vs-DB ingestion coverage diagnostics."""
 
-import time
 from pathlib import Path
 from sqlite3 import Connection
 
-from ccrecall.content import extract_text_content, is_tool_result
+from whenever import Instant
+
 from ccrecall.import_log_ops import import_log_source_index
-from ccrecall.parsing import is_insertable_message, parse_all_with_uuids
+from ccrecall.message_ops import message_content_parts
+from ccrecall.parsing import parse_all_with_uuids, select_active_leaf_entry
 
 STALE_TAIL_SECONDS = 15 * 60
 
 
 def _entry_expects_message(entry: dict) -> bool:
-    """Mirror message_ops.build_message_row's content-based skip rules."""
-    if not is_insertable_message(entry):
-        return False
-    content = entry.get("message", {}).get("content", "")
-    if entry.get("type") == "user" and is_tool_result(content):
-        return False
-    text, _has_tool_use, _has_thinking, _tool_summary, tool_content = extract_text_content(content)
-    return bool(text or tool_content)
+    """True when an entry should have a ``messages`` row after ingestion."""
+    return message_content_parts(entry) is not None
 
 
 def _expected_uuids(filepaths: list[Path]) -> list[str]:
@@ -27,11 +22,11 @@ def _expected_uuids(filepaths: list[Path]) -> list[str]:
     entries: list[dict] = []
     for filepath in filepaths:
         entries.extend(parse_all_with_uuids(filepath))
-    uuid_to_entry = {entry["uuid"]: entry for entry in entries if entry.get("uuid")}
-    if not uuid_to_entry:
+    latest = select_active_leaf_entry(entries)
+    if latest is None:
         return []
 
-    latest = max(uuid_to_entry.values(), key=lambda entry: entry.get("timestamp") or "")
+    uuid_to_entry = {entry["uuid"]: entry for entry in entries if entry.get("uuid")}
     ordered_branch: list[dict] = []
     current_uuid: str | None = latest["uuid"]
     while current_uuid:
@@ -50,7 +45,12 @@ def _is_contiguous_suffix(indices: list[int], total: int) -> bool:
     return indices == list(range(indices[0], total))
 
 
-def summarize_ingestion(conn: Connection, *, stale_tail_seconds: int = STALE_TAIL_SECONDS) -> dict[str, int]:
+def summarize_ingestion(
+    conn: Connection,
+    *,
+    stale_tail_seconds: int = STALE_TAIL_SECONDS,
+    sources: dict[str, dict[str, list[Path]]] | None = None,
+) -> dict[str, int]:
     """Classify transcript ingestion gaps by comparing JSONL UUID order to DB rows.
 
     ``pending_tail`` means the DB is missing only a contiguous suffix from an
@@ -61,7 +61,8 @@ def summarize_ingestion(conn: Connection, *, stale_tail_seconds: int = STALE_TAI
     with import-log rows but no surviving JSONL is counted as ``missing_source``.
     """
     cursor = conn.cursor()
-    sources = import_log_source_index(cursor)
+    if sources is None:
+        sources = import_log_source_index(cursor)
 
     summary = {
         "sessions_checked": 0,
@@ -82,7 +83,7 @@ def summarize_ingestion(conn: Connection, *, stale_tail_seconds: int = STALE_TAI
             summary["sessions_checked"] += 1
             summary["missing_source_sessions"] += 1
 
-    now = time.time()
+    now = Instant.now()
     for session_uuid, paths in sources.items():
         if paths["missing"]:
             continue
@@ -107,8 +108,8 @@ def summarize_ingestion(conn: Connection, *, stale_tail_seconds: int = STALE_TAI
             continue
 
         if _is_contiguous_suffix(missing_indices, len(expected)):
-            newest_mtime = max(path.stat().st_mtime for path in filepaths)
-            if now - newest_mtime <= stale_tail_seconds:
+            newest_mtime = max(Instant.from_timestamp(path.stat().st_mtime) for path in filepaths)
+            if (now - newest_mtime).total("seconds") <= stale_tail_seconds:
                 summary["pending_tail_sessions"] += 1
                 summary["pending_tail_turns"] += len(missing_indices)
             else:

--- a/src/ccrecall/ingestion_status.py
+++ b/src/ccrecall/ingestion_status.py
@@ -1,0 +1,121 @@
+"""Read-only transcript-vs-DB ingestion coverage diagnostics."""
+
+import time
+from pathlib import Path
+from sqlite3 import Connection
+
+from ccrecall.content import extract_text_content, is_tool_result
+from ccrecall.import_log_ops import import_log_source_index
+from ccrecall.parsing import is_insertable_message, parse_all_with_uuids
+
+STALE_TAIL_SECONDS = 15 * 60
+
+
+def _entry_expects_message(entry: dict) -> bool:
+    """Mirror message_ops.build_message_row's content-based skip rules."""
+    if not is_insertable_message(entry):
+        return False
+    content = entry.get("message", {}).get("content", "")
+    if entry.get("type") == "user" and is_tool_result(content):
+        return False
+    text, _has_tool_use, _has_thinking, _tool_summary, tool_content = extract_text_content(content)
+    return bool(text or tool_content)
+
+
+def _expected_uuids(filepaths: list[Path]) -> list[str]:
+    """Return ordered active-branch UUIDs expected to have messages rows."""
+    entries: list[dict] = []
+    for filepath in filepaths:
+        entries.extend(parse_all_with_uuids(filepath))
+    uuid_to_entry = {entry["uuid"]: entry for entry in entries if entry.get("uuid")}
+    if not uuid_to_entry:
+        return []
+
+    latest = max(uuid_to_entry.values(), key=lambda entry: entry.get("timestamp") or "")
+    ordered_branch: list[dict] = []
+    current_uuid: str | None = latest["uuid"]
+    while current_uuid:
+        entry = uuid_to_entry.get(current_uuid)
+        if entry is None:
+            break
+        ordered_branch.append(entry)
+        current_uuid = entry.get("parentUuid")
+    ordered_branch.reverse()
+    return [entry["uuid"] for entry in ordered_branch if _entry_expects_message(entry)]
+
+
+def _is_contiguous_suffix(indices: list[int], total: int) -> bool:
+    if not indices:
+        return False
+    return indices == list(range(indices[0], total))
+
+
+def summarize_ingestion(conn: Connection, *, stale_tail_seconds: int = STALE_TAIL_SECONDS) -> dict[str, int]:
+    """Classify transcript ingestion gaps by comparing JSONL UUID order to DB rows.
+
+    ``pending_tail`` means the DB is missing only a contiguous suffix from an
+    existing transcript that was modified recently, which is normal while Claude
+    Code is still writing the session. ``stale_tail`` is the same shape after the
+    grace window. ``ingestion_gap`` means missing UUIDs are in the middle of the
+    expected active branch and should be recoverable by import/sync. A session
+    with import-log rows but no surviving JSONL is counted as ``missing_source``.
+    """
+    cursor = conn.cursor()
+    sources = import_log_source_index(cursor)
+
+    summary = {
+        "sessions_checked": 0,
+        "ok_sessions": 0,
+        "pending_tail_sessions": 0,
+        "pending_tail_turns": 0,
+        "stale_tail_sessions": 0,
+        "stale_tail_turns": 0,
+        "ingestion_gap_sessions": 0,
+        "ingestion_gap_turns": 0,
+        "missing_source_sessions": 0,
+    }
+
+    for session_uuid, paths in sources.items():
+        if not paths["missing"]:
+            continue
+        if cursor.execute("SELECT 1 FROM sessions WHERE uuid = ?", (session_uuid,)).fetchone() is not None:
+            summary["sessions_checked"] += 1
+            summary["missing_source_sessions"] += 1
+
+    now = time.time()
+    for session_uuid, paths in sources.items():
+        if paths["missing"]:
+            continue
+        filepaths = paths["existing"]
+        session_row = cursor.execute("SELECT id FROM sessions WHERE uuid = ?", (session_uuid,)).fetchone()
+        if session_row is None:
+            continue
+        summary["sessions_checked"] += 1
+        session_id = session_row[0]
+        existing_msg_uuids = {
+            row[0]
+            for row in cursor.execute(
+                "SELECT uuid FROM messages WHERE session_id = ? AND uuid IS NOT NULL",
+                (session_id,),
+            ).fetchall()
+        }
+
+        expected = _expected_uuids(filepaths)
+        missing_indices = [i for i, uuid in enumerate(expected) if uuid not in existing_msg_uuids]
+        if not missing_indices:
+            summary["ok_sessions"] += 1
+            continue
+
+        if _is_contiguous_suffix(missing_indices, len(expected)):
+            newest_mtime = max(path.stat().st_mtime for path in filepaths)
+            if now - newest_mtime <= stale_tail_seconds:
+                summary["pending_tail_sessions"] += 1
+                summary["pending_tail_turns"] += len(missing_indices)
+            else:
+                summary["stale_tail_sessions"] += 1
+                summary["stale_tail_turns"] += len(missing_indices)
+        else:
+            summary["ingestion_gap_sessions"] += 1
+            summary["ingestion_gap_turns"] += len(missing_indices)
+
+    return summary

--- a/src/ccrecall/message_ops.py
+++ b/src/ccrecall/message_ops.py
@@ -14,6 +14,20 @@ from ccrecall.content import (
     is_tool_result,
     parse_origin,
 )
+from ccrecall.parsing import is_insertable_message
+
+
+def message_content_parts(entry: dict) -> tuple[str, bool, str] | None:
+    """Return content fields for entries that should have a messages row."""
+    if not is_insertable_message(entry):
+        return None
+    content = entry.get("message", {}).get("content", "")
+    if entry.get("type") == "user" and is_tool_result(content):
+        return None
+    text, _has_tool_use, has_thinking, _tool_summary, tool_content = extract_text_content(content)
+    if not text and not tool_content:
+        return None
+    return text, has_thinking, tool_content
 
 
 def upsert_session(
@@ -50,18 +64,15 @@ def build_message_row(
     A tool-only assistant turn (no prose, just tool_use blocks) still produces a
     row — content is '' and tool_content carries the searchable marker text.
     """
-    entry_type = entry.get("type")
-    if entry_type not in ("user", "assistant"):
-        return None
-    content = entry.get("message", {}).get("content", "")
-    if entry_type == "user" and is_tool_result(content):
+    parts = message_content_parts(entry)
+    if parts is None:
         return None
     uuid = entry.get("uuid")
     if not uuid or uuid not in valid_branch_uuids or uuid in existing_uuids:
         return None
-    text, _has_tool_use, has_thinking, _tool_summary, tool_content = extract_text_content(content)
-    if not text and not tool_content:
-        return None
+    text, has_thinking, tool_content = parts
+    content = entry.get("message", {}).get("content", "")
+    entry_type = entry.get("type")
     is_notification = entry_type == "user" and (is_task_notification(content) or is_teammate_message(content))
     return (
         session_id,

--- a/src/ccrecall/message_ops.py
+++ b/src/ccrecall/message_ops.py
@@ -108,3 +108,31 @@ def insert_new_messages(
             new_count += 1
             existing_uuids.add(row[1])
     return new_count
+
+
+def update_missing_tool_content(
+    cursor: sqlite3.Cursor,
+    session_id: int,
+    messages: list[dict],
+    existing_uuids: set[str],
+) -> int:
+    """Populate tool_content for existing messages that predate the column.
+
+    ``insert_new_messages`` intentionally skips UUIDs already present in the DB.
+    That keeps normal re-syncs idempotent, but it also means a row created before
+    ``messages.tool_content`` existed would stay NULL until the explicit
+    backfill. Repair those rows whenever the transcript is parsed again.
+    """
+    updated = 0
+    for entry in messages:
+        uuid = entry.get("uuid")
+        if not uuid or uuid not in existing_uuids:
+            continue
+        content = entry.get("message", {}).get("content", "")
+        _text, _has_tool_use, _has_thinking, _tool_summary, tool_content = extract_text_content(content)
+        cursor.execute(
+            "UPDATE messages SET tool_content = ? WHERE session_id = ? AND uuid = ? AND tool_content IS NULL",
+            (tool_content, session_id, uuid),
+        )
+        updated += cursor.rowcount
+    return updated

--- a/src/ccrecall/parsing.py
+++ b/src/ccrecall/parsing.py
@@ -121,23 +121,26 @@ def select_active_leaf_entry(all_entries: list[dict]) -> dict | None:
 
 def sort_session_files(filepaths: list[Path]) -> list[Path]:
     """Order sibling transcript files so parent-chain segments replay before descendants."""
-    entries_by_path = {path: list(parse_all_with_uuids(path)) for path in filepaths}
+    entries_by_path = {
+        path: [
+            (entry.get("uuid"), entry.get("parentUuid"), entry.get("timestamp") or "")
+            for entry in parse_all_with_uuids(path)
+        ]
+        for path in filepaths
+    }
     uuid_to_parent = {
-        entry["uuid"]: entry.get("parentUuid")
-        for entries in entries_by_path.values()
-        for entry in entries
-        if entry.get("uuid")
+        uuid: parent_uuid for entries in entries_by_path.values() for uuid, parent_uuid, _timestamp in entries if uuid
     }
 
     def key(path: Path) -> tuple[str, int, str]:
         entries = entries_by_path[path]
         if not entries:
             return "", 0, path.name
-        latest_timestamp = max(entry.get("timestamp") or "" for entry in entries)
+        latest_timestamp = max(timestamp for _uuid, _parent_uuid, timestamp in entries)
         latest_depth = max(
-            branch_depth(entry["uuid"], uuid_to_parent)
-            for entry in entries
-            if entry.get("uuid") and (entry.get("timestamp") or "") == latest_timestamp
+            branch_depth(uuid, uuid_to_parent)
+            for uuid, _parent_uuid, timestamp in entries
+            if uuid and timestamp == latest_timestamp
         )
         return latest_timestamp, latest_depth, path.name
 

--- a/src/ccrecall/parsing.py
+++ b/src/ccrecall/parsing.py
@@ -94,6 +94,56 @@ def parse_all_with_uuids(filepath: Path) -> Generator[dict, None, None]:
         yield from parse_lines_with_uuids(f)
 
 
+def branch_depth(uuid: str, uuid_to_parent: dict[str, str | None]) -> int:
+    """Return ancestry depth for a transcript UUID within a parsed session graph."""
+    depth = 0
+    current: str | None = uuid
+    seen: set[str] = set()
+    while current and current not in seen:
+        seen.add(current)
+        depth += 1
+        current = uuid_to_parent.get(current)
+    return depth
+
+
+def select_active_leaf_entry(all_entries: list[dict]) -> dict | None:
+    """Pick the active leaf, preferring the deepest descendant when timestamps tie."""
+    uuid_to_entry = {entry["uuid"]: entry for entry in all_entries if entry.get("uuid")}
+    if not uuid_to_entry:
+        return None
+    uuid_to_parent = {uuid: entry.get("parentUuid") for uuid, entry in uuid_to_entry.items()}
+    latest_timestamp = max(entry.get("timestamp") or "" for entry in uuid_to_entry.values())
+    latest_candidates = [
+        entry for entry in uuid_to_entry.values() if (entry.get("timestamp") or "") == latest_timestamp
+    ]
+    return max(latest_candidates, key=lambda entry: branch_depth(entry["uuid"], uuid_to_parent))
+
+
+def sort_session_files(filepaths: list[Path]) -> list[Path]:
+    """Order sibling transcript files so parent-chain segments replay before descendants."""
+    entries_by_path = {path: list(parse_all_with_uuids(path)) for path in filepaths}
+    uuid_to_parent = {
+        entry["uuid"]: entry.get("parentUuid")
+        for entries in entries_by_path.values()
+        for entry in entries
+        if entry.get("uuid")
+    }
+
+    def key(path: Path) -> tuple[str, int, str]:
+        entries = entries_by_path[path]
+        if not entries:
+            return "", 0, path.name
+        latest_timestamp = max(entry.get("timestamp") or "" for entry in entries)
+        latest_depth = max(
+            branch_depth(entry["uuid"], uuid_to_parent)
+            for entry in entries
+            if entry.get("uuid") and (entry.get("timestamp") or "") == latest_timestamp
+        )
+        return latest_timestamp, latest_depth, path.name
+
+    return sorted(filepaths, key=key)
+
+
 def extract_session_metadata(entries: list[dict]) -> dict:
     """Extract session metadata from entries."""
     metadata = {
@@ -143,8 +193,10 @@ def find_all_branches(all_entries: list[dict]) -> list[dict]:
     if not uuid_to_entry:
         return []
 
-    # Find active branch (latest -> root)
-    latest = max(uuid_to_entry.values(), key=lambda e: e.get("timestamp") or "")
+    # Find active branch (latest/deepest leaf -> root)
+    latest = select_active_leaf_entry(all_entries)
+    if latest is None:
+        return []
     active_uuids: set[str] = set()
     current: str | None = latest["uuid"]
     while current:

--- a/src/ccrecall/session_ops.py
+++ b/src/ccrecall/session_ops.py
@@ -46,6 +46,7 @@ def sync_session(
     embed: bool = True,
     file_size: int | None = None,
     file_mtime: float | None = None,
+    *,
     force: bool = False,
 ) -> int:
     """Import a single JSONL session file, returning the count of new messages inserted (or -1 if skipped).
@@ -59,6 +60,8 @@ def sync_session(
     matches an existing *non-NULL* hash, the file is unchanged and the function
     returns -1; a stored ``NULL`` hash (a sync-written placeholder) with a
     provided ``file_hash`` is treated as stale and re-processed.
+    ``force=True`` bypasses the import_log hash-match skip and reprocesses the
+    transcript.
     ``_project_id``, when provided by the import_conversations.py adapter, is
     used directly so the project upsert step is skipped and no second DB lookup
     runs. ``embed`` controls whether chunk embeddings are written — the import

--- a/src/ccrecall/session_ops.py
+++ b/src/ccrecall/session_ops.py
@@ -46,6 +46,7 @@ def sync_session(
     embed: bool = True,
     file_size: int | None = None,
     file_mtime: float | None = None,
+    force: bool = False,
 ) -> int:
     """Import a single JSONL session file, returning the count of new messages inserted (or -1 if skipped).
 
@@ -66,7 +67,7 @@ def sync_session(
     """
     cursor = conn.cursor()
 
-    log_row, should_skip = import_log_skip_check(cursor, filepath, file_hash)
+    log_row, should_skip = import_log_skip_check(cursor, filepath, file_hash, force=force)
     if should_skip:
         log.debug("sync_session skip %s (import_log hash match)", filepath.name)
         return -1

--- a/src/ccrecall/session_ops.py
+++ b/src/ccrecall/session_ops.py
@@ -29,7 +29,7 @@ from ccrecall.branch_ops import sync_branch
 from ccrecall.db import chunk_vec_queryable
 from ccrecall.formatting import normalize_project_key
 from ccrecall.import_log_ops import import_log_skip_check, upsert_import_log
-from ccrecall.message_ops import insert_new_messages, upsert_session
+from ccrecall.message_ops import insert_new_messages, update_missing_tool_content, upsert_session
 from ccrecall.models import LOGGER_NAME
 from ccrecall.parsing import extract_session_metadata, extract_session_uuid, find_all_branches, parse_all_with_uuids
 from ccrecall.project_ops import upsert_project
@@ -117,6 +117,7 @@ def sync_session(
     )
     existing_uuids = {row[0] for row in cursor.fetchall()}
 
+    repaired_tool_content = update_missing_tool_content(cursor, session_id, messages, existing_uuids)
     new_count = insert_new_messages(cursor, session_id, messages, valid_branch_uuids, existing_uuids)
 
     # Build uuid -> message_id mapping
@@ -138,5 +139,5 @@ def sync_session(
 
     upsert_import_log(cursor, filepath, session_id, file_hash, log_row, file_size, file_mtime)
 
-    log.debug("sync_session %s: new_count=%d", filepath.name, new_count)
+    log.debug("sync_session %s: new_count=%d repaired_tool_content=%d", filepath.name, new_count, repaired_tool_content)
     return new_count

--- a/src/ccrecall/status.py
+++ b/src/ccrecall/status.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from ccrecall.config import DEFAULT_DB_PATH, get_db_path, load_settings
 from ccrecall.db import branch_embedding_coverage, chunk_vec_queryable, vec_available
 from ccrecall.hooks.backfill_status import count_status as count_embedding_status
+from ccrecall.import_log_ops import import_log_source_index
 from ccrecall.ingestion_status import summarize_ingestion
 from ccrecall.tool_content_status import (
     count_eligible as count_tool_content_pending,
@@ -111,10 +112,11 @@ def collect_status(*, db: Path = DEFAULT_DB_PATH, days: int | None = None, check
             }
 
         tool_pending = count_tool_content_pending(cursor, days)
-        tool_missing = count_pending_missing_jsonl(cursor, days) if tool_pending else 0
+        source_index = import_log_source_index(cursor) if check_ingestion or tool_pending else None
+        tool_missing = count_pending_missing_jsonl(cursor, days, source_index) if tool_pending else 0
         tool_total = count_tool_content_total(cursor, days)
         embedded_watermark, embeddable_watermark = branch_embedding_coverage(conn)
-        ingestion = summarize_ingestion(conn) if check_ingestion else None
+        ingestion = summarize_ingestion(conn, sources=source_index) if check_ingestion else None
 
     embedding_backfill: dict = {
         "available": False,

--- a/src/ccrecall/status.py
+++ b/src/ccrecall/status.py
@@ -1,0 +1,245 @@
+"""Consolidated read-only health/status reporting for the CLI."""
+
+import contextlib
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+from ccrecall.config import DEFAULT_DB_PATH, get_db_path, load_settings
+from ccrecall.db import branch_embedding_coverage, chunk_vec_queryable, vec_available
+from ccrecall.hooks.backfill_status import count_status as count_embedding_status
+from ccrecall.ingestion_status import summarize_ingestion
+from ccrecall.tool_content_status import (
+    count_eligible as count_tool_content_pending,
+)
+from ccrecall.tool_content_status import (
+    count_pending_missing_jsonl,
+)
+from ccrecall.tool_content_status import (
+    count_total_sessions as count_tool_content_total,
+)
+
+
+def _settings_for_db(db: Path) -> dict:
+    settings = load_settings()
+    if db != DEFAULT_DB_PATH:
+        settings["db_path"] = str(db)
+    return settings
+
+
+@contextlib.contextmanager
+def _readonly_connection(db_path: Path, *, load_vec: bool = False):
+    """Open an existing SQLite DB without creating/migrating it."""
+    if not db_path.exists():
+        raise FileNotFoundError(db_path)
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.execute("PRAGMA query_only = ON")
+    try:
+        if load_vec:
+            vec_available(conn)
+        yield conn
+    finally:
+        conn.close()
+
+
+def _db_counts(conn: sqlite3.Connection) -> dict[str, int]:
+    cursor = conn.cursor()
+    projects = cursor.execute("SELECT COUNT(*) FROM projects").fetchone()[0]
+    sessions = cursor.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+    messages = cursor.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+    branches = cursor.execute("SELECT COUNT(*) FROM branches").fetchone()[0]
+    active_branches = cursor.execute("SELECT COUNT(*) FROM branches WHERE is_active = 1").fetchone()[0]
+    branch_invariant_violations = count_branch_invariant_violations(conn)
+    return {
+        "projects": projects,
+        "sessions": sessions,
+        "messages": messages,
+        "branches": branches,
+        "active_branches": active_branches,
+        "branch_invariant_violations": branch_invariant_violations,
+    }
+
+
+def _has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    return any(row[1] == column for row in conn.execute(f"PRAGMA table_info({table})"))
+
+
+def count_branch_invariant_violations(conn: sqlite3.Connection) -> int:
+    """Count sessions with more than one active branch row."""
+    return len(
+        conn.execute(
+            "SELECT session_id FROM branches WHERE is_active = 1 GROUP BY session_id HAVING COUNT(*) > 1"
+        ).fetchall()
+    )
+
+
+def collect_status(*, db: Path = DEFAULT_DB_PATH, days: int | None = None, check_ingestion: bool = False) -> dict:
+    """Collect read-only status across DB, ingestion, tool content, and embeddings."""
+    settings = _settings_for_db(db)
+    db_path = get_db_path(settings)
+
+    with _readonly_connection(db_path, load_vec=False) as conn:
+        cursor = conn.cursor()
+        db_counts = _db_counts(conn)
+        schema_current = _has_column(conn, "messages", "tool_content")
+
+        if not schema_current:
+            return {
+                "db_path": str(db_path),
+                "db_size_bytes": db_path.stat().st_size if db_path.exists() else 0,
+                "days": days,
+                "database": db_counts,
+                "schema": {"current": False, "reason": "messages.tool_content column missing"},
+                "ingestion": None,
+                "tool_content": {
+                    "total_sessions": None,
+                    "done_sessions": None,
+                    "pending_sessions": None,
+                    "pending_backfillable_sessions": None,
+                    "pending_missing_jsonl_sessions": None,
+                },
+                "embeddings": {
+                    "watermark": {"embedded_branches": None, "total_branches": None},
+                    "backfill": {
+                        "available": False,
+                        "error": "database schema is out of date; run `ccrecall import` to migrate",
+                        "branches": {"embedded": None, "total": None, "remaining": None, "errored": None},
+                        "chunks": {"done": None, "total": None},
+                    },
+                },
+            }
+
+        tool_pending = count_tool_content_pending(cursor, days)
+        tool_missing = count_pending_missing_jsonl(cursor, days) if tool_pending else 0
+        tool_total = count_tool_content_total(cursor, days)
+        embedded_watermark, embeddable_watermark = branch_embedding_coverage(conn)
+        ingestion = summarize_ingestion(conn) if check_ingestion else None
+
+    embedding_backfill: dict = {
+        "available": False,
+        "error": "sqlite-vec unavailable or not initialized",
+        "branches": {"embedded": None, "total": None, "remaining": None, "errored": None},
+        "chunks": {"done": None, "total": None},
+    }
+    try:
+        with _readonly_connection(db_path, load_vec=True) as conn:
+            if chunk_vec_queryable(conn):
+                counts = count_embedding_status(conn.cursor(), days)
+                embedding_backfill = {
+                    "available": True,
+                    "error": None,
+                    "branches": {
+                        "embedded": counts["embedded_branches"],
+                        "total": counts["total_branches"],
+                        "remaining": counts["eligible"],
+                        "errored": counts["errored"],
+                    },
+                    "chunks": {"done": counts["done"], "total": counts["universe"]},
+                }
+    except (sqlite3.Error, OSError) as exc:
+        embedding_backfill["error"] = str(exc)
+
+    return {
+        "db_path": str(db_path),
+        "db_size_bytes": db_path.stat().st_size if db_path.exists() else 0,
+        "days": days,
+        "database": db_counts,
+        "schema": {"current": True, "reason": None},
+        "ingestion": ingestion,
+        "tool_content": {
+            "total_sessions": tool_total,
+            "done_sessions": tool_total - tool_pending,
+            "pending_sessions": tool_pending,
+            "pending_backfillable_sessions": tool_pending - tool_missing,
+            "pending_missing_jsonl_sessions": tool_missing,
+        },
+        "embeddings": {
+            "watermark": {"embedded_branches": embedded_watermark, "total_branches": embeddable_watermark},
+            "backfill": embedding_backfill,
+        },
+    }
+
+
+def print_status_report(status: dict) -> None:
+    """Render collected status in a compact human-readable form."""
+    db = status["database"]
+    print(f"Database: {status['db_path']}")
+    print(f"Size: {status['db_size_bytes'] / (1024 * 1024):.2f} MB")
+    print(f"Projects: {db['projects']}")
+    print(f"Sessions: {db['sessions']}")
+    print(f"Branches: {db['branches']} ({db['active_branches']} active)")
+    print(f"Messages: {db['messages']}")
+    print(f"Branch invariant violations: {db['branch_invariant_violations']} session(s) with multiple active branches")
+
+    schema = status.get("schema", {"current": True})
+    if not schema["current"]:
+        print(f"Schema: out of date ({schema['reason']})")
+        print("Run `ccrecall import` to apply migrations before checking ingestion/backfill status.")
+        return
+
+    ingestion = status["ingestion"]
+    if ingestion is None:
+        print("Ingestion: not checked (run `ccrecall status --check-ingestion`)")
+    else:
+        print(
+            "Ingestion: "
+            f"{ingestion['ok_sessions']}/{ingestion['sessions_checked']} sessions up to date; "
+            f"pending tail {ingestion['pending_tail_sessions']} session(s) "
+            f"/{ingestion['pending_tail_turns']} turn(s); "
+            f"stale tail {ingestion['stale_tail_sessions']} session(s) "
+            f"/{ingestion['stale_tail_turns']} turn(s); "
+            f"gaps {ingestion['ingestion_gap_sessions']} session(s) "
+            f"/{ingestion['ingestion_gap_turns']} turn(s); "
+            f"missing source {ingestion['missing_source_sessions']} session(s)"
+        )
+
+    tool = status["tool_content"]
+    total = tool["total_sessions"]
+    done = tool["done_sessions"]
+    pct = (done / total * 100) if total else 0.0
+    print(f"Tool content: {done}/{total} sessions backfilled ({pct:.0f}%)")
+    print(
+        f"  remaining: {tool['pending_sessions']} sessions; "
+        f"backfillable: {tool['pending_backfillable_sessions']}; "
+        f"missing JSONL: {tool['pending_missing_jsonl_sessions']}"
+    )
+
+    embeddings = status["embeddings"]
+    backfill = embeddings["backfill"]
+    if backfill["available"]:
+        branches = backfill["branches"]
+        chunks = backfill["chunks"]
+        total = branches["total"]
+        embedded = branches["embedded"]
+        pct = (embedded / total * 100) if total else 0.0
+        print(f"Embeddings: {embedded}/{total} branches embedded ({pct:.0f}%)")
+        print(f"  branch backfill: {branches['remaining']} remaining; {branches['errored']} errored")
+        print(f"  chunk coverage: {chunks['done']}/{chunks['total']} chunks at current version")
+    else:
+        watermark = embeddings["watermark"]
+        total = watermark["total_branches"]
+        embedded = watermark["embedded_branches"]
+        print(f"Embeddings: unavailable ({backfill['error']})")
+        print(f"  watermark: {embedded}/{total} branches")
+
+
+def run(
+    *,
+    db: Path = DEFAULT_DB_PATH,
+    days: int | None = None,
+    check_ingestion: bool = False,
+    output_format: str = "markdown",
+) -> None:
+    try:
+        status = collect_status(db=db, days=days, check_ingestion=check_ingestion)
+    except FileNotFoundError as exc:
+        if output_format == "json":
+            print(json.dumps({"error": "database_not_found", "path": str(exc.filename or exc.args[0])}))
+        else:
+            print(f"ccrecall status: database not found: {exc.filename or exc.args[0]}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    if output_format == "json":
+        print(json.dumps(status, indent=2))
+    else:
+        print_status_report(status)

--- a/src/ccrecall/tool_content_status.py
+++ b/src/ccrecall/tool_content_status.py
@@ -1,0 +1,30 @@
+"""Read-only status helpers for ``messages.tool_content`` coverage."""
+
+import sqlite3
+
+from ccrecall.hooks.tool_content_eligibility import ELIGIBILITY_FROM, days_modifier, eligibility_clause
+from ccrecall.import_log_ops import import_log_source_index
+
+
+def count_eligible(cursor: sqlite3.Cursor, days: int | None) -> int:
+    where, params = eligibility_clause(days)
+    return cursor.execute(f"SELECT COUNT(DISTINCT s.id) {ELIGIBILITY_FROM} {where}", params).fetchone()[0]
+
+
+def count_pending_missing_jsonl(cursor: sqlite3.Cursor, days: int | None) -> int:
+    """Count pending sessions with at least one missing source transcript file."""
+    where, params = eligibility_clause(days)
+    pending = cursor.execute(f"SELECT DISTINCT s.id, s.uuid {ELIGIBILITY_FROM} {where}", params).fetchall()
+
+    sources = import_log_source_index(cursor)
+    return sum(1 for _session_id, session_uuid in pending if sources.get(session_uuid, {}).get("missing"))
+
+
+def count_total_sessions(cursor: sqlite3.Cursor, days: int | None) -> int:
+    """Count every session with messages (the backfill's universe), for status."""
+    where = "WHERE 1=1"
+    params: list = []
+    if days is not None:
+        where += " AND b.ended_at > datetime('now', ?)"
+        params.append(days_modifier(days))
+    return cursor.execute(f"SELECT COUNT(DISTINCT s.id) {ELIGIBILITY_FROM} {where}", params).fetchone()[0]

--- a/src/ccrecall/tool_content_status.py
+++ b/src/ccrecall/tool_content_status.py
@@ -1,9 +1,14 @@
 """Read-only status helpers for ``messages.tool_content`` coverage."""
 
 import sqlite3
+from pathlib import Path
 
 from ccrecall.hooks.tool_content_eligibility import ELIGIBILITY_FROM, days_modifier, eligibility_clause
-from ccrecall.import_log_ops import import_log_source_index
+from ccrecall.import_log_ops import (
+    import_log_source_index,
+    pending_tool_content_uuids,
+    transcript_pending_tool_content_uuids,
+)
 
 
 def count_eligible(cursor: sqlite3.Cursor, days: int | None) -> int:
@@ -11,13 +16,33 @@ def count_eligible(cursor: sqlite3.Cursor, days: int | None) -> int:
     return cursor.execute(f"SELECT COUNT(DISTINCT s.id) {ELIGIBILITY_FROM} {where}", params).fetchone()[0]
 
 
-def count_pending_missing_jsonl(cursor: sqlite3.Cursor, days: int | None) -> int:
-    """Count pending sessions with at least one missing source transcript file."""
+def count_pending_missing_jsonl(
+    cursor: sqlite3.Cursor,
+    days: int | None,
+    sources: dict[str, dict[str, list[Path]]] | None = None,
+) -> int:
+    """Count pending sessions whose NULL tool_content rows cannot be recovered from surviving sources."""
     where, params = eligibility_clause(days)
     pending = cursor.execute(f"SELECT DISTINCT s.id, s.uuid {ELIGIBILITY_FROM} {where}", params).fetchall()
 
-    sources = import_log_source_index(cursor)
-    return sum(1 for _session_id, session_uuid in pending if sources.get(session_uuid, {}).get("missing"))
+    if sources is None:
+        sources = import_log_source_index(cursor)
+
+    missing = 0
+    for _session_id, session_uuid in pending:
+        paths = sources.get(session_uuid, {"existing": [], "missing": []})
+        if not paths["missing"]:
+            continue
+        if not paths["existing"]:
+            missing += 1
+            continue
+        pending_uuids = pending_tool_content_uuids(cursor, session_uuid)
+        recoverable_uuids: set[str] = set()
+        for path in paths["existing"]:
+            recoverable_uuids.update(transcript_pending_tool_content_uuids(path, pending_uuids))
+        if pending_uuids - recoverable_uuids:
+            missing += 1
+    return missing
 
 
 def count_total_sessions(cursor: sqlite3.Cursor, days: int | None) -> int:

--- a/tests/test_backfill_tool_content.py
+++ b/tests/test_backfill_tool_content.py
@@ -442,6 +442,30 @@ class TestBackfillStatus:
         data = json.loads(capsys.readouterr().out)
         assert data["total_sessions"] == 1
         assert data["pending_sessions"] == 1
+        assert data["pending_backfillable_sessions"] == 1
+        assert data["pending_missing_jsonl_sessions"] == 0
+        assert data["done_sessions"] == 0
+
+    def test_status_splits_pending_missing_jsonl(self, tmp_path, capsys):
+        conn = _make_conn()
+        missing_path = tmp_path / "sess-missing.jsonl"
+        _seed_session(
+            conn,
+            filepath=missing_path,
+            existing_messages=[("u1", "user", "hi", "2026-01-01T10:00:00Z")],
+        )
+
+        with (
+            patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
+            patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
+        ):
+            code = run(status=True, json_mode=True)
+        assert code == EXIT_OK
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["pending_sessions"] == 1
+        assert data["pending_backfillable_sessions"] == 0
+        assert data["pending_missing_jsonl_sessions"] == 1
         assert data["done_sessions"] == 0
 
     def test_status_does_not_write(self, tmp_path):

--- a/tests/test_import_pipeline.py
+++ b/tests/test_import_pipeline.py
@@ -68,6 +68,35 @@ class TestImportSessionBasic:
         message_count = cursor.fetchone()[0]
         assert message_count == total_messages, "Message count should match returned value"
 
+    def test_unchanged_import_repairs_pending_tool_content(self, memory_db, project_id):
+        """Import fast-skip paths must not bypass pending tool_content repair."""
+        fixture_file = FIXTURE_DIR / "tool_heavy.jsonl"
+
+        import_session(memory_db, fixture_file, project_id)
+        memory_db.commit()
+
+        cursor = memory_db.cursor()
+        cursor.execute(
+            """
+            SELECT session_id, uuid FROM messages
+            WHERE role = 'assistant' AND tool_content IS NOT NULL AND tool_content != ''
+            LIMIT 1
+            """
+        )
+        session_id, uuid = cursor.fetchone()
+        cursor.execute("UPDATE messages SET tool_content = NULL WHERE session_id = ? AND uuid = ?", (session_id, uuid))
+        memory_db.commit()
+
+        branches_imported, total_messages = import_session(memory_db, fixture_file, project_id)
+        memory_db.commit()
+
+        repaired = cursor.execute(
+            "SELECT tool_content FROM messages WHERE session_id = ? AND uuid = ?", (session_id, uuid)
+        ).fetchone()[0]
+        assert branches_imported >= 0
+        assert total_messages > 0
+        assert repaired, "unchanged import should repair NULL tool_content instead of fast-skipping"
+
 
 class TestImportSessionWithBranches:
     """Test import of a session with a rewind recorded in the JSONL.
@@ -804,7 +833,7 @@ class TestPrintStatsEmbeddingCoverage:
         print_stats(db=db_path)
         out = capsys.readouterr().out
 
-        assert "Embeddings: 2/3 branches (67%)" in out
+        assert "watermark: 2/3 branches" in out
 
     def test_zero_embeddable_branches(self, tmp_path, capsys):
         """A DB with no embeddable branches reports 0/0 without dividing by zero."""
@@ -815,7 +844,7 @@ class TestPrintStatsEmbeddingCoverage:
         print_stats(db=db_path)
         out = capsys.readouterr().out
 
-        assert "Embeddings: 0/0 branches" in out
+        assert "watermark: 0/0 branches" in out
 
 
 class TestEmptySessionCascadeRegression:

--- a/tests/test_import_pipeline.py
+++ b/tests/test_import_pipeline.py
@@ -1,5 +1,6 @@
 """Integration tests for the import pipeline with v3 schema guards."""
 
+import json
 import shutil
 import sqlite3
 import tempfile
@@ -96,6 +97,191 @@ class TestImportSessionBasic:
         assert branches_imported >= 0
         assert total_messages > 0
         assert repaired, "unchanged import should repair NULL tool_content instead of fast-skipping"
+
+    def test_pending_repair_imports_all_session_siblings_to_preserve_active_branch(self, memory_db, tmp_path):
+        """Repairing an earlier sibling must not leave that sibling as the active branch."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        parent = project_dir / "sess-split.jsonl"
+        agent = project_dir / "agent-sess-split.jsonl"
+        parent.write_text(
+            "\n".join(
+                json.dumps(entry)
+                for entry in [
+                    {
+                        "uuid": "u1",
+                        "parentUuid": None,
+                        "type": "user",
+                        "timestamp": "2026-01-01T10:00:00Z",
+                        "message": {"role": "user", "content": "please inspect"},
+                    },
+                    {
+                        "uuid": "a1",
+                        "parentUuid": "u1",
+                        "type": "assistant",
+                        "timestamp": "2026-01-01T10:00:01Z",
+                        "message": {
+                            "role": "assistant",
+                            "content": [
+                                {"type": "text", "text": "I will inspect it."},
+                                {"type": "tool_use", "name": "Read", "input": {"file_path": "src/app.py"}},
+                            ],
+                        },
+                    },
+                ]
+            )
+            + "\n"
+        )
+        agent.write_text(
+            "\n".join(
+                json.dumps(entry)
+                for entry in [
+                    {
+                        "uuid": "u2",
+                        "parentUuid": "a1",
+                        "type": "user",
+                        "timestamp": "2026-01-01T10:00:02Z",
+                        "message": {"role": "user", "content": "now fix it"},
+                    },
+                    {
+                        "uuid": "a2",
+                        "parentUuid": "u2",
+                        "type": "assistant",
+                        "timestamp": "2026-01-01T10:00:03Z",
+                        "message": {"role": "assistant", "content": "fixed"},
+                    },
+                ]
+            )
+            + "\n"
+        )
+
+        import_project(memory_db, project_dir)
+        cursor = memory_db.cursor()
+        session_id, tool_uuid = cursor.execute("SELECT session_id, uuid FROM messages WHERE uuid = 'a1'").fetchone()
+        cursor.execute(
+            "UPDATE messages SET tool_content = NULL WHERE session_id = ? AND uuid = ?", (session_id, tool_uuid)
+        )
+        memory_db.commit()
+
+        import_project(memory_db, project_dir)
+
+        repaired, leaf_uuid = cursor.execute(
+            """
+            SELECT m.tool_content, b.leaf_uuid
+            FROM messages m
+            JOIN branches b ON b.session_id = m.session_id
+            WHERE m.session_id = ? AND m.uuid = ? AND b.is_active = 1
+            """,
+            (session_id, tool_uuid),
+        ).fetchone()
+        assert repaired
+        assert leaf_uuid == "a2"
+
+    def test_later_sibling_repair_does_not_reimport_processed_parent(self, memory_db, tmp_path):
+        """A repair discovered in a later sibling should not replay siblings already handled in this run."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        parent = project_dir / "sess-later.jsonl"
+        agent = project_dir / "agent-sess-later.jsonl"
+        parent.write_text(
+            json.dumps(
+                {
+                    "uuid": "u1",
+                    "parentUuid": None,
+                    "type": "user",
+                    "timestamp": "2026-01-01T10:00:00Z",
+                    "message": {"role": "user", "content": "start"},
+                }
+            )
+            + "\n"
+        )
+        agent.write_text(
+            json.dumps(
+                {
+                    "uuid": "a1",
+                    "parentUuid": "u1",
+                    "type": "assistant",
+                    "timestamp": "2026-01-01T10:00:01Z",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "tool_use", "name": "Read", "input": {"file_path": "src/app.py"}}],
+                    },
+                }
+            )
+            + "\n"
+        )
+
+        import_project(memory_db, project_dir)
+        cursor = memory_db.cursor()
+        session_id = cursor.execute("SELECT id FROM sessions WHERE uuid = 'sess-later'").fetchone()[0]
+        cursor.execute("UPDATE messages SET tool_content = NULL WHERE session_id = ? AND uuid = 'a1'", (session_id,))
+        memory_db.commit()
+
+        _sessions, _messages, skipped = import_project(memory_db, project_dir)
+
+        repaired = cursor.execute(
+            "SELECT tool_content FROM messages WHERE session_id = ? AND uuid = 'a1'", (session_id,)
+        ).fetchone()[0]
+        assert repaired
+        assert skipped == 1
+
+    def test_equal_timestamp_repair_keeps_agent_sibling_active(self, memory_db, tmp_path):
+        """Equal latest timestamps must still replay the parent before its agent sibling."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        parent = project_dir / "sess-equal.jsonl"
+        agent = project_dir / "agent-sess-equal.jsonl"
+        shared_ts = "2026-01-01T10:00:01Z"
+        parent.write_text(
+            "\n".join(
+                json.dumps(entry)
+                for entry in [
+                    {
+                        "uuid": "u1",
+                        "parentUuid": None,
+                        "type": "user",
+                        "timestamp": "2026-01-01T10:00:00Z",
+                        "message": {"role": "user", "content": "inspect"},
+                    },
+                    {
+                        "uuid": "a1",
+                        "parentUuid": "u1",
+                        "type": "assistant",
+                        "timestamp": shared_ts,
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"type": "tool_use", "name": "Read", "input": {"file_path": "src/app.py"}}],
+                        },
+                    },
+                ]
+            )
+            + "\n"
+        )
+        agent.write_text(
+            json.dumps(
+                {
+                    "uuid": "a2",
+                    "parentUuid": "a1",
+                    "type": "assistant",
+                    "timestamp": shared_ts,
+                    "message": {"role": "assistant", "content": "agent follow-up"},
+                }
+            )
+            + "\n"
+        )
+
+        import_project(memory_db, project_dir)
+        cursor = memory_db.cursor()
+        session_id = cursor.execute("SELECT id FROM sessions WHERE uuid = 'sess-equal'").fetchone()[0]
+        cursor.execute("UPDATE messages SET tool_content = NULL WHERE session_id = ? AND uuid = 'a1'", (session_id,))
+        memory_db.commit()
+
+        import_project(memory_db, project_dir)
+
+        leaf_uuid = cursor.execute(
+            "SELECT leaf_uuid FROM branches WHERE session_id = ? AND is_active = 1", (session_id,)
+        ).fetchone()[0]
+        assert leaf_uuid == "a2"
 
 
 class TestImportSessionWithBranches:

--- a/tests/test_ingestion_status.py
+++ b/tests/test_ingestion_status.py
@@ -140,6 +140,35 @@ def test_multifile_session_uses_parent_chain_not_import_log_order(memory_db, tmp
     assert status["ingestion_gap_sessions"] == 0
 
 
+def test_multifile_equal_timestamp_prefers_deeper_agent_leaf(memory_db, tmp_path):
+    parent = tmp_path / "sess-equal.jsonl"
+    agent = tmp_path / "agent-sess-equal.jsonl"
+    shared_ts = "2026-01-01T10:00:01Z"
+    _write_jsonl(
+        parent,
+        [
+            _entry("u1", None, "2026-01-01T10:00:00Z", "user", "first"),
+            _entry("a1", "u1", shared_ts, "assistant", "answer"),
+        ],
+    )
+    _write_jsonl(agent, [_entry("a2", "a1", shared_ts, "assistant", "agent follow-up")])
+    memory_db.execute("INSERT INTO sessions (uuid) VALUES ('sess-equal')")
+    session_id = memory_db.execute("SELECT last_insert_rowid()").fetchone()[0]
+    for uuid in ["u1", "a1"]:
+        memory_db.execute(
+            "INSERT INTO messages (session_id, uuid, role, content, tool_content) VALUES (?, ?, 'user', 'x', '')",
+            (session_id, uuid),
+        )
+    _insert_import_log(memory_db, agent, 1)
+    _insert_import_log(memory_db, parent, 2)
+
+    status = summarize_ingestion(memory_db)
+
+    assert status["pending_tail_sessions"] == 1
+    assert status["pending_tail_turns"] == 1
+    assert status["ok_sessions"] == 0
+
+
 def test_import_log_only_session_is_not_counted(memory_db, tmp_path):
     filepath = tmp_path / "filtered-away.jsonl"
     _insert_import_log(memory_db, filepath, 0)

--- a/tests/test_ingestion_status.py
+++ b/tests/test_ingestion_status.py
@@ -1,0 +1,164 @@
+"""Tests for transcript-vs-DB ingestion diagnostics."""
+
+import os
+import time
+from pathlib import Path
+
+from conftest import make_jsonl_entry as _entry
+from conftest import write_jsonl as _write_jsonl
+
+from ccrecall.ingestion_status import summarize_ingestion
+
+
+def _seed_session(memory_db, filepath: Path, db_uuids: list[str]) -> None:
+    session_uuid = filepath.stem.removeprefix("agent-")
+    memory_db.execute("INSERT INTO sessions (uuid) VALUES (?)", (session_uuid,))
+    session_id = memory_db.execute("SELECT last_insert_rowid()").fetchone()[0]
+    for uuid in db_uuids:
+        memory_db.execute(
+            "INSERT INTO messages (session_id, uuid, role, content, tool_content) VALUES (?, ?, 'user', 'x', '')",
+            (session_id, uuid),
+        )
+    memory_db.execute(
+        "INSERT INTO import_log (file_path, file_hash, messages_imported) VALUES (?, 'hash', ?)",
+        (str(filepath), len(db_uuids)),
+    )
+    memory_db.commit()
+
+
+def _insert_import_log(memory_db, filepath: Path, message_count: int = 0) -> None:
+    memory_db.execute(
+        "INSERT INTO import_log (file_path, file_hash, messages_imported) VALUES (?, 'hash', ?)",
+        (str(filepath), message_count),
+    )
+    memory_db.commit()
+
+
+def _write_four_turns(filepath: Path) -> None:
+    _write_jsonl(
+        filepath,
+        [
+            _entry("u1", None, "2026-01-01T10:00:00Z", "user", "first"),
+            _entry("a1", "u1", "2026-01-01T10:00:01Z", "assistant", "answer"),
+            _entry("u2", "a1", "2026-01-01T10:00:02Z", "user", "second"),
+            _entry("a2", "u2", "2026-01-01T10:00:03Z", "assistant", "answer"),
+        ],
+    )
+
+
+def test_pending_tail_for_recent_contiguous_suffix(memory_db, tmp_path):
+    filepath = tmp_path / "sess-tail.jsonl"
+    _write_four_turns(filepath)
+    _seed_session(memory_db, filepath, ["u1", "a1"])
+
+    status = summarize_ingestion(memory_db)
+
+    assert status["pending_tail_sessions"] == 1
+    assert status["pending_tail_turns"] == 2
+    assert status["ingestion_gap_sessions"] == 0
+
+
+def test_stale_tail_for_old_contiguous_suffix(memory_db, tmp_path):
+    filepath = tmp_path / "sess-stale.jsonl"
+    _write_four_turns(filepath)
+    old = time.time() - 3600
+    os.utime(filepath, (old, old))
+    _seed_session(memory_db, filepath, ["u1", "a1"])
+
+    status = summarize_ingestion(memory_db)
+
+    assert status["stale_tail_sessions"] == 1
+    assert status["stale_tail_turns"] == 2
+    assert status["pending_tail_sessions"] == 0
+
+
+def test_middle_missing_uuid_is_ingestion_gap(memory_db, tmp_path):
+    filepath = tmp_path / "sess-gap.jsonl"
+    _write_four_turns(filepath)
+    _seed_session(memory_db, filepath, ["u1", "u2", "a2"])
+
+    status = summarize_ingestion(memory_db)
+
+    assert status["ingestion_gap_sessions"] == 1
+    assert status["ingestion_gap_turns"] == 1
+    assert status["pending_tail_sessions"] == 0
+
+
+def test_missing_source_when_no_transcript_survives(memory_db, tmp_path):
+    filepath = tmp_path / "sess-gone.jsonl"
+    _seed_session(memory_db, filepath, ["u1"])
+
+    status = summarize_ingestion(memory_db)
+
+    assert status["missing_source_sessions"] == 1
+    assert status["sessions_checked"] == 1
+
+
+def test_complete_session_is_ok(memory_db, tmp_path):
+    filepath = tmp_path / "sess-ok.jsonl"
+    _write_four_turns(filepath)
+    _seed_session(memory_db, filepath, ["u1", "a1", "u2", "a2"])
+
+    status = summarize_ingestion(memory_db)
+
+    assert status["ok_sessions"] == 1
+    assert status["pending_tail_sessions"] == 0
+    assert status["ingestion_gap_sessions"] == 0
+
+
+def test_multifile_session_uses_parent_chain_not_import_log_order(memory_db, tmp_path):
+    parent = tmp_path / "sess-multi.jsonl"
+    agent = tmp_path / "agent-sess-multi.jsonl"
+    _write_jsonl(
+        parent,
+        [
+            _entry("u1", None, "2026-01-01T10:00:00Z", "user", "first"),
+            _entry("a1", "u1", "2026-01-01T10:00:01Z", "assistant", "answer"),
+        ],
+    )
+    _write_jsonl(
+        agent,
+        [
+            _entry("u2", "a1", "2026-01-01T10:00:02Z", "user", "second"),
+            _entry("a2", "u2", "2026-01-01T10:00:03Z", "assistant", "answer"),
+        ],
+    )
+    memory_db.execute("INSERT INTO sessions (uuid) VALUES ('sess-multi')")
+    session_id = memory_db.execute("SELECT last_insert_rowid()").fetchone()[0]
+    for uuid in ["u1", "a1"]:
+        memory_db.execute(
+            "INSERT INTO messages (session_id, uuid, role, content, tool_content) VALUES (?, ?, 'user', 'x', '')",
+            (session_id, uuid),
+        )
+    _insert_import_log(memory_db, agent, 0)
+    _insert_import_log(memory_db, parent, 2)
+
+    status = summarize_ingestion(memory_db)
+
+    assert status["pending_tail_sessions"] == 1
+    assert status["pending_tail_turns"] == 2
+    assert status["ingestion_gap_sessions"] == 0
+
+
+def test_import_log_only_session_is_not_counted(memory_db, tmp_path):
+    filepath = tmp_path / "filtered-away.jsonl"
+    _insert_import_log(memory_db, filepath, 0)
+
+    status = summarize_ingestion(memory_db)
+
+    assert status["sessions_checked"] == 0
+    assert status["missing_source_sessions"] == 0
+
+
+def test_partial_multifile_source_loss_counts_as_missing_source(memory_db, tmp_path):
+    parent = tmp_path / "sess-partial.jsonl"
+    missing_agent = tmp_path / "agent-sess-partial.jsonl"
+    _write_jsonl(parent, [_entry("u1", None, "2026-01-01T10:00:00Z", "user", "first")])
+    _seed_session(memory_db, parent, ["u1"])
+    _insert_import_log(memory_db, missing_agent, 0)
+
+    status = summarize_ingestion(memory_db)
+
+    assert status["sessions_checked"] == 1
+    assert status["missing_source_sessions"] == 1
+    assert status["ok_sessions"] == 0

--- a/tests/test_session_ops.py
+++ b/tests/test_session_ops.py
@@ -14,6 +14,7 @@ from ccrecall.db import _ensure_vec_schema, vec_available
 from ccrecall.embed_ops import MAX_WRITE_PATH_EMBEDS_PER_SYNC, embed_branch_chunks
 from ccrecall.embeddings import EMBEDDING_DIM, EMBEDDING_MODEL, EMBEDDING_VERSION
 from ccrecall.hooks.import_conversations import get_file_hash
+from ccrecall.import_log_ops import has_pending_tool_content
 from ccrecall.parsing import extract_session_uuid
 from ccrecall.schema import SCHEMA
 from ccrecall.session_ops import sync_session
@@ -134,6 +135,37 @@ class TestSyncSessionCreatesBranches:
         )
         sample = cursor.fetchone()[0]
         assert sample.startswith("["), "tool_content should carry a '[ToolName: ...]' marker"
+
+    def test_resync_repairs_existing_null_tool_content(self, memory_db):
+        """Re-parsing a session should populate old rows whose tool_content is NULL."""
+
+        fixture_path = FIXTURE_DIR / "tool_heavy.jsonl"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_dir = Path(tmpdir)
+            sync_session(memory_db, fixture_path, project_dir)
+            memory_db.commit()
+
+            cursor = memory_db.cursor()
+            cursor.execute(
+                """
+                SELECT session_id, uuid FROM messages
+                WHERE role = 'assistant' AND tool_content IS NOT NULL AND tool_content != ''
+                LIMIT 1
+                """
+            )
+            session_id, uuid = cursor.fetchone()
+            cursor.execute(
+                "UPDATE messages SET tool_content = NULL WHERE session_id = ? AND uuid = ?", (session_id, uuid)
+            )
+            memory_db.commit()
+
+            sync_session(memory_db, fixture_path, project_dir)
+            memory_db.commit()
+
+        repaired = memory_db.execute(
+            "SELECT tool_content FROM messages WHERE session_id = ? AND uuid = ?", (session_id, uuid)
+        ).fetchone()[0]
+        assert repaired, "re-sync should repair NULL tool_content without waiting for backfill"
 
 
 class TestSyncSessionWritesNullHashImportLog:
@@ -373,6 +405,66 @@ class TestImportLogExactHashSkip:
         assert import_log_row_after == import_log_row_before, (
             f"import_log row must be unchanged after -1 skip: before={import_log_row_before}, after={import_log_row_after}"
         )
+
+    def test_exact_hash_match_reprocesses_when_tool_content_is_pending(self, memory_db):
+        """Hash dedup must not block repairing old NULL tool_content rows."""
+        fixture_path = FIXTURE_DIR / "tool_heavy.jsonl"
+        real_hash = get_file_hash(fixture_path)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_dir = Path(tmpdir)
+            sync_session(memory_db, fixture_path, project_dir, file_hash=real_hash)
+            memory_db.commit()
+
+        cursor = memory_db.cursor()
+        cursor.execute(
+            """
+            SELECT session_id, uuid FROM messages
+            WHERE role = 'assistant' AND tool_content IS NOT NULL AND tool_content != ''
+            LIMIT 1
+            """
+        )
+        session_id, uuid = cursor.fetchone()
+        cursor.execute("UPDATE messages SET tool_content = NULL WHERE session_id = ? AND uuid = ?", (session_id, uuid))
+        memory_db.commit()
+
+        with tempfile.TemporaryDirectory() as tmpdir2:
+            project_dir2 = Path(tmpdir2)
+            result = sync_session(memory_db, fixture_path, project_dir2, file_hash=real_hash)
+            memory_db.commit()
+
+        repaired = cursor.execute(
+            "SELECT tool_content FROM messages WHERE session_id = ? AND uuid = ?", (session_id, uuid)
+        ).fetchone()[0]
+        assert result >= 0, "matching hash should reprocess when tool_content is pending"
+        assert repaired, "matching-hash reprocess should repair NULL tool_content"
+
+    def test_pending_tool_content_check_is_file_scoped(self, memory_db, tmp_path):
+        """A pending row from a missing sibling transcript must not keep reparsing this file forever."""
+        parent = tmp_path / "sess-split.jsonl"
+        agent = tmp_path / "agent-sess-split.jsonl"
+        parent.write_text(
+            json.dumps(
+                {
+                    "uuid": "u1",
+                    "parentUuid": None,
+                    "type": "user",
+                    "timestamp": "2026-01-01T10:00:00Z",
+                    "message": {"role": "user", "content": "hi"},
+                }
+            )
+            + "\n"
+        )
+        memory_db.execute("INSERT INTO sessions (uuid) VALUES ('sess-split')")
+        session_id = memory_db.execute("SELECT last_insert_rowid()").fetchone()[0]
+        memory_db.execute(
+            "INSERT INTO messages (session_id, uuid, role, content, tool_content) VALUES (?, 'agent-row', 'assistant', '', NULL)",
+            (session_id,),
+        )
+        memory_db.commit()
+
+        assert has_pending_tool_content(memory_db.cursor(), parent) is False
+        assert not agent.exists()
 
 
 class TestSyncThenImportDedupIntegration:

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from ccrecall.db import get_connection
 from ccrecall.status import collect_status, run
+from ccrecall.tool_content_status import count_pending_missing_jsonl
 
 
 def test_collect_status_skips_deep_ingestion_by_default(tmp_path):
@@ -104,3 +105,82 @@ def test_run_human_mentions_consolidated_sections(tmp_path, capsys):
     assert "Ingestion:" in out
     assert "Tool content:" in out
     assert "Embeddings:" in out
+
+
+def test_pending_missing_jsonl_counts_only_unrecoverable_pending_rows(memory_db, tmp_path):
+    parent = tmp_path / "sess-partial.jsonl"
+    missing_agent = tmp_path / "agent-sess-partial.jsonl"
+    parent.write_text(
+        json.dumps(
+            {
+                "uuid": "u1",
+                "parentUuid": None,
+                "type": "user",
+                "timestamp": "2026-01-01T10:00:00Z",
+                "message": {"role": "user", "content": "recoverable"},
+            }
+        )
+        + "\n"
+    )
+    memory_db.execute("INSERT INTO sessions (uuid) VALUES ('sess-partial')")
+    session_id = memory_db.execute("SELECT last_insert_rowid()").fetchone()[0]
+    memory_db.execute("INSERT INTO branches (session_id, leaf_uuid, is_active) VALUES (?, 'u1', 1)", (session_id,))
+    memory_db.execute(
+        "INSERT INTO messages (session_id, uuid, role, content, tool_content) VALUES (?, 'u1', 'user', 'x', NULL)",
+        (session_id,),
+    )
+    memory_db.execute(
+        "INSERT INTO import_log (file_path, file_hash, messages_imported) VALUES (?, 'hash', 1)",
+        (str(parent),),
+    )
+    memory_db.execute(
+        "INSERT INTO import_log (file_path, file_hash, messages_imported) VALUES (?, 'hash', 0)",
+        (str(missing_agent),),
+    )
+    memory_db.commit()
+
+    assert count_pending_missing_jsonl(memory_db.cursor(), None) == 0
+
+    memory_db.execute("UPDATE messages SET uuid = 'agent-only' WHERE session_id = ?", (session_id,))
+    memory_db.commit()
+
+    assert count_pending_missing_jsonl(memory_db.cursor(), None) == 1
+
+
+def test_pending_missing_jsonl_requires_all_pending_rows_recoverable(memory_db, tmp_path):
+    parent = tmp_path / "sess-mixed.jsonl"
+    missing_agent = tmp_path / "agent-sess-mixed.jsonl"
+    parent.write_text(
+        json.dumps(
+            {
+                "uuid": "u1",
+                "parentUuid": None,
+                "type": "user",
+                "timestamp": "2026-01-01T10:00:00Z",
+                "message": {"role": "user", "content": "recoverable"},
+            }
+        )
+        + "\n"
+    )
+    memory_db.execute("INSERT INTO sessions (uuid) VALUES ('sess-mixed')")
+    session_id = memory_db.execute("SELECT last_insert_rowid()").fetchone()[0]
+    memory_db.execute("INSERT INTO branches (session_id, leaf_uuid, is_active) VALUES (?, 'u1', 1)", (session_id,))
+    memory_db.execute(
+        "INSERT INTO messages (session_id, uuid, role, content, tool_content) VALUES (?, 'u1', 'user', 'x', NULL)",
+        (session_id,),
+    )
+    memory_db.execute(
+        "INSERT INTO messages (session_id, uuid, role, content, tool_content) VALUES (?, 'agent-only', 'assistant', 'x', NULL)",
+        (session_id,),
+    )
+    memory_db.execute(
+        "INSERT INTO import_log (file_path, file_hash, messages_imported) VALUES (?, 'hash', 1)",
+        (str(parent),),
+    )
+    memory_db.execute(
+        "INSERT INTO import_log (file_path, file_hash, messages_imported) VALUES (?, 'hash', 1)",
+        (str(missing_agent),),
+    )
+    memory_db.commit()
+
+    assert count_pending_missing_jsonl(memory_db.cursor(), None) == 1

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,106 @@
+"""Tests for the consolidated ccrecall status reporter."""
+
+import json
+import sqlite3
+from unittest.mock import patch
+
+from ccrecall.db import get_connection
+from ccrecall.status import collect_status, run
+
+
+def test_collect_status_skips_deep_ingestion_by_default(tmp_path):
+    db_path = tmp_path / "status.db"
+    with get_connection({"db_path": str(db_path)}, load_vec=False):
+        pass
+
+    with patch("ccrecall.status.summarize_ingestion") as summarize:
+        status = collect_status(db=db_path)
+
+    summarize.assert_not_called()
+    assert status["ingestion"] is None
+    assert "tool_content" in status
+    assert "embeddings" in status
+
+
+def test_collect_status_does_not_create_missing_database(tmp_path):
+    db_path = tmp_path / "missing.db"
+
+    try:
+        collect_status(db=db_path)
+    except FileNotFoundError:
+        pass
+    else:  # pragma: no cover - assertion branch
+        raise AssertionError("collect_status should reject missing DB paths")
+
+    assert not db_path.exists()
+
+
+def test_collect_status_reports_outdated_schema_without_migrating(tmp_path):
+    db_path = tmp_path / "old.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE projects (id INTEGER PRIMARY KEY);
+        CREATE TABLE sessions (id INTEGER PRIMARY KEY, uuid TEXT);
+        CREATE TABLE messages (id INTEGER PRIMARY KEY, session_id INTEGER, uuid TEXT);
+        CREATE TABLE branches (id INTEGER PRIMARY KEY, session_id INTEGER, is_active INTEGER);
+        """
+    )
+    conn.close()
+
+    status = collect_status(db=db_path)
+
+    assert status["schema"]["current"] is False
+    assert "tool_content" in status["schema"]["reason"]
+
+
+def test_collect_status_skips_missing_jsonl_scan_when_tool_content_complete(tmp_path):
+    db_path = tmp_path / "status.db"
+    with get_connection({"db_path": str(db_path)}, load_vec=False):
+        pass
+
+    with patch("ccrecall.status.count_pending_missing_jsonl") as count_missing:
+        status = collect_status(db=db_path)
+
+    count_missing.assert_not_called()
+    assert status["tool_content"]["pending_sessions"] == 0
+
+
+def test_collect_status_runs_deep_ingestion_when_requested(tmp_path):
+    db_path = tmp_path / "status.db"
+    with get_connection({"db_path": str(db_path)}, load_vec=False):
+        pass
+
+    expected = {"sessions_checked": 0, "ok_sessions": 0}
+    with patch("ccrecall.status.summarize_ingestion", return_value=expected) as summarize:
+        status = collect_status(db=db_path, check_ingestion=True)
+
+    summarize.assert_called_once()
+    assert status["ingestion"] == expected
+
+
+def test_run_json_outputs_consolidated_payload(tmp_path, capsys):
+    db_path = tmp_path / "status.db"
+    with get_connection({"db_path": str(db_path)}, load_vec=False):
+        pass
+
+    run(db=db_path, output_format="json")
+
+    data = json.loads(capsys.readouterr().out)
+    assert data["database"]["sessions"] == 0
+    assert data["ingestion"] is None
+    assert "tool_content" in data
+    assert "embeddings" in data
+
+
+def test_run_human_mentions_consolidated_sections(tmp_path, capsys):
+    db_path = tmp_path / "status.db"
+    with get_connection({"db_path": str(db_path)}, load_vec=False):
+        pass
+
+    run(db=db_path)
+
+    out = capsys.readouterr().out
+    assert "Ingestion:" in out
+    assert "Tool content:" in out
+    assert "Embeddings:" in out


### PR DESCRIPTION
### Consolidated Status
- Added `ccrecall status` as the primary read-only health command so users can see database counts, ingestion diagnostics, tool-content backfill coverage, and embedding coverage in one place instead of stitching together older status commands.
- Kept deep transcript-vs-database checks behind `--check-ingestion` because they parse JSONL source files and are more expensive than the default status view.
- Preserved JSON output through the existing global `--json` CLI format so automation can consume the same consolidated status data.

### Ingestion And Backfill Diagnostics
- Added ingestion gap classification that compares import-log JSONL sources with persisted message UUIDs, distinguishing normal recent transcript tails from stale tails, middle-of-branch gaps, and missing source files.
- Split tool-content pending sessions into backfillable and missing-JSONL buckets so users can tell whether remaining work is actionable or blocked by missing transcript sources.
- Updated legacy `ccrecall stats` and embedding-only status language to point users toward the consolidated status surface while keeping existing callers working.

### Tool Content Repair
- Changed import and sync skip checks so unchanged transcript files still reprocess when they can repair existing `NULL` `messages.tool_content` rows.
- Populated missing tool-content values during normal session re-syncs instead of requiring users to wait for the explicit backfill path.

### Verification
- `uv run pytest` passed with 962 tests.
- `uvx prek run --all-files` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a consolidated, read-only `status` command with human-readable or JSON output covering database health, tool-content coverage, embedding/backfill progress, and optional deep ingestion checks.
  * Enhanced ingestion diagnostics with clearer reporting, including split counts for pending sessions that are **missing JSONL** vs **backfillable**.
* **Bug Fixes**
  * Re-imports now repair missing assistant tool content instead of skipping unchanged transcripts, with repair behavior correctly scoped to the relevant transcript file.
* **Documentation**
  * Updated the changelog and CLI help examples to reflect the new `status` command and its checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->