### PR TITLE
fix: scope capability check to new transcripts, not all changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 * cache unchanged ingestion checks ([#105](https://github.com/NodeJSmith/claude-code-recall/issues/105)) ([64e8a39](https://github.com/NodeJSmith/claude-code-recall/commit/64e8a39fd9ad1742ae2170241630bf4c1bb36264))
 
+## 2026-08-09
+
+- fix false-positive capability check failures caused by unrelated, concurrent Claude Code sessions (#112)
+
 ## 2026-08-08
 
 - add opt-in Claude-powered Branch Resume Brief enrichment (#106)

--- a/src/ccrecall/llm_summarizer.py
+++ b/src/ccrecall/llm_summarizer.py
@@ -348,16 +348,15 @@ def invoke_claude(
     return InvocationResult(status=STATUS_OK, response_body=validated)
 
 
-def _snapshot_importable_transcripts(projects_dir: Path) -> dict[Path, tuple[int, int]]:
+def _snapshot_importable_transcripts(projects_dir: Path) -> set[Path]:
     if not projects_dir.exists():
-        return {}
-    found: dict[Path, tuple[int, int]] = {}
+        return set()
+    found: set[Path] = set()
     for path in discover_importable_transcript_files(projects_dir).files:
         if path.is_file() and not path.is_symlink():
             with contextlib.suppress(Exception):
                 extract_session_uuid(path)
-                path_stat = path.stat()
-                found[path.resolve()] = (path_stat.st_size, path_stat.st_mtime_ns)
+                found.add(path.resolve())
     return found
 
 
@@ -431,8 +430,13 @@ def run_capability_check(
             return CapabilityCheckResult(status=status, diagnostic=diagnostic)
 
         after = _snapshot_importable_transcripts(projects_dir)
-        if after != before:
-            diagnostic = "no-session-persistence changed importable transcripts; remove them before retrying"
+        # Only a *new* transcript path counts as a leak: a --no-session-persistence failure
+        # always writes a fresh session file (new UUID), never mutates an existing one. Ignoring
+        # in-place changes to pre-existing transcripts avoids false positives from unrelated,
+        # concurrent Claude Code sessions appending to their own transcripts during this check.
+        new_paths = after - before
+        if new_paths:
+            diagnostic = "no-session-persistence created a new importable transcript; remove it before retrying"
             write_capability_sidecar(
                 sidecar_path,
                 status=STATUS_CAPABILITY_UNVERIFIED,

--- a/tests/test_llm_summarizer.py
+++ b/tests/test_llm_summarizer.py
@@ -555,9 +555,6 @@ class TestCapabilitySidecar:
         assert created_transcript.exists()
 
     def test_capability_check_ignores_existing_importable_transcript_changing_in_place(self, tmp_path):
-        """A concurrent, unrelated Claude Code session appending to its own transcript during the
-        check must not fail it — a real --no-session-persistence leak always creates a brand-new
-        session file, never mutates an already-existing one (see design.md's "new *.jsonl" gate)."""
 
         projects_dir = tmp_path / "projects"
         project = projects_dir / "proj"

--- a/tests/test_llm_summarizer.py
+++ b/tests/test_llm_summarizer.py
@@ -554,7 +554,10 @@ class TestCapabilitySidecar:
         assert result.status == STATUS_CAPABILITY_UNVERIFIED
         assert created_transcript.exists()
 
-    def test_capability_check_fails_if_existing_importable_transcript_changes_in_place(self, tmp_path):
+    def test_capability_check_ignores_existing_importable_transcript_changing_in_place(self, tmp_path):
+        """A concurrent, unrelated Claude Code session appending to its own transcript during the
+        check must not fail it — a real --no-session-persistence leak always creates a brand-new
+        session file, never mutates an already-existing one (see design.md's "new *.jsonl" gate)."""
 
         projects_dir = tmp_path / "projects"
         project = projects_dir / "proj"
@@ -577,7 +580,7 @@ class TestCapabilitySidecar:
             run=fake_run,
         )
 
-        assert result.status == STATUS_CAPABILITY_UNVERIFIED
+        assert result.status == STATUS_OK
 
     @pytest.mark.parametrize(
         "relative_path",


### PR DESCRIPTION
### Capability check false positive

- `run_capability_check()` verifies that `claude -p --no-session-persistence` doesn't leak a transcript by diffing `~/.claude/projects/` before/after the subprocess call. It was diffing size/mtime of *every* existing importable transcript, so any change to any transcript — including an unrelated, concurrent Claude Code session appending to its own transcript during the check window — tripped a false `STATUS_CAPABILITY_UNVERIFIED`, even though nothing leaked.
- `design.md` (`design/specs/008-llm-summary-enrichment/design.md:420`) only specifies detecting a *newly created* importable transcript — a genuine leak always writes a fresh session file (new UUID), never mutates an existing one. `_snapshot_importable_transcripts` now returns a set of paths instead of a size/mtime map, and the failure condition is `new_paths = after - before`, matching what the design actually calls for.
- Verified live: ran `ccrecall backfill llm-summaries --check-capability` with this session itself as a concurrent writer to `~/.claude/projects/`. It now reports capability check passed instead of the prior false failure.
- Staged as RED (failing test proving the false positive) then GREEN (the fix), per commit convention.

### Housekeeping
- Dropped a test docstring duplicating the adjacent production comment, matching this file's zero-comment, name-only-test convention.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented capability checks from falsely failing when unrelated concurrent sessions update existing transcripts.
  - Changes to already recognized transcripts are now accepted, while newly appearing importable transcripts continue to be detected appropriately.

- **Documentation**
  - Added a changelog entry documenting the capability-check reliability improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->