### PR TITLE
feat: add --before/--after filters to search commands

### DIFF
--- a/src/ccrecall/cli/commands.py
+++ b/src/ccrecall/cli/commands.py
@@ -63,6 +63,12 @@ _NOTIFS = Annotated[
     bool, _FLAG, Parameter(name=["--include-notifications"], help="Include task notification messages.")
 ]
 _DB = Annotated[Path, Parameter(name=["--db"], help="Database path.")]
+# Shared across recent/search/search-messages so help text and semantics can't drift
+# between commands. Validated by ccrecall.dates.validate_date_boundaries at runtime
+# (accepts YYYY-MM-DD or a full ISO-8601 instant); an unparseable value exits 2
+# rather than silently comparing wrong.
+_BEFORE = Annotated[str | None, Parameter(help="Sessions started before this date/datetime (ISO).")]
+_AFTER = Annotated[str | None, Parameter(help="Sessions started after this date/datetime (ISO).")]
 # Default for `tail -n`, sourced from session_tail so the two never drift.
 _TAIL_DEFAULT_N = session_tail_mod.DEFAULT_TAIL_EVENTS
 # Default result counts for the recent/search commands.
@@ -220,8 +226,8 @@ def cmd_recent(
         ),
     ] = _DEFAULT_RECENT_N,
     sort_order: Annotated[Literal["desc", "asc"], Parameter(name=["--sort-order"], help="Sort order.")] = "desc",
-    before: Annotated[str | None, Parameter(help="Sessions before this datetime (ISO).")] = None,
-    after: Annotated[str | None, Parameter(help="Sessions after this datetime (ISO).")] = None,
+    before: _BEFORE = None,
+    after: _AFTER = None,
     session: Annotated[str | None, Parameter(help="Filter by session UUID (prefix match).")] = None,
     project: Annotated[str | None, Parameter(help="Filter by project name(s), comma-separated.")] = None,
     path: Annotated[str | None, Parameter(help="Filter by cwd substring (e.g. worktree name).")] = None,
@@ -267,12 +273,16 @@ def cmd_search(
     session: Annotated[str | None, Parameter(help="Filter by session UUID (prefix match).")] = None,
     project: Annotated[str | None, Parameter(help="Filter by project name(s), comma-separated.")] = None,
     path: Annotated[str | None, Parameter(help="Filter by cwd substring (e.g. worktree name).")] = None,
+    before: _BEFORE = None,
+    after: _AFTER = None,
     verbose: _VERBOSE = False,
     include_notifications: _NOTIFS = False,
     db: _DB = DEFAULT_DB_PATH,
     ctx: CLIContextParam = DEFAULT_CLI_CONTEXT,
 ) -> None:
     """Search conversation sessions (keyword + vector fusion).
+
+    Date filters (--before/--after) are branch-level (session start time).
 
     With --json: {query, ranked, count, results: [{score, session_uuid, handle, project, git_branch, topic, ...}]}
     """
