### PR TITLE
perf: cache unchanged ingestion checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2026-08-04
 
+- cache confirmed-OK ingestion checks for faster repeated status audits (#105)
 - recover scoped vector matches beyond the initial KNN window (#102)
 
 ## [0.21.0](https://github.com/NodeJSmith/claude-code-recall/compare/v0.20.0...v0.21.0) (2026-08-03)

--- a/design/research/2026-08-04-issue-103-ingestion-cache/research.md
+++ b/design/research/2026-08-04-issue-103-ingestion-cache/research.md
@@ -1,0 +1,94 @@
+# Research Brief: Issue 103 - Skip unchanged sessions in `ccrecall status --check-ingestion`
+
+## Findings
+
+- `ccrecall status --check-ingestion` enters through `status.collect_status(..., check_ingestion=True)`, opens the DB read-only with `PRAGMA query_only = ON`, builds an `import_log`-derived source index, then calls `ingestion_status.summarize_ingestion()`.
+- `summarize_ingestion()` reparses every tracked existing transcript via `_expected_uuids()` -> `parse_all_with_uuids()` and compares expected active-branch UUIDs with `messages.uuid`. That is the scaling pain: OK sessions are fully parsed again every run.
+- Existing import skip precedent is strong but not identical: `hooks/import_conversations.import_session()` first skips by `import_log.file_size` + `file_mtime`, then hashes only on stat mismatch, then delegates to `session_ops.sync_session()` to update `import_log`.
+- `import_log` is per file; ingestion status is per session and can combine multiple transcript files (`agent-*.jsonl` plus parent file). Tests already cover multi-file ordering and partial source loss.
+- `status.py` currently treats status as read-only and avoids migrating/creating DBs. Any DB-backed "last confirmed OK" marker means `--check-ingestion` either becomes a controlled writer or must degrade when the cache table/columns are absent.
+- Schema changes are centralized in `schema.py` and `db.py`; additive changes use `SCHEMA_CORE` plus a self-guarded migration pattern (`_migrate_to_v3`, `_migrate_to_v4`). `tests/test_db.py` pins table/column layout, so schema snapshots must be updated.
+
+## Options and tradeoffs
+
+### Option A - New per-session ingestion check cache table (recommended)
+
+Add a table such as `ingestion_check_cache(session_uuid TEXT PRIMARY KEY, source_fingerprint TEXT NOT NULL, checked_at DATETIME DEFAULT CURRENT_TIMESTAMP)`. `summarize_ingestion()` computes a stable fingerprint from the session's existing source paths and stat metadata, skips full parsing when the stored fingerprint matches, and writes/updates the row only after the session classifies as OK.
+
+Pros:
+
+- Matches the real domain boundary: the expensive check is per session, not per file.
+- Handles multi-file sessions cleanly with one fingerprint over the sorted path set.
+- Keeps `import_log` focused on import dedup, not audit-cache state.
+- Lets failed/problem sessions remain uncached and therefore always rechecked.
+
+Cons:
+
+- Requires a schema addition and migration/test snapshot updates.
+- Makes `status --check-ingestion` write cache metadata unless an explicit "no persistence" fallback is chosen.
+- Needs careful behavior when the cache table is absent on a read-only connection.
+
+### Option B - Reuse/add columns on `import_log`
+
+Store OK-confirmation stat columns per import-log row and skip when every row in a session has matching OK metadata.
+
+Pros:
+
+- Reuses the table already keyed by `file_path` and already carrying `file_size`/`file_mtime`.
+- Fewer new concepts for file freshness.
+
+Cons:
+
+- Awkward for multi-file sessions: OK is a group property, but rows are per file.
+- Couples audit-check semantics to import dedup state.
+- More likely to produce edge-case ambiguity when one file in a session changes or goes missing.
+
+### Option C - Non-persistent/stat-only shortcut from `import_log`
+
+Trust matching `import_log.file_size`/`file_mtime` as "unchanged enough" and skip without recording that `--check-ingestion` ever confirmed the session.
+
+Pros:
+
+- No schema/write behavior change.
+- Easy and aligned with import fast-skip mechanics.
+
+Cons:
+
+- Undercuts the purpose of `--check-ingestion`: historical gaps or prior importer bugs can be hidden forever if import_log stats match.
+- Does not satisfy the "previously confirmed OK" requirement.
+- Less defensible as an audit mode.
+
+## Recommended approach
+
+Use Option A: a new per-session cache table storing only confirmed-OK freshness. Cache hits should increment `sessions_checked` and `ok_sessions`, but skip `_expected_uuids()` and the `messages.uuid` set query. Cache misses should run the current full logic unchanged.
+
+Only cache OK sessions. Do not cache `pending_tail`, `stale_tail`, `ingestion_gap`, or `missing_source`: those states should remain visible and self-heal naturally after import/sync or file recovery.
+
+## Implementation notes
+
+- Fingerprint should include all existing source paths for a session, sorted deterministically, plus stat metadata. Prefer `st_size` and `st_mtime_ns` if possible; the existing import table uses float `st_mtime`, but new cache code can avoid float equality issues.
+- A missing source should bypass cache entirely. Partial source loss is already counted as `missing_source`; do not let an old OK marker mask it.
+- Add small helpers in `ingestion_status.py`, e.g. `_source_fingerprint(filepaths)`, `_cached_ok(cursor, session_uuid, fingerprint)`, `_record_ok(cursor, session_uuid, fingerprint)`.
+- Decide explicitly how `status.py` opens the DB for `--check-ingestion`. Best fit: keep default status read-only, but for `check_ingestion=True` use a writable connection after the existing outdated-schema guard, or document that the deep check records cache metadata.
+- If keeping read-only status is non-negotiable, make persistence opportunistic: read cache only if table exists and suppress writes on `sqlite3.OperationalError`; this is less predictable but preserves the surface contract.
+- Schema work likely means `SCHEMA_VERSION = 5`, adding the table to `SCHEMA_CORE`, and adding an additive `_migrate_to_v5()`/always-safe table creation path. Update the schema-equivalence pin in `tests/test_db.py`.
+
+## Tests
+
+- `test_complete_session_cache_hit_skips_parse`: first run records OK; second run with unchanged file counts it OK without calling `parse_all_with_uuids()`.
+- `test_cache_invalidates_on_file_append_or_mtime_change`: modify transcript and assert the full parse path runs and pending/stale/gap logic still works.
+- `test_problem_sessions_are_not_cached`: create an ingestion gap; repeated runs still parse/reclassify it.
+- `test_missing_or_partial_source_bypasses_cache`: existing multi-file partial-loss behavior remains `missing_source` even after a prior OK marker.
+- `test_status_check_ingestion_uses_cache_connection_behavior`: pin whether `collect_status(check_ingestion=True)` writes cache metadata or degrades read-only.
+- Schema tests: fresh DB contains the new cache table; migration from older DB is reentrant; schema snapshot updated.
+
+## Risks / open questions
+
+- Main product decision: may `ccrecall status --check-ingestion` mutate the DB? The optimization is cleanest if yes, but that conflicts with current `status.py` read-only design.
+- Cache fingerprint granularity: `mtime_ns` is safer than float mtime, but cross-platform filesystem precision should be considered.
+- Existing DBs without the new schema need a graceful path: require `ccrecall import`/migration first, or let check run uncached until the cache table exists.
+- There is no need for new dependencies.
+
+## Suggested next step
+
+Write a small design/implementation plan choosing the DB-write behavior for `--check-ingestion`, then implement the new per-session cache table and regression tests around skip, invalidation, and problem-session non-caching.

--- a/design/specs/007-issue-103-ingestion-cache/design.md
+++ b/design/specs/007-issue-103-ingestion-cache/design.md
@@ -23,7 +23,7 @@
 ## Functional Requirements
 
 - **FR#1** The ingestion check must persist a per-session confirmed-OK freshness marker after a full check finds no missing expected UUIDs.
-- **FR#2** The ingestion check must skip transcript parsing for a session when its stored confirmed-OK marker matches the current source fingerprint.
+- **FR#2** The ingestion check must skip transcript parsing for a session when its stored confirmed-OK marker matches the current source fingerprint and current DB message UUID coverage.
 - **FR#3** The source fingerprint must cover the complete existing source file set for a session, including deterministic path order and file stat metadata.
 - **FR#4** The ingestion check must not use or write an OK cache marker for sessions with missing source files or missing expected UUIDs.
 - **FR#5** `ccrecall status --check-ingestion` must use a connection mode that can read and update the cache while preserving the existing non-creating behavior for missing databases and the outdated-schema early return.
@@ -40,7 +40,7 @@
 
 Add a dedicated per-session cache table rather than extending `import_log`. `import_log` is keyed by `file_path`, while `summarize_ingestion()` works at a session boundary and can combine parent and `agent-*.jsonl` files. A session-level row avoids group-property ambiguity and keeps import dedup state separate from audit-check state.
 
-The schema change should follow the existing additive migration pattern in `src/ccrecall/schema.py` and `src/ccrecall/db.py`: add an `ingestion_check_cache` table to `SCHEMA_CORE`, bump `SCHEMA_VERSION` from `4` to `5`, and add a small `_migrate_to_v5()` that creates the table idempotently. Wire it from `_apply_migrations()` alongside the existing self-guarded additive migrations. Update `tests/test_db.py` table and column snapshots.
+The schema change should follow the existing additive migration pattern in `src/ccrecall/schema.py` and `src/ccrecall/db.py`: keep the v5 `ingestion_check_cache` table-creation migration, add `db_coverage_fingerprint` to `SCHEMA_CORE`, bump `SCHEMA_VERSION` from `5` to `6`, and add a small `_migrate_to_v6()` that appends the column idempotently. Wire it from `_apply_migrations()` alongside the existing self-guarded additive migrations. Update `tests/test_db.py` table and column snapshots.
 
 Use a table shape like:
 
@@ -48,11 +48,12 @@ Use a table shape like:
 CREATE TABLE IF NOT EXISTS ingestion_check_cache (
   session_uuid TEXT PRIMARY KEY,
   source_fingerprint TEXT NOT NULL,
+  db_coverage_fingerprint TEXT NOT NULL DEFAULT '',
   checked_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 ```
 
-In `src/ccrecall/ingestion_status.py`, add helpers for source fingerprinting, cache lookup, and recording. The fingerprint should be deterministic across runs and include every existing source path sorted by string path plus each file's `st_size` and `st_mtime_ns`. Missing sources must bypass the cache entirely so an old OK marker never hides partial source loss. Only call `_record_ok()` after the current full logic reaches the existing `ok_sessions` path.
+In `src/ccrecall/ingestion_status.py`, add helpers for source fingerprinting, DB coverage fingerprinting, cache lookup, and recording. The source fingerprint should be deterministic across runs and include every existing source path sorted by string path plus each file's `st_size` and `st_mtime_ns`. The DB coverage fingerprint should include the ordered set of stored message UUIDs for the session so cache hits cannot hide deleted or replaced DB messages. Missing sources must bypass the cache entirely so an old OK marker never hides partial source loss. Only call `_record_ok()` after the current full logic reaches the existing `ok_sessions` path.
 
 For `src/ccrecall/status.py`, keep `_readonly_connection()` for default status and embedding reads, but let the `check_ingestion=True` path open the DB through `get_connection(settings, load_vec=False)` after the current outdated-schema guard. This preserves the current no-create behavior by checking `db_path.exists()` before opening, and it preserves the outdated-schema early return by probing with `_readonly_connection()` first. The check can then deliberately write cache metadata as part of the expensive audit mode.
 
@@ -63,9 +64,9 @@ For `src/ccrecall/status.py`, keep `_readonly_connection()` for default status a
 ## Changed Files
 
 - modify: `src/ccrecall/schema.py` - add the ingestion check cache table to the baseline schema.
-- modify: `src/ccrecall/db.py` - bump schema version and add the idempotent v5 table migration.
+- modify: `src/ccrecall/db.py` - bump schema version and add the idempotent v6 column migration.
 - modify: `src/ccrecall/status.py` - use a writable, migration-aware connection only for `check_ingestion=True` after preserving missing/outdated DB behavior.
 - modify: `src/ccrecall/ingestion_status.py` - add fingerprint, cache hit, and cache record behavior around the existing per-session classification loop.
 - modify: `tests/test_ingestion_status.py` - add cache hit, invalidation, and no-cache-for-problem-session coverage.
 - modify: `tests/test_status.py` - pin `collect_status(check_ingestion=True)` cache-writing connection behavior.
-- modify: `tests/test_db.py` - update schema table/column snapshot and migration coverage for v5.
+- modify: `tests/test_db.py` - update schema table/column snapshot and migration coverage for v6.

--- a/design/specs/007-issue-103-ingestion-cache/design.md
+++ b/design/specs/007-issue-103-ingestion-cache/design.md
@@ -1,0 +1,71 @@
+# Design: Issue 103 Ingestion Check Cache
+
+**Date:** 2026-08-04
+**Status:** archived
+**Mode:** sketch
+
+## Problem
+
+`ccrecall status --check-ingestion` reparses every tracked transcript on every run, even when a session was already confirmed OK and all source transcript files are unchanged. The check gets slower as history grows because `ingestion_status.summarize_ingestion()` always calls `_expected_uuids()` and `parse_all_with_uuids()` for every existing source group.
+
+## Goals
+
+- Make repeated `ccrecall status --check-ingestion` runs skip sessions that were previously confirmed OK and whose transcript source set is unchanged.
+- Preserve audit correctness by fully rechecking first-time, modified, missing-source, and problem sessions.
+- Keep the cache state local to the conversations DB and aligned with existing schema/migration patterns.
+
+## Non-Goals
+
+- Do not change the ingestion classification semantics for `pending_tail`, `stale_tail`, `ingestion_gap`, or `missing_source`.
+- Do not use import-log stat equality alone as proof that a session is OK.
+- Do not introduce new dependencies or embedding/vector behavior.
+
+## Functional Requirements
+
+- **FR#1** The ingestion check must persist a per-session confirmed-OK freshness marker after a full check finds no missing expected UUIDs.
+- **FR#2** The ingestion check must skip transcript parsing for a session when its stored confirmed-OK marker matches the current source fingerprint.
+- **FR#3** The source fingerprint must cover the complete existing source file set for a session, including deterministic path order and file stat metadata.
+- **FR#4** The ingestion check must not use or write an OK cache marker for sessions with missing source files or missing expected UUIDs.
+- **FR#5** `ccrecall status --check-ingestion` must use a connection mode that can read and update the cache while preserving the existing non-creating behavior for missing databases and the outdated-schema early return.
+
+## Acceptance Criteria
+
+- **AC#1** `uv run pytest tests/test_ingestion_status.py` passes with new tests proving first-run OK recording and second-run cache-hit parsing skip behavior.
+- **AC#2** `uv run pytest tests/test_ingestion_status.py` passes with tests proving file append/stat changes invalidate the cache and problem sessions are reparsed rather than cached.
+- **AC#3** `uv run pytest tests/test_status.py` passes with a test pinning that `collect_status(check_ingestion=True)` can persist ingestion-cache metadata without creating a missing DB or bypassing the outdated-schema guard.
+- **AC#4** `uv run pytest tests/test_db.py` passes with schema-version, fresh-schema, and snapshot expectations updated for the new cache table.
+- **AC#5** `uv run pytest tests/test_ingestion_status.py tests/test_status.py tests/test_db.py` passes locally.
+
+## Approach
+
+Add a dedicated per-session cache table rather than extending `import_log`. `import_log` is keyed by `file_path`, while `summarize_ingestion()` works at a session boundary and can combine parent and `agent-*.jsonl` files. A session-level row avoids group-property ambiguity and keeps import dedup state separate from audit-check state.
+
+The schema change should follow the existing additive migration pattern in `src/ccrecall/schema.py` and `src/ccrecall/db.py`: add an `ingestion_check_cache` table to `SCHEMA_CORE`, bump `SCHEMA_VERSION` from `4` to `5`, and add a small `_migrate_to_v5()` that creates the table idempotently. Wire it from `_apply_migrations()` alongside the existing self-guarded additive migrations. Update `tests/test_db.py` table and column snapshots.
+
+Use a table shape like:
+
+```sql
+CREATE TABLE IF NOT EXISTS ingestion_check_cache (
+  session_uuid TEXT PRIMARY KEY,
+  source_fingerprint TEXT NOT NULL,
+  checked_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+In `src/ccrecall/ingestion_status.py`, add helpers for source fingerprinting, cache lookup, and recording. The fingerprint should be deterministic across runs and include every existing source path sorted by string path plus each file's `st_size` and `st_mtime_ns`. Missing sources must bypass the cache entirely so an old OK marker never hides partial source loss. Only call `_record_ok()` after the current full logic reaches the existing `ok_sessions` path.
+
+For `src/ccrecall/status.py`, keep `_readonly_connection()` for default status and embedding reads, but let the `check_ingestion=True` path open the DB through `get_connection(settings, load_vec=False)` after the current outdated-schema guard. This preserves the current no-create behavior by checking `db_path.exists()` before opening, and it preserves the outdated-schema early return by probing with `_readonly_connection()` first. The check can then deliberately write cache metadata as part of the expensive audit mode.
+
+## Reference Artifacts
+
+- `design/research/2026-08-04-issue-103-ingestion-cache/research.md` - saved prior research brief used as discovery input.
+
+## Changed Files
+
+- modify: `src/ccrecall/schema.py` - add the ingestion check cache table to the baseline schema.
+- modify: `src/ccrecall/db.py` - bump schema version and add the idempotent v5 table migration.
+- modify: `src/ccrecall/status.py` - use a writable, migration-aware connection only for `check_ingestion=True` after preserving missing/outdated DB behavior.
+- modify: `src/ccrecall/ingestion_status.py` - add fingerprint, cache hit, and cache record behavior around the existing per-session classification loop.
+- modify: `tests/test_ingestion_status.py` - add cache hit, invalidation, and no-cache-for-problem-session coverage.
+- modify: `tests/test_status.py` - pin `collect_status(check_ingestion=True)` cache-writing connection behavior.
+- modify: `tests/test_db.py` - update schema table/column snapshot and migration coverage for v5.

--- a/src/ccrecall/cli/commands.py
+++ b/src/ccrecall/cli/commands.py
@@ -111,11 +111,11 @@ def cmd_status(
     check_ingestion: Annotated[
         bool,
         _FLAG,
-        Parameter(help="Deep-check JSONL transcripts against DB rows to classify ingestion gaps."),
+        Parameter(help="Deep-check JSONL transcripts and cache confirmed-OK sessions."),
     ] = False,
     ctx: CLIContextParam = DEFAULT_CLI_CONTEXT,
 ) -> None:
-    """Show consolidated read-only health and backfill status."""
+    """Show consolidated health and backfill status."""
     status_mod.run(db=db, days=days, check_ingestion=check_ingestion, output_format=ctx.output_format)
 
 

--- a/src/ccrecall/db.py
+++ b/src/ccrecall/db.py
@@ -19,7 +19,7 @@ from ccrecall.schema import SCHEMA_CORE, SCHEMA_FTS4, SCHEMA_FTS5, detect_fts_su
 
 # Current schema version. Bump when adding a migration and wire the new DDL
 # delta into _apply_migrations (see _migrate_to_v1 for the version-1 shape).
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 # Shared SQL predicate for "branches that are candidates to embed": active
 # leaves (the query path only returns is_active=1) with a usable summary. This
@@ -466,6 +466,25 @@ def _migrate_to_v4(conn: sqlite3.Connection) -> None:
     )
 
 
+def _migrate_to_v5(conn: sqlite3.Connection) -> None:
+    """Version-5 migration: add the ingestion check cache table.
+
+    Runs outside the version-gated BEGIN IMMEDIATE block, matching v3/v4's
+    additive style: this branch may be behind the installed version
+    (user_version > SCHEMA_VERSION) but the table still needs to exist for this
+    code to work. Concurrent processes may race on the CREATE TABLE IF NOT
+    EXISTS; SQLite handles that idempotently. No commit here — the caller
+    commits.
+    """
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS ingestion_check_cache ("
+        "session_uuid TEXT PRIMARY KEY, "
+        "source_fingerprint TEXT NOT NULL, "
+        "checked_at DATETIME DEFAULT CURRENT_TIMESTAMP"
+        ")"
+    )
+
+
 def _apply_migrations(conn: sqlite3.Connection) -> None:
     """Apply version-gated schema migrations up to SCHEMA_VERSION, atomically.
 
@@ -505,13 +524,13 @@ def _apply_migrations(conn: sqlite3.Connection) -> None:
     """
     current = conn.execute("PRAGMA user_version").fetchone()[0]
 
-    # _migrate_to_v3 and _migrate_to_v4 are additive (ALTER TABLE ADD COLUMN)
-    # and self-guarded by catching the duplicate-column error, so they run
+    # _migrate_to_v3, _migrate_to_v4, and _migrate_to_v5 are additive and run
     # outside the version gate — this branch may be behind the installed
-    # version (user_version > SCHEMA_VERSION) but the columns still need to
-    # exist for this code to work.
+    # version (user_version > SCHEMA_VERSION) but the columns/table still need
+    # to exist for this code to work.
     _migrate_to_v3(conn)
     _migrate_to_v4(conn)
+    _migrate_to_v5(conn)
     conn.commit()
 
     if current >= SCHEMA_VERSION:

--- a/src/ccrecall/db.py
+++ b/src/ccrecall/db.py
@@ -19,7 +19,7 @@ from ccrecall.schema import SCHEMA_CORE, SCHEMA_FTS4, SCHEMA_FTS5, detect_fts_su
 
 # Current schema version. Bump when adding a migration and wire the new DDL
 # delta into _apply_migrations (see _migrate_to_v1 for the version-1 shape).
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 # Shared SQL predicate for "branches that are candidates to embed": active
 # leaves (the query path only returns is_active=1) with a usable summary. This
@@ -480,9 +480,19 @@ def _migrate_to_v5(conn: sqlite3.Connection) -> None:
         "CREATE TABLE IF NOT EXISTS ingestion_check_cache ("
         "session_uuid TEXT PRIMARY KEY, "
         "source_fingerprint TEXT NOT NULL, "
+        "db_coverage_fingerprint TEXT NOT NULL DEFAULT '', "
         "checked_at DATETIME DEFAULT CURRENT_TIMESTAMP"
         ")"
     )
+
+
+def _migrate_to_v6(conn: sqlite3.Connection) -> None:
+    """Version-6 migration: add DB coverage fingerprint to ingestion cache."""
+    try:
+        conn.execute("ALTER TABLE ingestion_check_cache ADD COLUMN db_coverage_fingerprint TEXT NOT NULL DEFAULT ''")
+    except sqlite3.OperationalError as e:
+        if "duplicate column name" not in str(e):
+            raise
 
 
 def _apply_migrations(conn: sqlite3.Connection) -> None:
@@ -524,13 +534,14 @@ def _apply_migrations(conn: sqlite3.Connection) -> None:
     """
     current = conn.execute("PRAGMA user_version").fetchone()[0]
 
-    # _migrate_to_v3, _migrate_to_v4, and _migrate_to_v5 are additive and run
+    # _migrate_to_v3 through _migrate_to_v6 are additive and run
     # outside the version gate — this branch may be behind the installed
     # version (user_version > SCHEMA_VERSION) but the columns/table still need
     # to exist for this code to work.
     _migrate_to_v3(conn)
     _migrate_to_v4(conn)
     _migrate_to_v5(conn)
+    _migrate_to_v6(conn)
     conn.commit()
 
     if current >= SCHEMA_VERSION:

--- a/src/ccrecall/ingestion_status.py
+++ b/src/ccrecall/ingestion_status.py
@@ -1,4 +1,8 @@
-"""Read-only transcript-vs-DB ingestion coverage diagnostics."""
+"""Transcript-vs-DB ingestion coverage diagnostics.
+
+Diagnostics are read-only except for confirmed-OK cache rows, which let later
+deep-check runs skip reparsing unchanged transcript sources.
+"""
 
 from pathlib import Path
 from sqlite3 import Connection
@@ -43,6 +47,33 @@ def _is_contiguous_suffix(indices: list[int], total: int) -> bool:
     if not indices:
         return False
     return indices == list(range(indices[0], total))
+
+
+def _source_fingerprint(filepaths: list[Path]) -> str | None:
+    """Return a deterministic stat fingerprint, or None if any source is missing."""
+    parts: list[str] = []
+    for path in sorted(filepaths, key=str):
+        try:
+            stat = path.stat()
+        except FileNotFoundError:
+            return None
+        parts.append(f"{path}\t{stat.st_size}\t{stat.st_mtime_ns}")
+    return "\n".join(parts)
+
+
+def _cached_ok_fingerprint(cursor, session_uuid: str) -> str | None:
+    row = cursor.execute(
+        "SELECT source_fingerprint FROM ingestion_check_cache WHERE session_uuid = ?",
+        (session_uuid,),
+    ).fetchone()
+    return row[0] if row is not None else None
+
+
+def _record_ok_fingerprint(cursor, session_uuid: str, source_fingerprint: str) -> None:
+    cursor.execute(
+        "INSERT OR REPLACE INTO ingestion_check_cache (session_uuid, source_fingerprint) VALUES (?, ?)",
+        (session_uuid, source_fingerprint),
+    )
 
 
 def summarize_ingestion(
@@ -92,6 +123,16 @@ def summarize_ingestion(
         if session_row is None:
             continue
         summary["sessions_checked"] += 1
+
+        source_fingerprint = _source_fingerprint(filepaths)
+        if source_fingerprint is None:
+            summary["missing_source_sessions"] += 1
+            continue
+
+        if _cached_ok_fingerprint(cursor, session_uuid) == source_fingerprint:
+            summary["ok_sessions"] += 1
+            continue
+
         session_id = session_row[0]
         existing_msg_uuids = {
             row[0]
@@ -105,6 +146,7 @@ def summarize_ingestion(
         missing_indices = [i for i, uuid in enumerate(expected) if uuid not in existing_msg_uuids]
         if not missing_indices:
             summary["ok_sessions"] += 1
+            _record_ok_fingerprint(cursor, session_uuid, source_fingerprint)
             continue
 
         if _is_contiguous_suffix(missing_indices, len(expected)):

--- a/src/ccrecall/ingestion_status.py
+++ b/src/ccrecall/ingestion_status.py
@@ -61,18 +61,41 @@ def _source_fingerprint(filepaths: list[Path]) -> str | None:
     return "\n".join(parts)
 
 
-def _cached_ok_fingerprint(cursor, session_uuid: str) -> str | None:
+def _db_coverage_fingerprint(cursor, session_id: int) -> str:
+    """Return the stored UUID membership token for cache validation."""
+    rows = cursor.execute(
+        """
+        SELECT uuid
+        FROM messages
+        WHERE session_id = ? AND uuid IS NOT NULL
+        ORDER BY uuid
+        """,
+        (session_id,),
+    ).fetchall()
+    return "\n".join(row[0] for row in rows)
+
+
+def _cached_ok_fingerprint(cursor, session_uuid: str) -> tuple[str, str] | None:
     row = cursor.execute(
-        "SELECT source_fingerprint FROM ingestion_check_cache WHERE session_uuid = ?",
+        "SELECT source_fingerprint, db_coverage_fingerprint FROM ingestion_check_cache WHERE session_uuid = ?",
         (session_uuid,),
     ).fetchone()
-    return row[0] if row is not None else None
+    return (row[0], row[1]) if row is not None else None
 
 
-def _record_ok_fingerprint(cursor, session_uuid: str, source_fingerprint: str) -> None:
+def _record_ok_fingerprint(
+    cursor,
+    session_uuid: str,
+    source_fingerprint: str,
+    db_coverage_fingerprint: str,
+) -> None:
     cursor.execute(
-        "INSERT OR REPLACE INTO ingestion_check_cache (session_uuid, source_fingerprint) VALUES (?, ?)",
-        (session_uuid, source_fingerprint),
+        """
+        INSERT OR REPLACE INTO ingestion_check_cache
+        (session_uuid, source_fingerprint, db_coverage_fingerprint)
+        VALUES (?, ?, ?)
+        """,
+        (session_uuid, source_fingerprint, db_coverage_fingerprint),
     )
 
 
@@ -106,6 +129,7 @@ def summarize_ingestion(
         "ingestion_gap_turns": 0,
         "missing_source_sessions": 0,
     }
+    ok_cache_writes: list[tuple[str, str, str]] = []
 
     for session_uuid, paths in sources.items():
         if not paths["missing"]:
@@ -129,7 +153,9 @@ def summarize_ingestion(
             summary["missing_source_sessions"] += 1
             continue
 
-        if _cached_ok_fingerprint(cursor, session_uuid) == source_fingerprint:
+        db_coverage_fingerprint = _db_coverage_fingerprint(cursor, session_row[0])
+
+        if _cached_ok_fingerprint(cursor, session_uuid) == (source_fingerprint, db_coverage_fingerprint):
             summary["ok_sessions"] += 1
             continue
 
@@ -146,7 +172,7 @@ def summarize_ingestion(
         missing_indices = [i for i, uuid in enumerate(expected) if uuid not in existing_msg_uuids]
         if not missing_indices:
             summary["ok_sessions"] += 1
-            _record_ok_fingerprint(cursor, session_uuid, source_fingerprint)
+            ok_cache_writes.append((session_uuid, source_fingerprint, db_coverage_fingerprint))
             continue
 
         if _is_contiguous_suffix(missing_indices, len(expected)):
@@ -160,5 +186,8 @@ def summarize_ingestion(
         else:
             summary["ingestion_gap_sessions"] += 1
             summary["ingestion_gap_turns"] += len(missing_indices)
+
+    for session_uuid, source_fingerprint, db_coverage_fingerprint in ok_cache_writes:
+        _record_ok_fingerprint(cursor, session_uuid, source_fingerprint, db_coverage_fingerprint)
 
     return summary

--- a/src/ccrecall/schema.py
+++ b/src/ccrecall/schema.py
@@ -100,6 +100,13 @@ CREATE TABLE IF NOT EXISTS import_log (
   file_mtime REAL
 );
 
+-- Confirmed-OK ingestion audit cache
+CREATE TABLE IF NOT EXISTS ingestion_check_cache (
+  session_uuid TEXT PRIMARY KEY,
+  source_fingerprint TEXT NOT NULL,
+  checked_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
 -- Chunk metadata table (per-exchange embedding store)
 -- Source of truth for which chunk rowids belong to a branch, and the carrier
 -- of the Track B locator (first_message_uuid, timestamp) plus bounded display

--- a/src/ccrecall/schema.py
+++ b/src/ccrecall/schema.py
@@ -104,6 +104,7 @@ CREATE TABLE IF NOT EXISTS import_log (
 CREATE TABLE IF NOT EXISTS ingestion_check_cache (
   session_uuid TEXT PRIMARY KEY,
   source_fingerprint TEXT NOT NULL,
+  db_coverage_fingerprint TEXT NOT NULL DEFAULT '',
   checked_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/src/ccrecall/status.py
+++ b/src/ccrecall/status.py
@@ -1,4 +1,8 @@
-"""Consolidated read-only health/status reporting for the CLI."""
+"""Consolidated health/status reporting for the CLI.
+
+Default status reads are read-only; ``--check-ingestion`` also records
+confirmed-OK cache metadata for future deep-check runs.
+"""
 
 import contextlib
 import json
@@ -7,7 +11,7 @@ import sys
 from pathlib import Path
 
 from ccrecall.config import DEFAULT_DB_PATH, get_db_path, load_settings
-from ccrecall.db import branch_embedding_coverage, chunk_vec_queryable, vec_available
+from ccrecall.db import branch_embedding_coverage, chunk_vec_queryable, get_connection, vec_available
 from ccrecall.hooks.backfill_status import count_status as count_embedding_status
 from ccrecall.import_log_ops import import_log_source_index
 from ccrecall.ingestion_status import summarize_ingestion
@@ -76,9 +80,10 @@ def count_branch_invariant_violations(conn: sqlite3.Connection) -> int:
 
 
 def collect_status(*, db: Path = DEFAULT_DB_PATH, days: int | None = None, check_ingestion: bool = False) -> dict:
-    """Collect read-only status across DB, ingestion, tool content, and embeddings."""
+    """Collect status across DB, ingestion, tool content, and embeddings."""
     settings = _settings_for_db(db)
     db_path = get_db_path(settings)
+    ingestion = None
 
     with _readonly_connection(db_path, load_vec=False) as conn:
         cursor = conn.cursor()
@@ -112,11 +117,16 @@ def collect_status(*, db: Path = DEFAULT_DB_PATH, days: int | None = None, check
             }
 
         tool_pending = count_tool_content_pending(cursor, days)
-        source_index = import_log_source_index(cursor) if check_ingestion or tool_pending else None
+        source_index = import_log_source_index(cursor) if tool_pending else None
         tool_missing = count_pending_missing_jsonl(cursor, days, source_index) if tool_pending else 0
         tool_total = count_tool_content_total(cursor, days)
         embedded_watermark, embeddable_watermark = branch_embedding_coverage(conn)
-        ingestion = summarize_ingestion(conn, sources=source_index) if check_ingestion else None
+
+    if check_ingestion:
+        if not db_path.exists():
+            raise FileNotFoundError(db_path)
+        with get_connection(settings, load_vec=False) as conn:
+            ingestion = summarize_ingestion(conn, sources=import_log_source_index(conn.cursor()))
 
     embedding_backfill: dict = {
         "available": False,

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -45,6 +45,7 @@ class TestSchemaCreation:
             "messages",
             "branch_messages",
             "import_log",
+            "ingestion_check_cache",
         }
         assert expected.issubset(tables)
 
@@ -804,6 +805,103 @@ class TestSchemaVersioning:
         assert first_version == second_version == db_module.SCHEMA_VERSION
         assert first_active == second_active == 1
 
+    def test_migration_from_v4_creates_ingestion_check_cache_table(self, tmp_path):
+        """A v4 DB gains the ingestion check cache table and is stamped to v5 on open."""
+        db_path = tmp_path / "v4_to_v5.db"
+        conn = sqlite3.connect(db_path)
+        conn.executescript(
+            """
+            CREATE TABLE projects (
+              id INTEGER PRIMARY KEY,
+              path TEXT UNIQUE NOT NULL,
+              key TEXT UNIQUE NOT NULL,
+              name TEXT,
+              created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE sessions (
+              id INTEGER PRIMARY KEY,
+              uuid TEXT UNIQUE NOT NULL,
+              project_id INTEGER REFERENCES projects(id),
+              parent_session_id INTEGER REFERENCES sessions(id),
+              git_branch TEXT,
+              cwd TEXT,
+              imported_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE branches (
+              id INTEGER PRIMARY KEY,
+              session_id INTEGER NOT NULL REFERENCES sessions(id),
+              leaf_uuid TEXT NOT NULL,
+              is_active INTEGER DEFAULT 1,
+              started_at DATETIME,
+              ended_at DATETIME,
+              exchange_count INTEGER DEFAULT 0,
+              files_modified TEXT,
+              commits TEXT,
+              tool_counts TEXT,
+              aggregated_content TEXT,
+              context_summary TEXT,
+              context_summary_json TEXT,
+              summary_version INTEGER DEFAULT 0,
+              embedding_version INTEGER DEFAULT 0,
+              embedding_model TEXT,
+              summary_version_at_embed INTEGER,
+              UNIQUE(session_id)
+            );
+            CREATE TABLE messages (
+              id INTEGER PRIMARY KEY,
+              session_id INTEGER NOT NULL REFERENCES sessions(id),
+              uuid TEXT,
+              parent_uuid TEXT,
+              timestamp DATETIME,
+              role TEXT CHECK(role IN ('user', 'assistant')),
+              content TEXT NOT NULL,
+              tool_summary TEXT,
+              has_tool_use INTEGER DEFAULT 0,
+              tool_content TEXT,
+              has_thinking INTEGER DEFAULT 0,
+              is_notification INTEGER DEFAULT 0,
+              origin TEXT,
+              UNIQUE(session_id, uuid)
+            );
+            CREATE TABLE branch_messages (
+              branch_id INTEGER NOT NULL REFERENCES branches(id),
+              message_id INTEGER NOT NULL REFERENCES messages(id),
+              PRIMARY KEY (branch_id, message_id)
+            );
+            CREATE TABLE import_log (
+              id INTEGER PRIMARY KEY,
+              file_path TEXT UNIQUE NOT NULL,
+              file_hash TEXT,
+              imported_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+              messages_imported INTEGER DEFAULT 0,
+              file_size INTEGER,
+              file_mtime REAL
+            );
+            CREATE TABLE chunks (
+              id INTEGER PRIMARY KEY,
+              branch_id INTEGER NOT NULL REFERENCES branches(id),
+              exchange_index INTEGER NOT NULL,
+              content_hash TEXT NOT NULL,
+              first_message_uuid TEXT,
+              timestamp TEXT,
+              user_text TEXT,
+              assistant_text TEXT,
+              was_capped INTEGER NOT NULL DEFAULT 0,
+              embedding_version INTEGER NOT NULL DEFAULT 0,
+              embedding_model TEXT,
+              UNIQUE(branch_id, exchange_index)
+            );
+            PRAGMA user_version = 4;
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        with get_connection(settings={"db_path": str(db_path)}, load_vec=False) as migrated:
+            assert migrated.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+            columns = [row[1] for row in migrated.execute("PRAGMA table_info(ingestion_check_cache)").fetchall()]
+            assert columns == ["session_uuid", "source_fingerprint", "checked_at"]
+
     def test_migration_toctou_race_runs_migration_once(self, tmp_path):
         """Two connections racing to open the same v0 DB must not both migrate.
 
@@ -920,6 +1018,7 @@ class TestSchemaEquivalencePin:
         "branches_fts",
         "chunks",
         "import_log",
+        "ingestion_check_cache",
         "messages",
         "projects",
         "sessions",
@@ -974,6 +1073,11 @@ class TestSchemaEquivalencePin:
             (4, "messages_imported", "INTEGER", 0, "0", 0),
             (5, "file_size", "INTEGER", 0, None, 0),
             (6, "file_mtime", "REAL", 0, None, 0),
+        ],
+        "ingestion_check_cache": [
+            (0, "session_uuid", "TEXT", 0, None, 1),
+            (1, "source_fingerprint", "TEXT", 1, None, 0),
+            (2, "checked_at", "DATETIME", 0, "CURRENT_TIMESTAMP", 0),
         ],
         "messages": [
             (0, "id", "INTEGER", 0, None, 1),

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -900,7 +900,7 @@ class TestSchemaVersioning:
         with get_connection(settings={"db_path": str(db_path)}, load_vec=False) as migrated:
             assert migrated.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
             columns = [row[1] for row in migrated.execute("PRAGMA table_info(ingestion_check_cache)").fetchall()]
-            assert columns == ["session_uuid", "source_fingerprint", "checked_at"]
+            assert columns == ["session_uuid", "source_fingerprint", "db_coverage_fingerprint", "checked_at"]
 
     def test_migration_toctou_race_runs_migration_once(self, tmp_path):
         """Two connections racing to open the same v0 DB must not both migrate.
@@ -1077,7 +1077,8 @@ class TestSchemaEquivalencePin:
         "ingestion_check_cache": [
             (0, "session_uuid", "TEXT", 0, None, 1),
             (1, "source_fingerprint", "TEXT", 1, None, 0),
-            (2, "checked_at", "DATETIME", 0, "CURRENT_TIMESTAMP", 0),
+            (2, "db_coverage_fingerprint", "TEXT", 1, "''", 0),
+            (3, "checked_at", "DATETIME", 0, "CURRENT_TIMESTAMP", 0),
         ],
         "messages": [
             (0, "id", "INTEGER", 0, None, 1),

--- a/tests/test_ingestion_status.py
+++ b/tests/test_ingestion_status.py
@@ -3,10 +3,12 @@
 import os
 import time
 from pathlib import Path
+from unittest.mock import patch
 
 from conftest import make_jsonl_entry as _entry
 from conftest import write_jsonl as _write_jsonl
 
+from ccrecall import parsing
 from ccrecall.ingestion_status import summarize_ingestion
 
 
@@ -32,6 +34,13 @@ def _insert_import_log(memory_db, filepath: Path, message_count: int = 0) -> Non
         (str(filepath), message_count),
     )
     memory_db.commit()
+
+
+def _cache_row(memory_db, session_uuid: str) -> tuple[str, str, str] | None:
+    return memory_db.execute(
+        "SELECT session_uuid, source_fingerprint, checked_at FROM ingestion_check_cache WHERE session_uuid = ?",
+        (session_uuid,),
+    ).fetchone()
 
 
 def _write_four_turns(filepath: Path) -> None:
@@ -104,6 +113,73 @@ def test_complete_session_is_ok(memory_db, tmp_path):
     assert status["ok_sessions"] == 1
     assert status["pending_tail_sessions"] == 0
     assert status["ingestion_gap_sessions"] == 0
+
+
+def test_ok_session_records_cache_and_unchanged_second_run_skips_parsing(memory_db, tmp_path):
+    filepath = tmp_path / "sess-cache.jsonl"
+    _write_four_turns(filepath)
+    _seed_session(memory_db, filepath, ["u1", "a1", "u2", "a2"])
+
+    first = summarize_ingestion(memory_db)
+
+    cached = _cache_row(memory_db, "sess-cache")
+    assert first["sessions_checked"] == 1
+    assert first["ok_sessions"] == 1
+    assert cached is not None
+
+    with patch(
+        "ccrecall.ingestion_status.parse_all_with_uuids", side_effect=AssertionError("cache hit should skip parsing")
+    ):
+        second = summarize_ingestion(memory_db)
+
+    assert second["sessions_checked"] == 1
+    assert second["ok_sessions"] == 1
+    assert _cache_row(memory_db, "sess-cache") == cached
+
+
+def test_transcript_change_invalidates_cache_and_reparses(memory_db, tmp_path):
+    filepath = tmp_path / "sess-cache-change.jsonl"
+    _write_four_turns(filepath)
+    _seed_session(memory_db, filepath, ["u1", "a1", "u2", "a2"])
+
+    summarize_ingestion(memory_db)
+    first_cache = _cache_row(memory_db, "sess-cache-change")
+    assert first_cache is not None
+
+    _write_jsonl(
+        filepath,
+        [
+            _entry("u1", None, "2026-01-01T10:00:00Z", "user", "first"),
+            _entry("a1", "u1", "2026-01-01T10:00:01Z", "assistant", "answer"),
+            _entry("u2", "a1", "2026-01-01T10:00:02Z", "user", "second updated"),
+            _entry("a2", "u2", "2026-01-01T10:00:03Z", "assistant", "answer"),
+        ],
+    )
+
+    with patch("ccrecall.ingestion_status.parse_all_with_uuids", wraps=parsing.parse_all_with_uuids) as parse_all:
+        status = summarize_ingestion(memory_db)
+
+    assert parse_all.call_count == 1
+    assert status["ok_sessions"] == 1
+    assert _cache_row(memory_db, "sess-cache-change")[1] != first_cache[1]
+
+
+def test_problem_session_is_not_cached_and_is_reparsed(memory_db, tmp_path):
+    filepath = tmp_path / "sess-problem.jsonl"
+    _write_four_turns(filepath)
+    _seed_session(memory_db, filepath, ["u1", "a1"])
+
+    first = summarize_ingestion(memory_db)
+
+    assert first["pending_tail_sessions"] == 1
+    assert _cache_row(memory_db, "sess-problem") is None
+
+    with patch("ccrecall.ingestion_status.parse_all_with_uuids", wraps=parsing.parse_all_with_uuids) as parse_all:
+        second = summarize_ingestion(memory_db)
+
+    assert parse_all.call_count == 1
+    assert second["pending_tail_sessions"] == 1
+    assert _cache_row(memory_db, "sess-problem") is None
 
 
 def test_multifile_session_uses_parent_chain_not_import_log_order(memory_db, tmp_path):
@@ -191,3 +267,48 @@ def test_partial_multifile_source_loss_counts_as_missing_source(memory_db, tmp_p
     assert status["sessions_checked"] == 1
     assert status["missing_source_sessions"] == 1
     assert status["ok_sessions"] == 0
+
+
+def test_partial_multifile_source_loss_stays_missing_source_after_prior_ok_cache(memory_db, tmp_path):
+    parent = tmp_path / "sess-partial-cache.jsonl"
+    agent = tmp_path / "agent-sess-partial-cache.jsonl"
+    _write_jsonl(
+        parent,
+        [
+            _entry("u1", None, "2026-01-01T10:00:00Z", "user", "first"),
+            _entry("a1", "u1", "2026-01-01T10:00:01Z", "assistant", "answer"),
+        ],
+    )
+    _write_jsonl(
+        agent,
+        [
+            _entry("u2", "a1", "2026-01-01T10:00:02Z", "user", "second"),
+            _entry("a2", "u2", "2026-01-01T10:00:03Z", "assistant", "answer"),
+        ],
+    )
+    memory_db.execute("INSERT INTO sessions (uuid) VALUES ('sess-partial-cache')")
+    session_id = memory_db.execute("SELECT last_insert_rowid()").fetchone()[0]
+    for uuid in ["u1", "a1", "u2", "a2"]:
+        memory_db.execute(
+            "INSERT INTO messages (session_id, uuid, role, content, tool_content) VALUES (?, ?, 'user', 'x', '')",
+            (session_id, uuid),
+        )
+    _insert_import_log(memory_db, parent, 2)
+    _insert_import_log(memory_db, agent, 2)
+
+    first = summarize_ingestion(memory_db)
+
+    assert first["ok_sessions"] == 1
+    assert _cache_row(memory_db, "sess-partial-cache") is not None
+
+    agent.unlink()
+
+    with patch(
+        "ccrecall.ingestion_status.parse_all_with_uuids",
+        side_effect=AssertionError("missing source should bypass cache and parsing"),
+    ):
+        second = summarize_ingestion(memory_db)
+
+    assert second["sessions_checked"] == 1
+    assert second["missing_source_sessions"] == 1
+    assert second["ok_sessions"] == 0

--- a/tests/test_ingestion_status.py
+++ b/tests/test_ingestion_status.py
@@ -36,9 +36,13 @@ def _insert_import_log(memory_db, filepath: Path, message_count: int = 0) -> Non
     memory_db.commit()
 
 
-def _cache_row(memory_db, session_uuid: str) -> tuple[str, str, str] | None:
+def _cache_row(memory_db, session_uuid: str) -> tuple[str, str, str, str] | None:
     return memory_db.execute(
-        "SELECT session_uuid, source_fingerprint, checked_at FROM ingestion_check_cache WHERE session_uuid = ?",
+        """
+        SELECT session_uuid, source_fingerprint, db_coverage_fingerprint, checked_at
+        FROM ingestion_check_cache
+        WHERE session_uuid = ?
+        """,
         (session_uuid,),
     ).fetchone()
 
@@ -162,6 +166,84 @@ def test_transcript_change_invalidates_cache_and_reparses(memory_db, tmp_path):
     assert parse_all.call_count == 1
     assert status["ok_sessions"] == 1
     assert _cache_row(memory_db, "sess-cache-change")[1] != first_cache[1]
+
+
+def test_mtime_only_change_invalidates_cache_and_reparses(memory_db, tmp_path):
+    filepath = tmp_path / "sess-cache-mtime.jsonl"
+    _write_four_turns(filepath)
+    _seed_session(memory_db, filepath, ["u1", "a1", "u2", "a2"])
+
+    summarize_ingestion(memory_db)
+    first_cache = _cache_row(memory_db, "sess-cache-mtime")
+    assert first_cache is not None
+
+    stat = filepath.stat()
+    os.utime(filepath, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1))
+
+    with patch("ccrecall.ingestion_status.parse_all_with_uuids", wraps=parsing.parse_all_with_uuids) as parse_all:
+        status = summarize_ingestion(memory_db)
+
+    assert parse_all.call_count == 1
+    assert status["ok_sessions"] == 1
+    assert _cache_row(memory_db, "sess-cache-mtime")[1] != first_cache[1]
+
+
+def test_deleted_db_message_invalidates_ok_cache_and_reports_gap(memory_db, tmp_path):
+    filepath = tmp_path / "sess-cache-db-gap.jsonl"
+    _write_four_turns(filepath)
+    _seed_session(memory_db, filepath, ["u1", "a1", "u2", "a2"])
+
+    first = summarize_ingestion(memory_db)
+
+    assert first["ok_sessions"] == 1
+    first_cache = _cache_row(memory_db, "sess-cache-db-gap")
+    assert first_cache is not None
+
+    memory_db.execute(
+        "DELETE FROM messages WHERE session_id = (SELECT id FROM sessions WHERE uuid = ?) AND uuid = ?",
+        ("sess-cache-db-gap", "a1"),
+    )
+    memory_db.commit()
+
+    with patch("ccrecall.ingestion_status.parse_all_with_uuids", wraps=parsing.parse_all_with_uuids) as parse_all:
+        second = summarize_ingestion(memory_db)
+
+    assert parse_all.call_count == 1
+    assert second["ok_sessions"] == 0
+    assert second["ingestion_gap_sessions"] == 1
+    assert second["ingestion_gap_turns"] == 1
+    assert _cache_row(memory_db, "sess-cache-db-gap") == first_cache
+
+
+def test_changed_db_uuid_membership_invalidates_ok_cache_and_reports_gap(memory_db, tmp_path):
+    filepath = tmp_path / "sess-cache-db-membership.jsonl"
+    _write_four_turns(filepath)
+    _seed_session(memory_db, filepath, ["u1", "a1", "u2", "a2"])
+
+    first = summarize_ingestion(memory_db)
+
+    assert first["ok_sessions"] == 1
+    first_cache = _cache_row(memory_db, "sess-cache-db-membership")
+    assert first_cache is not None
+
+    session_id = memory_db.execute("SELECT id FROM sessions WHERE uuid = ?", ("sess-cache-db-membership",)).fetchone()[
+        0
+    ]
+    memory_db.execute("DELETE FROM messages WHERE session_id = ? AND uuid = ?", (session_id, "a1"))
+    memory_db.execute(
+        "INSERT INTO messages (session_id, uuid, role, content, tool_content) VALUES (?, 'bogus', 'user', 'x', '')",
+        (session_id,),
+    )
+    memory_db.commit()
+
+    with patch("ccrecall.ingestion_status.parse_all_with_uuids", wraps=parsing.parse_all_with_uuids) as parse_all:
+        second = summarize_ingestion(memory_db)
+
+    assert parse_all.call_count == 1
+    assert second["ok_sessions"] == 0
+    assert second["ingestion_gap_sessions"] == 1
+    assert second["ingestion_gap_turns"] == 1
+    assert _cache_row(memory_db, "sess-cache-db-membership") == first_cache
 
 
 def test_problem_session_is_not_cached_and_is_reparsed(memory_db, tmp_path):

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -37,6 +37,19 @@ def test_collect_status_does_not_create_missing_database(tmp_path):
     assert not db_path.exists()
 
 
+def test_collect_status_check_ingestion_does_not_create_missing_database(tmp_path):
+    db_path = tmp_path / "missing-check.db"
+
+    try:
+        collect_status(db=db_path, check_ingestion=True)
+    except FileNotFoundError:
+        pass
+    else:  # pragma: no cover - assertion branch
+        raise AssertionError("collect_status should reject missing DB paths")
+
+    assert not db_path.exists()
+
+
 def test_collect_status_reports_outdated_schema_without_migrating(tmp_path):
     db_path = tmp_path / "old.db"
     conn = sqlite3.connect(db_path)
@@ -54,6 +67,34 @@ def test_collect_status_reports_outdated_schema_without_migrating(tmp_path):
 
     assert status["schema"]["current"] is False
     assert "tool_content" in status["schema"]["reason"]
+
+
+def test_collect_status_check_ingestion_reports_outdated_schema_without_migrating(tmp_path):
+    db_path = tmp_path / "old-check.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE projects (id INTEGER PRIMARY KEY);
+        CREATE TABLE sessions (id INTEGER PRIMARY KEY, uuid TEXT);
+        CREATE TABLE messages (id INTEGER PRIMARY KEY, session_id INTEGER, uuid TEXT);
+        CREATE TABLE branches (id INTEGER PRIMARY KEY, session_id INTEGER, is_active INTEGER);
+        """
+    )
+    conn.close()
+
+    with patch("ccrecall.status.summarize_ingestion") as summarize:
+        status = collect_status(db=db_path, check_ingestion=True)
+
+    summarize.assert_not_called()
+    assert status["schema"]["current"] is False
+    assert "tool_content" in status["schema"]["reason"]
+
+    probe = sqlite3.connect(db_path)
+    try:
+        columns = [row[1] for row in probe.execute("PRAGMA table_info(messages)").fetchall()]
+        assert "tool_content" not in columns
+    finally:
+        probe.close()
 
 
 def test_collect_status_skips_missing_jsonl_scan_when_tool_content_complete(tmp_path):
@@ -79,6 +120,42 @@ def test_collect_status_runs_deep_ingestion_when_requested(tmp_path):
 
     summarize.assert_called_once()
     assert status["ingestion"] == expected
+
+
+def test_collect_status_check_ingestion_uses_writable_connection_for_cache_metadata(tmp_path):
+    db_path = tmp_path / "status-cache.db"
+    with get_connection({"db_path": str(db_path)}, load_vec=False):
+        pass
+
+    expected = {"sessions_checked": 0, "ok_sessions": 0}
+    writable_sources = {"sess-cache": {"existing": [], "missing": []}}
+
+    def fake_summarize(conn, *, stale_tail_seconds=0, sources):
+        assert sources == writable_sources
+        conn.execute(
+            "INSERT OR REPLACE INTO ingestion_check_cache (session_uuid, source_fingerprint) VALUES (?, ?)",
+            ("sess-cache", "fp-1"),
+        )
+        return expected
+
+    with (
+        patch("ccrecall.status.import_log_source_index", return_value=writable_sources) as source_index,
+        patch("ccrecall.status.summarize_ingestion", side_effect=fake_summarize) as summarize,
+    ):
+        status = collect_status(db=db_path, check_ingestion=True)
+
+    source_index.assert_called_once()
+    summarize.assert_called_once()
+    assert status["ingestion"] == expected
+
+    verify = sqlite3.connect(db_path)
+    try:
+        row = verify.execute(
+            "SELECT session_uuid, source_fingerprint FROM ingestion_check_cache WHERE session_uuid = 'sess-cache'"
+        ).fetchone()
+        assert row == ("sess-cache", "fp-1")
+    finally:
+        verify.close()
 
 
 def test_run_json_outputs_consolidated_payload(tmp_path, capsys):


### PR DESCRIPTION
### Ingestion Audit Caching
- Add a dedicated `ingestion_check_cache` table and let `ccrecall status --check-ingestion` use a writable connection so repeated deep checks can skip reparsing transcript sources that were already confirmed OK.
- Fingerprint each session's full existing source set by path and file stats, then only record cache entries after a full OK pass so missing-source, stale-tail, and ingestion-gap sessions still force a real recheck.

### CLI and Status Semantics
- Update the `status` command help text and module docs to reflect that deep ingestion checks now persist confirmed-OK cache metadata instead of acting as a purely read-only audit.

### Tests and Schema Coverage
- Extend DB, ingestion-status, and status coverage to lock in the new schema version, migration path, cache invalidation behavior, and missing/outdated DB safeguards.

### Design Notes
- See `design/specs/007-issue-103-ingestion-cache/design.md` and `design/research/2026-08-04-issue-103-ingestion-cache/research.md`.

Closes #103


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ingestion checks now cache confirmed-successful sessions, speeding up repeated status audits.
  * Cached results automatically refresh when transcripts change or sources are missing.
  * Problematic sessions continue to receive full checks.
* **Bug Fixes**
  * Improved missing-database and outdated-schema reporting when ingestion checks are enabled.
* **Documentation**
  * Updated status help text and added research and design documentation for ingestion caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->