@@ -284,6 +294,8 @@ def cmd_search(
         session=session,
         project=project,
         path=path,
+        before=before,
+        after=after,
         output_format=ctx.output_format,
         verbose=verbose,
         include_notifications=include_notifications,
@@ -306,6 +318,8 @@ def cmd_search_messages(
     session: Annotated[str | None, Parameter(help="Filter by session UUID (prefix match).")] = None,
     project: Annotated[str | None, Parameter(help="Filter by project name(s), comma-separated.")] = None,
     path: Annotated[str | None, Parameter(help="Filter by cwd substring (e.g. worktree name).")] = None,
+    before: _BEFORE = None,
+    after: _AFTER = None,
     include_notifications: _NOTIFS = False,
     db: _DB = DEFAULT_DB_PATH,
     ctx: CLIContextParam = DEFAULT_CLI_CONTEXT,
@@ -315,6 +329,9 @@ def cmd_search_messages(
     Returns matched exchanges ranked by chunk distance — not rolled up to session,
     so multiple matches within one session all appear as separate results.
 
+    Date filters (--before/--after) are branch-level (the exchange's session
+    start time), not per-exchange, matching search and recent-chats.
+
     With --json: {query, ranked, count, results: [{score, session_uuid, handle, exchange_index, user, assistant, ...}]}
     """
     search_mod.run_messages(
@@ -323,6 +340,8 @@ def cmd_search_messages(
         session=session,
         project=project,
         path=path,
+        before=before,
+        after=after,
         output_format=ctx.output_format,
         include_notifications=include_notifications,
         db=db,

--- a/src/ccrecall/dates.py
+++ b/src/ccrecall/dates.py
@@ -1,13 +1,20 @@
 """Validation for --before/--after CLI date-range boundaries.
 
-Boundary values are never converted to a different representation — they are
-compared lexicographically, as-is, against the stored ISO-8601 UTC timestamp
-strings (branches.started_at), matching Claude Code's own transcript
-`timestamp` format. This module's only job is to reject, before it reaches
-SQL, anything that would silently corrupt that comparison: an unpadded month
-("2026-8-1"), a missing timezone, a non-ISO format. Both forms this accepts
-(bare date, full instant) share a zero-padded, fixed-width prefix with the
-stored strings, so a validated value always compares correctly unparsed.
+Boundary values are compared lexicographically against the stored ISO-8601
+UTC timestamp strings (branches.started_at), matching Claude Code's own
+transcript `timestamp` format. This module's job is to reject, before it
+reaches SQL, anything that would silently corrupt that comparison: an
+unpadded month ("2026-8-1"), a missing timezone, a non-ISO format — and to
+normalize a full instant to the exact fixed-width form the comparison
+depends on. A bare date is used as-is (it has no timezone to normalize and
+is already a valid prefix). A full instant is re-rendered to UTC with
+millisecond precision (see parse_date_boundary), because real transcript
+timestamps always carry milliseconds and a boundary missing them would sort
+incorrectly against same-second stored values (e.g. "...10Z" would compare
+less than "...10.635Z" purely because "." < "Z", even though ...10Z is
+chronologically earlier). Both normalized forms share a zero-padded,
+fixed-width prefix with the stored strings, so a validated value always
+compares correctly.
 """
 
 from whenever import Date, Instant
@@ -26,11 +33,17 @@ def parse_date_boundary(value: str, flag: str) -> str:
 
     A bare date is returned unchanged — it has no timezone to normalize, and
     compares correctly as a prefix against the stored UTC strings. A full
-    instant is re-rendered via format_iso() into the exact UTC "Z" form the
-    DB stores: a non-UTC offset (e.g. "+02:00") is a *different string* than
-    its UTC equivalent, so passing it through unchanged would silently break
-    the lexicographic comparison against started_at even though the instant
-    itself parsed correctly.
+    instant is re-rendered via format_iso(unit="millisecond") into the exact
+    UTC "Z" form the DB stores, with a fixed 3-digit fractional field: a
+    non-UTC offset (e.g. "+02:00") is a *different string* than its UTC
+    equivalent, and an instant with no fractional seconds (e.g. "...10Z")
+    sorts lexicographically *before* a stored millisecond timestamp in the
+    same second (e.g. "...10.635Z", since "." < "Z") even though it is
+    chronologically earlier — both would silently break the lexicographic
+    comparison against started_at even though the instant itself parsed
+    correctly. Forcing millisecond precision keeps every normalized boundary
+    the same fixed width as the stored strings, which real Claude Code
+    transcript timestamps always carry.
     """
     try:
         Date.parse_iso(value)
@@ -38,7 +51,7 @@ def parse_date_boundary(value: str, flag: str) -> str:
     except ValueError:
         pass
     try:
-        return Instant.parse_iso(value).format_iso()
+        return Instant.parse_iso(value).format_iso(unit="millisecond")
     except ValueError:
         raise ValueError(
             f"{flag} must be an ISO-8601 date (YYYY-MM-DD) or a timezone-aware "

--- a/src/ccrecall/dates.py
+++ b/src/ccrecall/dates.py
@@ -1,0 +1,56 @@
+"""Validation for --before/--after CLI date-range boundaries.
+
+Boundary values are never converted to a different representation — they are
+compared lexicographically, as-is, against the stored ISO-8601 UTC timestamp
+strings (branches.started_at), matching Claude Code's own transcript
+`timestamp` format. This module's only job is to reject, before it reaches
+SQL, anything that would silently corrupt that comparison: an unpadded month
+("2026-8-1"), a missing timezone, a non-ISO format. Both forms this accepts
+(bare date, full instant) share a zero-padded, fixed-width prefix with the
+stored strings, so a validated value always compares correctly unparsed.
+"""
+
+from whenever import Date, Instant
+
+
+def parse_date_boundary(value: str, flag: str) -> str:
+    """Validate a --before/--after value; return the string to use in SQL.
+
+    Accepts a bare ISO date (YYYY-MM-DD) or a full timezone-aware ISO-8601
+    instant (e.g. 2026-08-03T12:00:00Z or with a +HH:MM offset). Raises
+    ValueError with a user-facing message on anything else, so a malformed
+    date fails loudly at the CLI boundary instead of silently matching the
+    wrong rows (or none).
+
+    A bare date is returned unchanged — it has no timezone to normalize, and
+    compares correctly as a prefix against the stored UTC strings. A full
+    instant is re-rendered via format_iso() into the exact UTC "Z" form the
+    DB stores: a non-UTC offset (e.g. "+02:00") is a *different string* than
+    its UTC equivalent, so passing it through unchanged would silently break
+    the lexicographic comparison against started_at even though the instant
+    itself parsed correctly.
+    """
+    try:
+        Date.parse_iso(value)
+        return value
+    except ValueError:
+        pass
+    try:
+        return Instant.parse_iso(value).format_iso()
+    except ValueError:
+        raise ValueError(
+            f"{flag} must be an ISO-8601 date (YYYY-MM-DD) or a timezone-aware "
+            f"timestamp (e.g. 2026-08-03T12:00:00Z); got {value!r}"
+        ) from None
+
+
+def validate_date_boundaries(before: str | None, after: str | None) -> tuple[str | None, str | None]:
+    """Validate --before/--after and return the normalized pair to use in SQL.
+
+    Raises ValueError (via parse_date_boundary) on anything unparseable.
+    Callers must use the returned values, not the originals — a full instant
+    with a non-UTC offset is normalized to a different string here.
+    """
+    normalized_before = parse_date_boundary(before, "--before") if before is not None else None
+    normalized_after = parse_date_boundary(after, "--after") if after is not None else None
+    return normalized_before, normalized_after

--- a/src/ccrecall/dates.py
+++ b/src/ccrecall/dates.py
@@ -12,6 +12,8 @@ stored strings, so a validated value always compares correctly unparsed.
 
 from whenever import Date, Instant
 
+from ccrecall.errors import emit_error
+
 
 def parse_date_boundary(value: str, flag: str) -> str:
     """Validate a --before/--after value; return the string to use in SQL.
@@ -54,3 +56,24 @@ def validate_date_boundaries(before: str | None, after: str | None) -> tuple[str
     normalized_before = parse_date_boundary(before, "--before") if before is not None else None
     normalized_after = parse_date_boundary(after, "--after") if after is not None else None
     return normalized_before, normalized_after
+
+
+def validate_or_exit(before: str | None, after: str | None) -> tuple[str | None, str | None]:
+    """validate_date_boundaries, but exit 2 with a structured error instead of raising.
+
+    Every read command (recent-chats, search, search-messages) needs the same
+    validate-or-exit behavior at the same point in its run() — before the
+    db.exists() check — so this is the one place that pairs
+    validate_date_boundaries with emit_error, rather than each command
+    repeating the try/except.
+    """
+    try:
+        return validate_date_boundaries(before, after)
+    except ValueError as e:
+        emit_error(
+            str(e),
+            code="invalid_date",
+            exit_code=2,
+            remediation="Use YYYY-MM-DD or a full ISO-8601 timestamp like 2026-08-03T12:00:00Z.",
+        )
+        raise AssertionError("unreachable — emit_error always raises SystemExit") from e

--- a/src/ccrecall/recent_chats.py
+++ b/src/ccrecall/recent_chats.py
@@ -8,6 +8,7 @@ import sqlite3
 from pathlib import Path
 
 from ccrecall.config import DEFAULT_DB_PATH
+from ccrecall.dates import validate_date_boundaries
 from ccrecall.db import (
     escape_like,
     fetch_branch_messages,
@@ -61,6 +62,10 @@ def get_recent_sessions(
         sql += " AND s.uuid LIKE ? ESCAPE '\\'"
         params.append(f"{escape_like(session_id)}%")
 
+    # Mirrors search_query.py's scope_filter_clause (before/after clauses) —
+    # not reused because this function already builds its project/session/path
+    # filters inline rather than via that helper. Keep both in sync if the
+    # before/after comparison semantics ever change.
     if before:
         sql += " AND b.started_at < ?"
         params.append(before)
@@ -170,6 +175,19 @@ def run(
     # before reaching here. Both sides bound on MAX_RECENT_SESSIONS.
     n = max(1, min(MAX_RECENT_SESSIONS, n))
     projects = parse_project_filter(project)
+
+    try:
+        # Reassignment is required, not stylistic: a non-UTC offset instant is
+        # normalized to UTC here, and the original (unnormalized) value would
+        # compare incorrectly against the stored UTC timestamps.
+        before, after = validate_date_boundaries(before, after)
+    except ValueError as e:
+        emit_error(
+            str(e),
+            code="invalid_date",
+            exit_code=2,
+            remediation="Use YYYY-MM-DD or a full ISO-8601 timestamp like 2026-08-03T12:00:00Z.",
+        )
 
     if not db.exists():
         emit_error(

--- a/src/ccrecall/recent_chats.py
+++ b/src/ccrecall/recent_chats.py
@@ -8,7 +8,7 @@ import sqlite3
 from pathlib import Path
 
 from ccrecall.config import DEFAULT_DB_PATH
-from ccrecall.dates import validate_date_boundaries
+from ccrecall.dates import validate_or_exit
 from ccrecall.db import (
     escape_like,
     fetch_branch_messages,
@@ -176,18 +176,10 @@ def run(
     n = max(1, min(MAX_RECENT_SESSIONS, n))
     projects = parse_project_filter(project)
 
-    try:
-        # Reassignment is required, not stylistic: a non-UTC offset instant is
-        # normalized to UTC here, and the original (unnormalized) value would
-        # compare incorrectly against the stored UTC timestamps.
-        before, after = validate_date_boundaries(before, after)
-    except ValueError as e:
-        emit_error(
-            str(e),
-            code="invalid_date",
-            exit_code=2,
-            remediation="Use YYYY-MM-DD or a full ISO-8601 timestamp like 2026-08-03T12:00:00Z.",
-        )
+    # Reassignment is required, not stylistic: a non-UTC offset instant is
+    # normalized to UTC here, and the original (unnormalized) value would
+    # compare incorrectly against the stored UTC timestamps.
+    before, after = validate_or_exit(before, after)
 
     if not db.exists():
         emit_error(

--- a/src/ccrecall/search_cli.py
+++ b/src/ccrecall/search_cli.py
@@ -10,7 +10,7 @@ import sys
 from pathlib import Path
 
 from ccrecall.config import DEFAULT_DB_PATH
-from ccrecall.dates import validate_date_boundaries
+from ccrecall.dates import validate_or_exit
 from ccrecall.db import (
     branch_embedding_coverage,
     chunk_vec_queryable,
@@ -83,18 +83,10 @@ def run_messages(
     max_results = max(1, min(MAX_SEARCH_RESULTS, max_results))
     projects = parse_project_filter(project)
 
-    try:
-        # Reassignment is required, not stylistic: a non-UTC offset instant is
-        # normalized to UTC here, and the original (unnormalized) value would
-        # compare incorrectly against the stored UTC timestamps.
-        before, after = validate_date_boundaries(before, after)
-    except ValueError as e:
-        emit_error(
-            str(e),
-            code="invalid_date",
-            exit_code=2,
-            remediation="Use YYYY-MM-DD or a full ISO-8601 timestamp like 2026-08-03T12:00:00Z.",
-        )
+    # Reassignment is required, not stylistic: a non-UTC offset instant is
+    # normalized to UTC here, and the original (unnormalized) value would
+    # compare incorrectly against the stored UTC timestamps.
+    before, after = validate_or_exit(before, after)
 
     if not db.exists():
         emit_error(
@@ -211,18 +203,10 @@ def run(
     max_results = max(1, min(MAX_SEARCH_RESULTS, max_results))
     projects = parse_project_filter(project)
 
-    try:
-        # Reassignment is required, not stylistic: a non-UTC offset instant is
-        # normalized to UTC here, and the original (unnormalized) value would
-        # compare incorrectly against the stored UTC timestamps.
-        before, after = validate_date_boundaries(before, after)
-    except ValueError as e:
-        emit_error(
-            str(e),
-            code="invalid_date",
-            exit_code=2,
-            remediation="Use YYYY-MM-DD or a full ISO-8601 timestamp like 2026-08-03T12:00:00Z.",
-        )
+    # Reassignment is required, not stylistic: a non-UTC offset instant is
+    # normalized to UTC here, and the original (unnormalized) value would
+    # compare incorrectly against the stored UTC timestamps.
+    before, after = validate_or_exit(before, after)
 
     if not db.exists():
         if status:

--- a/src/ccrecall/search_cli.py
+++ b/src/ccrecall/search_cli.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 
 from ccrecall.config import DEFAULT_DB_PATH
+from ccrecall.dates import validate_date_boundaries
 from ccrecall.db import (
     branch_embedding_coverage,
     chunk_vec_queryable,
@@ -67,6 +68,8 @@ def run_messages(
     session: str | None = None,
     project: str | None = None,
     path: str | None = None,
+    before: str | None = None,
+    after: str | None = None,
     output_format: str = "markdown",
     include_notifications: bool = False,  # noqa: ARG001 — accepted for surface symmetry; moot on B (no fetch)
     db: Path = DEFAULT_DB_PATH,
@@ -79,6 +82,19 @@ def run_messages(
     """
     max_results = max(1, min(MAX_SEARCH_RESULTS, max_results))
     projects = parse_project_filter(project)
+
+    try:
+        # Reassignment is required, not stylistic: a non-UTC offset instant is
+        # normalized to UTC here, and the original (unnormalized) value would
+        # compare incorrectly against the stored UTC timestamps.
+        before, after = validate_date_boundaries(before, after)
+    except ValueError as e:
+        emit_error(
+            str(e),
+            code="invalid_date",
+            exit_code=2,
+            remediation="Use YYYY-MM-DD or a full ISO-8601 timestamp like 2026-08-03T12:00:00Z.",
+        )
 
     if not db.exists():
         emit_error(
@@ -98,6 +114,8 @@ def run_messages(
                 projects=projects,
                 session_id=session,
                 path=path,
+                before=before,
+                after=after,
             )
 
         if output_format == "json":
@@ -165,6 +183,8 @@ def run(
     session: str | None = None,
     project: str | None = None,
     path: str | None = None,
+    before: str | None = None,
+    after: str | None = None,
     output_format: str = "markdown",
     verbose: bool = False,
     include_notifications: bool = False,  # noqa: ARG001 — accepted for CLI compat; A-path has no transcript hydration
@@ -190,6 +210,19 @@ def run(
     # --max-results before reaching here. Both sides bound on MAX_SEARCH_RESULTS.
     max_results = max(1, min(MAX_SEARCH_RESULTS, max_results))
     projects = parse_project_filter(project)
+
+    try:
+        # Reassignment is required, not stylistic: a non-UTC offset instant is
+        # normalized to UTC here, and the original (unnormalized) value would
+        # compare incorrectly against the stored UTC timestamps.
+        before, after = validate_date_boundaries(before, after)
+    except ValueError as e:
+        emit_error(
+            str(e),
+            code="invalid_date",
+            exit_code=2,
+            remediation="Use YYYY-MM-DD or a full ISO-8601 timestamp like 2026-08-03T12:00:00Z.",
+        )
 
     if not db.exists():
         if status:
@@ -228,6 +261,8 @@ def run(
                 session_id=session,
                 path=path,
                 keyword_only=keyword_only,
+                before=before,
+                after=after,
             )
             caveat = compute_caveat(conn)
 

--- a/src/ccrecall/search_conversations.py
+++ b/src/ccrecall/search_conversations.py
@@ -38,6 +38,8 @@ def search_sessions(
     session_id: str | None = None,
     path: str | None = None,
     keyword_only: bool = False,
+    before: str | None = None,
+    after: str | None = None,
 ) -> tuple[list[dict], bool]:
     """Search for sessions, returning (cards, ranked).
 
@@ -82,9 +84,28 @@ def search_sessions(
         try:
             fts_ids = [
                 bid
-                for bid, _score in get_fts_branch_ids(cursor, query, fts_level, fts_top_k, projects, session_id, path)
+                for bid, _score in get_fts_branch_ids(
+                    cursor,
+                    query,
+                    fts_level,
+                    fts_top_k,
+                    projects=projects,
+                    session_id=session_id,
+                    path=path,
+                    before=before,
+                    after=after,
+                )
             ]
-            chunk_results = get_vec_chunk_ids(cursor, query_vec, chunk_top_k, projects, session_id, path)
+            chunk_results = get_vec_chunk_ids(
+                cursor,
+                query_vec,
+                chunk_top_k,
+                projects=projects,
+                session_id=session_id,
+                path=path,
+                before=before,
+                after=after,
+            )
             vec_branch_ids = [r[0] for r in chunk_results]
 
             # Score-returning fusion — branch_id → rrf_score (higher = better)
@@ -128,7 +149,17 @@ def search_sessions(
     # (null scores, recency order). The fts4 rung is recency-ordered with no
     # relevance score in this landing, so it is also surfaced as unranked — a
     # deferred Track A gap (issue #35), not the contract's end state.
-    fts_rows = get_fts_branch_ids(cursor, query, fts_level, fts_top_k, projects, session_id, path)
+    fts_rows = get_fts_branch_ids(
+        cursor,
+        query,
+        fts_level,
+        fts_top_k,
+        projects=projects,
+        session_id=session_id,
+        path=path,
+        before=before,
+        after=after,
+    )
     ranked = fts_level == "fts5" and bool(fts_rows)
     branch_scores = {bid: score for bid, score in fts_rows if score is not None} if ranked else None
     deduped_ids = dedup_by_session(cursor, [bid for bid, _score in fts_rows])
@@ -145,6 +176,8 @@ def search_messages(
     projects: list[str] | None = None,
     session_id: str | None = None,
     path: str | None = None,
+    before: str | None = None,
+    after: str | None = None,
 ) -> tuple[list[dict], bool]:
     """Search for matched exchanges (Entrypoint B), returning (snippets, ranked).
 
@@ -173,7 +206,9 @@ def search_messages(
     top_k = max(max_results * OVERFETCH_MULTIPLIER, OVERFETCH_FLOOR)
     cursor = conn.cursor()
 
-    raw = execute_chunk_knn(cursor, query_vec, top_k, projects, session_id, path)
+    raw = execute_chunk_knn(
+        cursor, query_vec, top_k, projects=projects, session_id=session_id, path=path, before=before, after=after
+    )
     if not raw:
         # Either no matches or a DB error caught inside execute_chunk_knn;
         # both cases return ranked=True (vec was available but yielded nothing).

--- a/src/ccrecall/search_query.py
+++ b/src/ccrecall/search_query.py
@@ -38,13 +38,22 @@ def scope_filter_clause(
     projects: list[str] | None,
     session_id: str | None,
     path: str | None,
+    before: str | None = None,
+    after: str | None = None,
 ) -> tuple[str, list]:
-    """Return (sql_fragment, params) for the project/session/path WHERE filters.
+    """Return (sql_fragment, params) for the project/session/path/date WHERE filters.
 
-    The fragment assumes the query's FROM aliases sessions as ``s`` and projects
-    as ``p``. The fragment leads with a space when non-empty; params are ordered
-    projects -> session -> path to match the clause order. Single source of truth
-    for the scope predicates shared by the FTS, LIKE, and chunk-KNN queries.
+    The fragment assumes the query's FROM aliases sessions as ``s``, projects
+    as ``p``, and branches as ``b``. The fragment leads with a space when
+    non-empty; params are ordered projects -> session -> path -> before -> after
+    to match the clause order. Single source of truth for the scope predicates
+    shared by the FTS, LIKE, and chunk-KNN queries. before/after filter on
+    b.started_at (branch-level, matching recent_chats.py's convention) and are
+    assumed already validated by dates.validate_date_boundaries — this function
+    does not parse or reformat them, only compares them lexicographically.
+    recent_chats.py's get_recent_sessions builds an equivalent before/after
+    clause inline (it doesn't route its filters through this helper) — keep
+    both in sync if the comparison semantics ever change.
     """
     clauses: list[str] = []
     params: list = []
@@ -58,6 +67,12 @@ def scope_filter_clause(
     if path:
         clauses.append("s.cwd LIKE ? ESCAPE '\\'")
         params.append(f"%{escape_like(path)}%")
+    if before:
+        clauses.append("b.started_at < ?")
+        params.append(before)
+    if after:
+        clauses.append("b.started_at > ?")
+        params.append(after)
     fragment = "".join(f" AND {clause}" for clause in clauses)
     return fragment, params
 
@@ -70,6 +85,8 @@ def get_fts_branch_ids(
     projects: list[str] | None = None,
     session_id: str | None = None,
     path: str | None = None,
+    before: str | None = None,
+    after: str | None = None,
 ) -> list[tuple[int, float | None]]:
     """Return ordered (branch_id, score_raw) pairs from FTS or LIKE search.
 
@@ -108,7 +125,9 @@ def get_fts_branch_ids(
         """
         params.append(fts_query)
 
-        scope_sql, scope_params = scope_filter_clause(projects=projects, session_id=session_id, path=path)
+        scope_sql, scope_params = scope_filter_clause(
+            projects=projects, session_id=session_id, path=path, before=before, after=after
+        )
         sql += scope_sql
         params.extend(scope_params)
 
@@ -131,7 +150,9 @@ def get_fts_branch_ids(
         """
         params.extend(f"%{term}%" for term in terms)
 
-        scope_sql, scope_params = scope_filter_clause(projects=projects, session_id=session_id, path=path)
+        scope_sql, scope_params = scope_filter_clause(
+            projects=projects, session_id=session_id, path=path, before=before, after=after
+        )
         sql += scope_sql
         params.extend(scope_params)
 

--- a/src/ccrecall/search_vector.py
+++ b/src/ccrecall/search_vector.py
@@ -15,6 +15,8 @@ def execute_chunk_knn(
     projects: list[str] | None = None,
     session_id: str | None = None,
     path: str | None = None,
+    before: str | None = None,
+    after: str | None = None,
 ) -> list[tuple[int, int, float]]:
     """Shared chunk-KNN core: run the vec MATCH query, filter to valid chunks, return in KNN order.
 
@@ -53,7 +55,9 @@ def execute_chunk_knn(
     """
     filter_params: list = [*chunk_ids, EMBEDDING_VERSION, EMBEDDING_MODEL]
 
-    scope_sql, scope_params = scope_filter_clause(projects=projects, session_id=session_id, path=path)
+    scope_sql, scope_params = scope_filter_clause(
+        projects=projects, session_id=session_id, path=path, before=before, after=after
+    )
     filter_sql += scope_sql
     filter_params.extend(scope_params)
 
@@ -75,6 +79,8 @@ def get_vec_chunk_ids(
     projects: list[str] | None = None,
     session_id: str | None = None,
     path: str | None = None,
+    before: str | None = None,
+    after: str | None = None,
 ) -> list[tuple[int, float, int]]:
     """Return ordered (branch_id, distance, chunk_id) from chunk-vec KNN (Entrypoint A).
 
@@ -82,7 +88,9 @@ def get_vec_chunk_ids(
     the first (closest) chunk per branch in KNN order. Returns empty list on DB
     error so the caller degrades to keyword search; non-DB bugs propagate.
     """
-    raw = execute_chunk_knn(cursor, query_vec, top_k, projects, session_id, path)
+    raw = execute_chunk_knn(
+        cursor, query_vec, top_k, projects=projects, session_id=session_id, path=path, before=before, after=after
+    )
     if not raw:
         return []
 

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -19,8 +19,12 @@ class TestParseDateBoundaryAccepts:
     def test_bare_date_returned_unchanged(self):
         assert parse_date_boundary("2026-08-01", "--before") == "2026-08-01"
 
-    def test_full_instant_with_z_returned_unchanged(self):
-        assert parse_date_boundary("2026-08-01T10:00:00Z", "--before") == "2026-08-01T10:00:00Z"
+    def test_full_instant_with_z_normalized_to_millisecond_precision(self):
+        # A boundary with no fractional seconds gains a zero-padded ".000"
+        # field, matching the width of real transcript timestamps (which
+        # always carry milliseconds) -- see the mixed-precision-sorting test
+        # below for why this matters.
+        assert parse_date_boundary("2026-08-01T10:00:00Z", "--before") == "2026-08-01T10:00:00.000Z"
 
     def test_full_instant_with_milliseconds_returned_unchanged(self):
         assert parse_date_boundary("2026-08-01T10:00:00.123Z", "--before") == "2026-08-01T10:00:00.123Z"
@@ -29,18 +33,31 @@ class TestParseDateBoundaryAccepts:
         # +02:00 must be converted to its UTC equivalent, not passed through
         # verbatim -- see the docstring in dates.py for why passthrough would
         # silently corrupt the lexicographic comparison against stored UTC values.
-        assert parse_date_boundary("2026-08-01T10:00:00+02:00", "--before") == "2026-08-01T08:00:00Z"
+        assert parse_date_boundary("2026-08-01T10:00:00+02:00", "--before") == "2026-08-01T08:00:00.000Z"
 
     def test_negative_offset_instant_normalized_to_utc(self):
-        assert parse_date_boundary("2026-08-01T10:00:00-05:00", "--after") == "2026-08-01T15:00:00Z"
+        assert parse_date_boundary("2026-08-01T10:00:00-05:00", "--after") == "2026-08-01T15:00:00.000Z"
 
     def test_normalized_instant_sorts_correctly_against_stored_format(self):
         # The whole point of normalization: after conversion, string comparison
         # must agree with actual chronological order against a Z-format value
         # that represents the same real instant.
         normalized = parse_date_boundary("2026-08-01T10:00:00+02:00", "--before")
-        same_instant_as_z = "2026-08-01T08:00:00Z"
+        same_instant_as_z = "2026-08-01T08:00:00.000Z"
         assert normalized == same_instant_as_z
+
+    def test_no_fractional_boundary_sorts_correctly_against_millisecond_stored_value(self):
+        # Regression for a real bug: before forcing millisecond precision, a
+        # boundary normalized without a fractional field (e.g. "...10Z")
+        # sorted lexicographically *before* a stored value in the same second
+        # that carries milliseconds (e.g. "...10.001Z"), because "." (0x2E)
+        # sorts before "Z" (0x5A) -- even though the stored value is
+        # chronologically *later*. Real Claude Code transcripts always carry
+        # milliseconds, so every full-instant boundary without them was
+        # silently wrong.
+        after_boundary = parse_date_boundary("2026-02-10T04:56:10Z", "--after")
+        stored_value_one_ms_later = "2026-02-10T04:56:10.001Z"
+        assert stored_value_one_ms_later > after_boundary
 
 
 class TestParseDateBoundaryRejects:
@@ -112,7 +129,7 @@ class TestValidateOrExit:
         # Confirms validate_or_exit doesn't bypass the normalization that
         # parse_date_boundary/validate_date_boundaries perform.
         before, _after = validate_or_exit("2026-08-01T10:00:00+02:00", None)
-        assert before == "2026-08-01T08:00:00Z"
+        assert before == "2026-08-01T08:00:00.000Z"
 
     def test_invalid_before_exits_2_with_structured_error(self, capsys):
         with pytest.raises(SystemExit) as exc_info:

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -8,9 +8,11 @@ filter that silently returns wrong results with no error at all -- exactly
 the failure mode this module exists to close off.
 """
 
+import json
+
 import pytest
 
-from ccrecall.dates import parse_date_boundary, validate_date_boundaries
+from ccrecall.dates import parse_date_boundary, validate_date_boundaries, validate_or_exit
 
 
 class TestParseDateBoundaryAccepts:
@@ -89,3 +91,41 @@ class TestValidateDateBoundaries:
 
     def test_only_after_provided(self):
         assert validate_date_boundaries(None, "2026-08-01") == (None, "2026-08-01")
+
+
+class TestValidateOrExit:
+    """validate_or_exit: the shared validate-then-emit_error helper.
+
+    Extracted after code review flagged the try/except/emit_error block as
+    copy-pasted verbatim across recent_chats.run, search_cli.run, and
+    search_cli.run_messages -- this is now the one place that pairs
+    validate_date_boundaries with the exit-2 behavior all three commands need.
+    """
+
+    def test_valid_pair_returned_normalized(self):
+        assert validate_or_exit("2026-08-10", "2026-08-01") == ("2026-08-10", "2026-08-01")
+
+    def test_both_none_returns_none_none(self):
+        assert validate_or_exit(None, None) == (None, None)
+
+    def test_offset_instant_normalized_on_the_exit_path_too(self):
+        # Confirms validate_or_exit doesn't bypass the normalization that
+        # parse_date_boundary/validate_date_boundaries perform.
+        before, _after = validate_or_exit("2026-08-01T10:00:00+02:00", None)
+        assert before == "2026-08-01T08:00:00Z"
+
+    def test_invalid_before_exits_2_with_structured_error(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            validate_or_exit("2025-8-1", "2026-08-01")
+        assert exc_info.value.code == 2
+        envelope = json.loads(capsys.readouterr().err)
+        assert envelope["code"] == "invalid_date"
+        assert "--before" in envelope["error"]
+
+    def test_invalid_after_exits_2_with_structured_error(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            validate_or_exit("2026-08-10", "not-a-date")
+        assert exc_info.value.code == 2
+        envelope = json.loads(capsys.readouterr().err)
+        assert envelope["code"] == "invalid_date"
+        assert "--after" in envelope["error"]

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,0 +1,91 @@
+"""Tests for --before/--after boundary validation (ccrecall.dates).
+
+Correctness here matters more than usual: stored timestamps are compared
+lexicographically as raw strings (see search_query.scope_filter_clause and
+recent_chats.get_recent_sessions), so a value that parses "successfully" but
+in a format that doesn't sort the same way as the stored strings produces a
+filter that silently returns wrong results with no error at all -- exactly
+the failure mode this module exists to close off.
+"""
+
+import pytest
+
+from ccrecall.dates import parse_date_boundary, validate_date_boundaries
+
+
+class TestParseDateBoundaryAccepts:
+    def test_bare_date_returned_unchanged(self):
+        assert parse_date_boundary("2026-08-01", "--before") == "2026-08-01"
+
+    def test_full_instant_with_z_returned_unchanged(self):
+        assert parse_date_boundary("2026-08-01T10:00:00Z", "--before") == "2026-08-01T10:00:00Z"
+
+    def test_full_instant_with_milliseconds_returned_unchanged(self):
+        assert parse_date_boundary("2026-08-01T10:00:00.123Z", "--before") == "2026-08-01T10:00:00.123Z"
+
+    def test_offset_instant_normalized_to_utc(self):
+        # +02:00 must be converted to its UTC equivalent, not passed through
+        # verbatim -- see the docstring in dates.py for why passthrough would
+        # silently corrupt the lexicographic comparison against stored UTC values.
+        assert parse_date_boundary("2026-08-01T10:00:00+02:00", "--before") == "2026-08-01T08:00:00Z"
+
+    def test_negative_offset_instant_normalized_to_utc(self):
+        assert parse_date_boundary("2026-08-01T10:00:00-05:00", "--after") == "2026-08-01T15:00:00Z"
+
+    def test_normalized_instant_sorts_correctly_against_stored_format(self):
+        # The whole point of normalization: after conversion, string comparison
+        # must agree with actual chronological order against a Z-format value
+        # that represents the same real instant.
+        normalized = parse_date_boundary("2026-08-01T10:00:00+02:00", "--before")
+        same_instant_as_z = "2026-08-01T08:00:00Z"
+        assert normalized == same_instant_as_z
+
+
+class TestParseDateBoundaryRejects:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "2026-8-1",  # unpadded month/day
+            "2026-08-01T10:00:00",  # missing timezone (naive)
+            "08/01/2026",  # US slash format
+            "not-a-date",
+            "",
+            "2026-13-01",  # invalid month
+            "2026-08-32",  # invalid day
+            "  2026-08-01",  # leading whitespace
+        ],
+    )
+    def test_rejects_unparseable_value(self, value):
+        with pytest.raises(ValueError, match="--before"):
+            parse_date_boundary(value, "--before")
+
+    def test_error_message_includes_flag_name(self):
+        with pytest.raises(ValueError, match="--after"):
+            parse_date_boundary("garbage", "--after")
+
+    def test_error_message_includes_offending_value(self):
+        with pytest.raises(ValueError, match="2026-8-1"):
+            parse_date_boundary("2026-8-1", "--before")
+
+
+class TestValidateDateBoundaries:
+    def test_both_none_returns_none_none(self):
+        assert validate_date_boundaries(None, None) == (None, None)
+
+    def test_valid_pair_returned_normalized(self):
+        before, after = validate_date_boundaries("2026-08-10", "2026-08-01")
+        assert (before, after) == ("2026-08-10", "2026-08-01")
+
+    def test_invalid_before_raises(self):
+        with pytest.raises(ValueError, match="--before"):
+            validate_date_boundaries("2026-8-1", "2026-08-01")
+
+    def test_invalid_after_raises(self):
+        with pytest.raises(ValueError, match="--after"):
+            validate_date_boundaries("2026-08-10", "not-a-date")
+
+    def test_only_before_provided(self):
+        assert validate_date_boundaries("2026-08-10", None) == ("2026-08-10", None)
+
+    def test_only_after_provided(self):
+        assert validate_date_boundaries(None, "2026-08-01") == (None, "2026-08-01")

--- a/tests/test_recent_chats.py
+++ b/tests/test_recent_chats.py
@@ -7,12 +7,14 @@ embedding_model, summary_version_at_embed) and the branch_vec virtual table
 are present.
 """
 
+import json
 import sqlite3
 
 import pytest
 from conftest import make_vec_conn
 
 from ccrecall.recent_chats import get_recent_sessions
+from ccrecall.recent_chats import run as recent_chats_run
 
 
 def _seed_sessions(conn: sqlite3.Connection) -> list[str]:
@@ -156,3 +158,81 @@ class TestRecentChatsInvariant:
 
         results_no_match = get_recent_sessions(memory_db, n=10, projects=["nonexistent"])
         assert len(results_no_match) == 0
+
+
+class TestRecentChatsDateFilters:
+    """--before/--after actually filter on started_at, not just accept the flag.
+
+    _seed_sessions gives sess-rc-1/2/3 started_at 2025-01-01/02/03T10:00:00Z
+    respectively. These tests exercise get_recent_sessions (the query layer)
+    directly with exact instants (unambiguous filtering) and bare dates
+    (documenting the inclusive/exclusive-of-that-day semantics that fall out
+    of comparing a short date string against the longer stored timestamps).
+    """
+
+    def test_after_exact_instant_excludes_that_session_and_earlier(self, memory_db):
+        _seed_sessions(memory_db)
+        results = get_recent_sessions(memory_db, n=10, after="2025-01-01T10:00:00Z")
+        assert {r["uuid"] for r in results} == {"sess-rc-2", "sess-rc-3"}
+
+    def test_before_exact_instant_excludes_that_session_and_later(self, memory_db):
+        _seed_sessions(memory_db)
+        results = get_recent_sessions(memory_db, n=10, before="2025-01-03T10:00:00Z")
+        assert {r["uuid"] for r in results} == {"sess-rc-1", "sess-rc-2"}
+
+    def test_before_and_after_combine_to_a_range(self, memory_db):
+        _seed_sessions(memory_db)
+        results = get_recent_sessions(memory_db, n=10, after="2025-01-01T10:00:00Z", before="2025-01-03T10:00:00Z")
+        assert {r["uuid"] for r in results} == {"sess-rc-2"}
+
+    def test_bare_date_after_includes_sessions_starting_that_day_onward(self, memory_db):
+        # "2025-01-02T10:00:00Z" > "2025-01-02" lexicographically, so a bare
+        # date --after is inclusive of that whole day.
+        _seed_sessions(memory_db)
+        results = get_recent_sessions(memory_db, n=10, after="2025-01-02")
+        assert {r["uuid"] for r in results} == {"sess-rc-2", "sess-rc-3"}
+
+    def test_bare_date_before_excludes_sessions_starting_that_day(self, memory_db):
+        # "2025-01-02T10:00:00Z" is NOT < "2025-01-02" lexicographically, so a
+        # bare date --before excludes that whole day (only strictly earlier days).
+        _seed_sessions(memory_db)
+        results = get_recent_sessions(memory_db, n=10, before="2025-01-02")
+        assert {r["uuid"] for r in results} == {"sess-rc-1"}
+
+    def test_no_filter_returns_all_sessions(self, memory_db):
+        _seed_sessions(memory_db)
+        results = get_recent_sessions(memory_db, n=10)
+        assert len(results) == 3
+
+    def test_filter_matching_nothing_returns_empty(self, memory_db):
+        _seed_sessions(memory_db)
+        results = get_recent_sessions(memory_db, n=10, after="2030-01-01")
+        assert results == []
+
+
+class TestRecentChatsInvalidDateRejected:
+    """run() rejects a malformed --before/--after before ever touching the DB.
+
+    Uses a nonexistent db path deliberately: date validation happens before
+    the db.exists() check in run(), so if this test ever started reaching the
+    db-not-found error instead of the invalid-date error, that would itself
+    signal the validation order regressed.
+    """
+
+    def test_malformed_before_exits_2_with_structured_error(self, tmp_path, capsys):
+        missing_db = tmp_path / "does-not-exist.db"
+        with pytest.raises(SystemExit) as exc_info:
+            recent_chats_run(before="2025-8-1", db=missing_db)
+        assert exc_info.value.code == 2
+        envelope = json.loads(capsys.readouterr().err)
+        assert envelope["code"] == "invalid_date"
+        assert "--before" in envelope["error"]
+
+    def test_malformed_after_exits_2_with_structured_error(self, tmp_path, capsys):
+        missing_db = tmp_path / "does-not-exist.db"
+        with pytest.raises(SystemExit) as exc_info:
+            recent_chats_run(after="not-a-date", db=missing_db)
+        assert exc_info.value.code == 2
+        envelope = json.loads(capsys.readouterr().err)
+        assert envelope["code"] == "invalid_date"
+        assert "--after" in envelope["error"]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1803,3 +1803,150 @@ class TestRecallCaveat:
         out = capsys.readouterr().out
         assert "unavailable" not in out
         assert "partial" not in out
+
+
+# --before/--after date filters (branch-level, matching recent_chats.py)
+
+
+def _seed_dated_branch(conn: sqlite3.Connection, uuid: str, started_at: str, content: str) -> int:
+    """Seed one session/branch pair with an explicit started_at; return branch_id.
+
+    search_db's fixture branches leave started_at NULL (unused by keyword
+    tests), so date-filter tests seed their own minimal branches instead of
+    touching that shared fixture.
+    """
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT OR IGNORE INTO projects (path, key, name) VALUES (?, ?, ?)", ("/p/dated", "-p-dated", "dated")
+    )
+    cursor.execute("SELECT id FROM projects WHERE key = ?", ("-p-dated",))
+    proj_id = cursor.fetchone()[0]
+    cursor.execute("INSERT INTO sessions (uuid, project_id, cwd) VALUES (?, ?, ?)", (uuid, proj_id, "/p/dated"))
+    sess_id = cursor.lastrowid
+    cursor.execute(
+        """
+        INSERT INTO branches (session_id, leaf_uuid, is_active, exchange_count,
+                               aggregated_content, started_at, ended_at)
+        VALUES (?, ?, 1, 1, ?, ?, ?)
+        """,
+        (sess_id, f"leaf-{uuid}", content, started_at, started_at),
+    )
+    branch_id = cursor.lastrowid
+    conn.commit()
+    return branch_id
+
+
+@pytest.fixture
+def dated_search_db():
+    """DB with two branches matching 'pytest', started 2025-01-01 and 2025-06-01."""
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(SCHEMA)
+    conn.commit()
+    _seed_dated_branch(conn, "sess-dated-old", "2025-01-01T10:00:00Z", "pytest fixtures old session")
+    _seed_dated_branch(conn, "sess-dated-new", "2025-06-01T10:00:00Z", "pytest fixtures new session")
+    yield conn
+    conn.close()
+
+
+class TestSearchSessionsDateFilters:
+    """search_sessions' --before/--after (threaded through scope_filter_clause)."""
+
+    def test_before_excludes_later_session(self, dated_search_db):
+        results, _ranked = search_sessions(
+            dated_search_db, "pytest", fts_level=None, max_results=10, before="2025-03-01"
+        )
+        uuids = {r["session_uuid"] for r in results}
+        assert uuids == {"sess-dated-old"}
+
+    def test_after_excludes_earlier_session(self, dated_search_db):
+        results, _ranked = search_sessions(
+            dated_search_db, "pytest", fts_level=None, max_results=10, after="2025-03-01"
+        )
+        uuids = {r["session_uuid"] for r in results}
+        assert uuids == {"sess-dated-new"}
+
+    def test_before_and_after_range_excludes_both(self, dated_search_db):
+        # Neither branch's started_at (2025-01-01, 2025-06-01) falls inside
+        # this window -- proves the two clauses actually AND together.
+        results, _ranked = search_sessions(
+            dated_search_db, "pytest", fts_level=None, max_results=10, after="2025-02-01", before="2025-03-01"
+        )
+        assert results == []
+
+    def test_no_date_filter_returns_both(self, dated_search_db):
+        results, _ranked = search_sessions(dated_search_db, "pytest", fts_level=None, max_results=10)
+        uuids = {r["session_uuid"] for r in results}
+        assert uuids == {"sess-dated-old", "sess-dated-new"}
+
+
+class TestSearchMessagesDateFilters:
+    """search_messages' --before/--after (threaded through execute_chunk_knn)."""
+
+    @pytest.mark.skipif(
+        not vec_available(sqlite3.connect(":memory:")),
+        reason="sqlite-vec not available",
+    )
+    def test_before_excludes_chunk_from_later_branch(self):
+        conn = make_vec_conn()
+        query_vec = [1.0 / EMBEDDING_DIM**0.5] * EMBEDDING_DIM
+
+        old_branch = _seed_dated_branch(conn, "sess-msg-old", "2025-01-01T10:00:00Z", "old branch content")
+        new_branch = _seed_dated_branch(conn, "sess-msg-new", "2025-06-01T10:00:00Z", "new branch content")
+        for branch_id, tag in [(old_branch, "old"), (new_branch, "new")]:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT INTO chunks (branch_id, exchange_index, content_hash, first_message_uuid,
+                                     timestamp, user_text, assistant_text, embedding_version, embedding_model)
+                VALUES (?, 0, ?, ?, '2025-01-01T10:00:00Z', ?, ?, ?, ?)
+                """,
+                (
+                    branch_id,
+                    f"h-{tag}",
+                    f"uuid-{tag}",
+                    f"{tag} user",
+                    f"{tag} assistant",
+                    EMBEDDING_VERSION,
+                    EMBEDDING_MODEL,
+                ),
+            )
+            chunk_id = cursor.lastrowid
+            upsert_chunk_vec(cursor, chunk_id, query_vec)
+        conn.commit()
+
+        with (
+            patch("ccrecall.search_conversations.model_available", return_value=True),
+            patch("ccrecall.search_conversations.embed_text", return_value=query_vec),
+        ):
+            snippets, ranked = search_messages(conn, "test query", max_results=10, before="2025-03-01")
+
+        assert ranked is True
+        assert {s["session_uuid"] for s in snippets} == {"sess-msg-old"}
+        conn.close()
+
+
+class TestSearchInvalidDateRejected:
+    """run()/run_messages() reject a malformed --before/--after before hitting the DB.
+
+    Same nonexistent-db-path technique as recent_chats' equivalent test: date
+    validation runs before the db.exists() check, so reaching db_not_found
+    instead of invalid_date would itself mean the validation order regressed.
+    """
+
+    def test_run_rejects_malformed_before(self, tmp_path, capsys):
+        missing_db = tmp_path / "does-not-exist.db"
+        with pytest.raises(SystemExit) as exc_info:
+            run(query="test", before="2025-8-1", db=missing_db)
+        assert exc_info.value.code == 2
+        envelope = json.loads(capsys.readouterr().err)
+        assert envelope["code"] == "invalid_date"
+        assert "--before" in envelope["error"]
+
+    def test_run_messages_rejects_malformed_after(self, tmp_path, capsys):
+        missing_db = tmp_path / "does-not-exist.db"
+        with pytest.raises(SystemExit) as exc_info:
+            run_messages(query="test", after="not-a-date", db=missing_db)
+        assert exc_info.value.code == 2
+        envelope = json.loads(capsys.readouterr().err)
+        assert envelope["code"] == "invalid_date"
+        assert "--after" in envelope["error"]


### PR DESCRIPTION
### Date filters for search and search-messages

- Added `--before`/`--after` to `search` and `search-messages`, matching the flag names and semantics `recent-chats` already had. Filtering is branch-level (session start time), not per-exchange, so `search-messages` filters on the containing session's start time even though it returns individual exchanges.
- Threaded the filter through `search_query.py`'s shared `scope_filter_clause` — the single spot that already builds the project/session/path `WHERE` predicates for the FTS5/FTS4/LIKE and chunk-KNN paths — so all three search backends pick up the new filter for free instead of needing a parallel implementation each.
- Added `ccrecall.dates` to validate and normalize `--before`/`--after` before they reach SQL. The comparison against `branches.started_at` is a raw lexicographic string comparison (never parsed into a different representation), so this module's job is narrow: reject anything that wouldn't compare correctly unparsed (unpadded months, missing timezone, non-ISO formats), and normalize a non-UTC offset instant (e.g. `+02:00`) to the UTC `Z` form the DB stores — passing it through unchanged would silently sort wrong against the stored timestamps even though it parsed fine.
- Retrofitted the same validation onto `recent-chats`' pre-existing `--before`/`--after` flags, which previously accepted anything with no validation and had no test coverage.

### Refactoring

- Extracted `validate_or_exit` in `dates.py` so `recent-chats`, `search`, and `search-messages` share one validate-then-exit-2 behavior at the same point in each `run()`, instead of each command repeating its own try/except around `validate_date_boundaries`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--before` and `--after` date filters to recent-session, conversation-search, and message-search commands.
  * Filters support ISO dates and timezone-aware timestamps, with timestamps normalized consistently.
  * Date ranges apply to session or branch start times across keyword, full-text, and vector searches.

* **Bug Fixes**
  * Invalid date values now produce clear structured errors and exit safely before searching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->