### PR TITLE
fix: salvage three independent bug fixes from the abandoned recap branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,8 @@ dist/
 coverage.xml
 htmlcov/
 
+# Local code-index artifacts
+.codegraph/
+
 # OS / editor
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Every time a Claude Code session ends, the conversation is synced to `~/.ccrecal
 
 ## Install
 
+**Supported platforms:** Linux (including WSL2) and macOS. Windows is not supported.
+
 ccrecall has two parts: a **Python package** (the `ccrecall` CLI plus the hook binaries) and a **Claude Code plugin** (the `/ccr-*` skills and the hook wiring). Install both.
 
 **1. Install the package** — puts `ccrecall` and the hook commands on your PATH:

--- a/design/specs/010-session-recaps/design.md
+++ b/design/specs/010-session-recaps/design.md
@@ -1,0 +1,487 @@
+# Design: Session Recaps
+
+> **Not implemented.** This feature was built on branch `114-115` (PR #118) and abandoned
+> before merge. Nothing described below ships. The design itself is still substantially
+> correct and is the intended starting point for any second attempt — read
+> [`retrospective.md`](retrospective.md) first for what to keep and what went wrong.
+
+**Status:** abandoned (attempt 1)
+
+**Date:** 2026-08-12
+**Scope-mode:** hold
+
+## Problem
+
+The opt-in LLM feature currently produces a rigid Branch Resume Brief from transcript JSONL files. Its continuation-oriented schema, citations, file-evidence checks, capability preflight, per-Stop invocation, and overloaded branch status make a simple recognition aid brittle and operationally difficult to trust.
+
+The desired product is a concise Session Recap: enough to recognize what a past session was about and what happened. Evaluation showed that normalized imported SQLite content is sufficient for this purpose. Successful DB- and JSONL-sourced recaps were equivalent on recognition, work arc, and outcome across the private sample, while DB packets were smaller and avoid a second transcript parse/readiness boundary. Sonnet completed every evaluated DB case; Haiku did not. The design therefore uses imported SQLite as the only recap authority and Sonnet as the default.
+
+Automatic generation still needs durable lifecycle semantics. SessionEnd cannot wait for sync or Claude, a detached spawn can fail, concurrent hooks and manual backfills can race, global provider failures can cause retry storms, and process timeouts can leave descendants alive. The feature must preserve intent and converge honestly without adding a daemon.
+
+## Goals
+
+- Generate a concise, recognizable, accurate account of a session's work arc and outcome from imported SQLite data only.
+- Use Sonnet by default while retaining per-run model, budget, and timeout overrides.
+- Generate automatically after meaningful ended sessions without adding model work or extra output to hook paths.
+- Preserve finalization intent, serialize provider work per installation, fence recovered workers, and prevent retry storms.
+- Expose complete, reconcilable pending, excluded, current, deferred, blocked, attempt, and recovery state.
+- Preserve deterministic summaries, existing v1 data, opt-in behavior, existing databases, incremental embeddings, and search ranking.
+
+## Non-Goals
+
+- Reading transcript JSONL files during recap selection, packet construction, generation, retry, or status.
+- A recap browser, daemon, resident scheduler, configurable prompts, or unsupported max-token control.
+- Per-item citations, file-evidence validation, continuation instructions, or authoritative task-completion claims.
+- Converting or deleting stored v1 envelopes.
+- Changing transcript JSONL decoding/content extraction, deterministic-summary content, search ranking, FTS, chunks, vectors, or embedding versions. Branch path discovery may additionally preserve order without changing parsed message content or membership.
+- Renaming every internal `summary_enrichment` symbol or public compatibility command in this release.
+
+## User Scenarios
+
+### Claude Code user: Automatic recap generation
+- **Goal:** Find a useful recap after meaningful work ends.
+- **Context:** LLM recaps are explicitly enabled and the platform supports safe provider-process cleanup.
+
+#### End a meaningful session
+
+1. **End the session**
+   - Sees: No recap UI, delay, or additional hook output.
+   - Decides: Nothing; prior opt-in controls automatic generation.
+   - Then: SessionEnd durably upserts finalization work and best-effort starts the detached drainer.
+2. **Let ccrecall finalize**
+   - Sees: Status later reports pending, deferred, current, excluded, blocked, or overdue work.
+   - Decides: Whether an overdue or blocked item needs the displayed recovery command.
+   - Then: The drainer performs final sync, captures one canonical DB input snapshot, and serially invokes Sonnet when admitted.
+3. **Recall the session later**
+   - Sees: A bounded Session Recap above the deterministic context summary.
+   - Decides: Whether this is the remembered session and whether to inspect existing recall/tail/search detail.
+   - Then: Missing, stale, malformed, failed, or legacy recap data silently falls back to deterministic context.
+
+### Claude Code user: Backfill and recover
+- **Goal:** Generate historical recaps and recover durable pending or failed work.
+- **Context:** `ccrecall status` identifies work and exact recovery actions.
+
+#### Run historical backfill
+
+1. **Inspect status**
+   - Sees: Recap schema/platform readiness, provider cooldown, policy/defaults, population counts, overdue jobs, and latest attempt outcomes.
+   - Decides: Whether to backfill, recover overdue work, reset provider health, or retry a targeted failure.
+   - Then: Status remains read-only and never invokes Claude.
+2. **Run backfill or recovery**
+   - Sees: Session/day selectors, attempt limit, targeted failure retry, and one-run model/budget/timeout options.
+   - Decides: Which selector or recovery action to use.
+   - Then: The command reconciles expired leases, queues matching work, and uses the same globally serialized drainer as SessionEnd.
+3. **Review accounting**
+   - Sees: Separate population, examined-candidate, deferred, and started-attempt partitions that reconcile.
+   - Decides: Whether any blocked failure warrants another explicit action.
+   - Then: Re-running unchanged converged work performs no provider calls.
+
+## Functional Requirements
+
+- **FR#1** A valid current v2 recap must contain a bounded non-empty summary and may contain a bounded title and normalized outcome; malformed optional fields must not invalidate a usable summary.
+- **FR#2** Recap generation must describe the session's recognizable work arc and evidenced outcome without advice, continuation planning, exhaustive chronology, or project-wide claims.
+- **FR#3** Recap input must come only from normalized imported SQLite records; recap code must not resolve or read transcript JSONL files.
+- **FR#4** The exact canonical DB projection written to the provider packet must produce a versioned `recap_input_hash` stored on the attempt.
+- **FR#5** A successful recap may materialize only when the active branch, claim token, recap contract, and recomputed `recap_input_hash` still match the captured attempt.
+- **FR#6** Rendering must display only a valid v2 envelope whose materialized input hash matches the branch's current recap input; every other case must use deterministic context only.
+- **FR#7** Automatic generation must remain opt-in, use Sonnet by default, and begin from SessionEnd rather than ordinary Stop.
+- **FR#8** SessionEnd must durably record finalization intent before best-effort detachment, return without waiting for sync or Claude, and preserve exact hook stdout on every path.
+- **FR#9** One durable finalization job per session must coalesce repeated requests and survive spawn failure, process death, concurrent Stop sync, and undocumented hook ordering.
+- **FR#10** Job and attempt claims must use monotonic fencing tokens so an expired worker cannot publish, terminalize, heartbeat, or acknowledge cleanup after recovery reclaims its work.
+- **FR#11** Provider invocation must be globally serialized per installation across automatic finalization, recovery, and manual backfill; capacity contention must leave durable pending work.
+- **FR#12** Classified global provider failures must open a shared capped cooldown, abort the current drain, leave remaining jobs pending, and never become transcript-specific materialized failures.
+- **FR#13** A write-capable recovery command must reconcile expired leases and cleanup obligations; read-only status must expose overdue work and the exact command without claiming deadline-driven recovery.
+- **FR#14** One versioned meaningful-session policy must be shared by automatic selection, manual backfill, and status, with stable reason codes and explainable measures.
+- **FR#15** Manual recovery must replace broad `--force` with targeted failure retry and optional one-run model, budget, and timeout overrides that do not mutate configuration.
+- **FR#16** Timeout handling must terminate, escalate, wait for, and reap the POSIX provider process group before recording ordinary timeout or deleting the packet.
+- **FR#17** Cleanup uncertainty must produce an actionable `cleanup_failed` outcome, block the job, retain only owner-protected quarantined packet/process metadata, and prevent a normal success/timeout claim.
+- **FR#18** Platforms without proven process-tree cleanup must visibly disable provider invocation while hooks may still preserve durable work; status and completion output must explain the limitation.
+- **FR#19** Worker completion output must separately reconcile a durable selector snapshot, final run-candidate dispositions, and started-attempt outcomes, including limits and global aborts.
+- **FR#20** Read-only status must distinguish a current recap schema with zero work from a missing, outdated, or partial recap schema and provide writable migration guidance.
+- **FR#21** Recap schema creation, constraints, ordering backfill, and indexes must become claim-capable atomically before any worker can process jobs.
+- **FR#22** Attempt and run history must use bounded indexed queries and a maintenance retention policy that preserves live/current/retry lineage while pruning eligible old terminal detail.
+- **FR#23** A continued and re-imported session must stale its old recap without deleting it, preserve unchanged exchange embeddings, and become normally eligible for refresh.
+- **FR#24** Every packet and provider process group must have a committed token-bound attempt owner before creation or launch; recovery must prove that process group dead and cleanup complete before replacement admission.
+- **FR#25** Automatic transcript-specific retries must use a durable versioned per-input budget and backoff, then transition exhausted work to a visible blocked reason until input changes or targeted retry resets it.
+- **FR#26** Packet quarantine must have visible count and byte limits that pause new provider admission when exceeded, plus oldest-age warnings, without deleting content while process liveness is uncertain.
+
+## Edge Cases
+
+- SessionEnd races with Stop or transcript persistence. The durable job is authoritative; the detached drainer coordinates with sync, performs a final sync, and captures recap input only from the committed DB state.
+- SessionEnd records intent but spawn fails and no later hook runs. A DB job or owner-only fallback marker remains visible; `ccrecall recap recover` is the explicit write-capable maintenance path. No design claim promises timely execution without an invocation.
+- Two SessionEnd events or manual backfill target one session. `UNIQUE(session_id)` coalesces the job; global and per-job fenced claims permit one live attempt.
+- A worker's lease expires while Claude may still run. Recovery does not admit replacement work until persisted PID/process-group/start identity proves that exact group exited and packet cleanup completes. Missing or ambiguous launch identity becomes `cleanup_failed`; fencing still rejects all late DB mutations.
+- Provider authentication, rate limiting, unsupported CLI, missing binary, or infrastructure failure occurs. The current attempt records `global_abort`, shared health opens a cooldown, the run stops, and no branch receives a transcript failure stamp.
+- Cooldown has not elapsed. Work remains durable as `deferred_cooldown`; no provider process starts. Elapsed cooldown admits one serialized normal probe.
+- Imported messages change during generation. Recomputed `recap_input_hash` differs; the attempt becomes `stale_discarded` and the previous recap remains untouched.
+- Message order is ambiguous in an upgraded DB. Migration backfills explicit `branch_messages.position` deterministically; branch detection is changed to retain an ordered root-to-leaf UUID list and subsequent imports write that order. Duplicate positions fail schema validation rather than silently changing packet order.
+- A tool-only assistant turn has empty prose. Non-empty `tool_content` remains in the ordered input projection and packet.
+- Claude returns malformed JSON or an unusable core summary. The attempt is `unusable_output`; oversized/invalid optional fields are normalized or dropped.
+- Timeout group termination succeeds but packet deletion fails. The result is `cleanup_failed`, not ordinary timeout; maintenance owns quarantine cleanup.
+- A process crashes after packet reservation but before file creation, or after file creation but before launch. The committed attempt's deterministic path/nonce lets recovery distinguish absent, removable unlaunched, and uncertain launched artifacts without scanning arbitrary files.
+- The platform cannot provide the tested POSIX group semantics. Provider work is disabled and visible; deterministic context remains fully functional.
+- Status opens an old or interrupted schema read-only. It inspects schema capabilities before recap queries and reports `unavailable` or `out_of_date`, not empty counts or a SQL exception.
+- A v1 payload remains stored. It is counted as legacy, never interpreted as v2, and never prevents deterministic fallback.
+- Attempt history is large. Latest-state/status queries use bounded indexes; maintenance prunes eligible terminal history in bounded transactions without touching jobs or materialized recaps.
+- Quarantine reaches its configured count or byte budget. Provider admission pauses globally and status reports the oldest age and recovery command; hooks may continue recording intent without creating packets.
+
+## Operational Lifecycle
+
+### Persistent state
+
+Four primary SQLite lifecycle records separate execution responsibilities; run-accounting tables described below supplement them:
+
+1. `session_recap_jobs`: one row per session, containing requested generation/input hash, trigger, state, reason, claim token, lease deadline, active attempt, next eligibility, and timestamps.
+2. `session_recap_attempts`: append-only provider-attempt audit containing captured input hash and versions, effective controls, trigger, retry/evaluation identity, claim token, timestamps, terminal outcome, reason, and capped diagnostic.
+3. `session_recap_runtime`: singleton globally fenced drainer lease containing monotonic token, owner PID, lease deadline, and heartbeat.
+4. `session_recap_provider_health`: singleton cooldown containing classified reason, consecutive global failure count, capped diagnostic, last failure, and `retry_after`.
+
+Filesystem wake-up markers are optional owner-only hints containing identifiers and timing only. They are never queue or ownership state and may be removed after the DB job commits. Existing PID files may suppress redundant process creation but never cause work loss.
+
+### Job and attempt transitions
+
+```text
+job:
+  pending -> claimed -> current
+                     -> excluded
+                     -> blocked
+                     -> pending (cooldown, stale input, bounded retry, reclaimed lease)
+  claimed --expired/recovered--> pending + prior attempt abandoned
+
+attempt:
+  reserved -> cancelled_before_launch
+           -> cleanup_failed
+           -> abandoned
+           -> running -> succeeded
+                      -> stale_discarded
+                      -> timeout
+                      -> budget_exceeded
+                      -> unusable_output
+                      -> global_abort
+                      -> cleanup_failed
+                      -> abandoned
+```
+
+Job claim occurs under `BEGIN IMMEDIATE`: reclaim expired ownership only after prior process cleanup is proven, increment the job token, and assign the lease. The claimant then performs final sync, refreshes the current input hash, and evaluates current/eligibility/cooldown before any attempt exists. Provider admission creates and binds a `reserved` attempt with deterministic owner-only packet path and nonce before packet creation. The provider wrapper itself supplies a preselected process-group identity: on POSIX the child becomes group leader with PGID equal to its PID, and the parent knows that identity from `Popen` before returning control. The parent persists leader PID/PGID plus OS process start identity before any further work; a crash after spawn but before persistence leaves an ambiguous reservation, never a safely removable one, and blocks replacement until conservative group discovery/reaping or explicit cleanup. Only a reservation proven never launched may become `cancelled_before_launch`. Every later mutation includes the active token. `current`, `excluded`, and `blocked` are decisions for the job's recorded requested input hash; the import transaction that stores a different current input hash or versions atomically resets old content-dependent `current`, `excluded`, or transcript-failure blocks to `pending` and clears their terminal fields. Stable environment/policy blocks such as `platform_unsupported` remain blocked across content changes and requeue only on capability change or targeted action. SessionEnd may also request a newer generation. Retryable/deferred work remains `pending` with a reason and optional next-eligible time.
+
+Automatic retries are per `(session, recap_input_hash, recap/input/policy versions)`. Timeout receives one automatic retry after capped backoff; `unusable_output`, `budget_exceeded`, `cleanup_failed`, and global failures receive none at the transcript level. Exhaustion sets a stable blocked reason with a targeted retry command. A changed input identity resets the budget; `--retry-failures` explicitly creates a new budget lineage without erasing prior attempts.
+
+### Global drainer and cooldown
+
+SessionEnd, manual backfill, and recovery all enqueue jobs and best-effort start the same serialized drainer. The drainer obtains the singleton runtime lease and processes one provider invocation at a time. It renews both runtime and job leases around bounded work. A second process exits without consuming or dropping jobs. Lease expiry alone never authorizes a replacement launch: recovery first resolves persisted process identity and cleanup phase, reaps the exact process group when live, and blocks globally on uncertainty.
+
+Before a provider attempt starts, health admission checks `retry_after`. Global failures close only the real started attempt as `global_abort`, update capped exponential cooldown with provider retry-after taking precedence, stop the drain, and leave other jobs pending. Success resets consecutive failures. `ccrecall recap reset-health` explicitly clears health; targeted session retry does not bypass it.
+
+### Recovery and convergence
+
+There is no daemon. Lease deadlines make overdue state detectable, not self-executing. SessionStart/SessionEnd may cheaply best-effort detach recovery. Every write-capable recap command first reconciles expired runtime/job leases, abandons fenced attempts, retries safe packet cleanup, and requeues eligible work. `ccrecall recap recover` exposes this directly. Read-only status reports overdue counts and exact guidance.
+
+An unchanged workload converges when each selected session is current, excluded, blocked after user-action-required failure, pending behind a future cooldown/lease, or already running. Once cooldowns and bounded automatic retries are exhausted or repaired, unchanged normal reruns make no duplicate provider calls.
+
+### Accounting
+
+Each manual run creates a `session_recap_runs` row and immutable `session_recap_run_candidates` membership rows for every candidate matching its selectors before applying `--limit`. Each membership row stores the snapshot input hash, initial disposition, final run disposition, and optional started attempt ID:
+
+- **Snapshot population:** immutable run-candidate membership count.
+- **Final candidate partition:** ineligible, already current, already running, deferred cooldown, deferred by limit, blocked, attempted, or deferred after incomplete abort.
+- **Started-attempt partition:** succeeded, timeout, budget exceeded, unusable output, stale discarded, global abort, cleanup failed, abandoned.
+
+`--limit` caps attempts associated with that run, not discovery. The serialized drainer atomically attaches an admitted attempt to one run-candidate row and decrements that run's remaining allowance; coalesced jobs may satisfy several run snapshots, but one attempt is owned by at most one run and other matching memberships finish as already running/current. A global abort marks the owning run incomplete and finalizes all unresolved membership rows as deferred after abort. Bounded run records persist selector metadata and counts without transcript content.
+
+### Retention
+
+Retain all nonterminal attempts, the latest successful attempt for each current input, the latest terminal attempt per job, and retry ancestors needed by retained rows. Other terminal attempts and detailed run records become prune-eligible after 90 days; run detail may compact to aggregate counts. Quarantine metadata records owner attempt, path nonce, byte size, age, process identity, and cleanup phase without content. Configured count and byte ceilings pause all new provider admission; age is warning/status information because age alone cannot prove safe deletion. `ccrecall recap maintain` reports dry-run counts by default and prunes only with an explicit option, in bounded transactions. It never deletes jobs or materialized recaps and never purges quarantine until process death is proven and cleanup ownership is reconciled. There is no force-purge override while liveness is uncertain.
+
+## Acceptance Criteria
+
+- **AC#1** `uv run pytest tests/test_summary_enrichment.py` proves loose v2 normalization, bounded rendering, v1 rejection, and deterministic fallback for absent, malformed, stale, failed, or hash-mismatched recaps. (FR#1, FR#2, FR#6)
+- **AC#2** DB-input tests prove packet bytes and `recap_input_hash` derive from the same transaction snapshot; import persists the current hash after links/metadata/deterministic summary finalize; changes to ordered content, tool content, admitted metadata, or policy/version stale the hash, while transcript path changes do not. (FR#3, FR#4, FR#5)
+- **AC#3** DB-input tests prove tool-only turns are retained and inactive, notification, child/session-external, and superseded messages are excluded. (FR#3, FR#4)
+- **AC#4** Hook tests prove Stop never starts recap inference; SessionEnd uses a migration-free bounded DB upsert when recap schema is ready, otherwise writes an owner-only fallback marker; intent precedes detachment; all paths emit exactly `{}`; and neither hook migrates, imports, or waits for the provider boundary. (FR#7, FR#8, FR#9)
+- **AC#5** Lifecycle tests prove concurrent drainers create one invocation, lease reclaim increments fencing, and every late heartbeat/write/terminal/cleanup acknowledgement from the old token is rejected. (FR#9, FR#10, FR#11)
+- **AC#6** Repeated-run tests prove shared cooldown prevents calls before `retry_after`, one serialized probe is admitted afterward, success resets health, explicit reset works, and global failures leave branch materialized state untouched. (FR#12)
+- **AC#7** Recovery tests prove expired jobs/attempts and cleanup obligations reconcile idempotently; status remains read-only and reports overdue work plus exact commands. (FR#13)
+- **AC#8** A committed de-identified eligibility artifact records sampled strata, labels, selected policy/version/reason codes, and candidate-rule comparison; synthetic tests cover every rule and worker/status parity. (FR#14)
+- **AC#9** CLI tests prove broad `--force` and `--check-capability` are absent; targeted retry and one-run model/budget/timeout controls are validated and never persist settings. (FR#15)
+- **AC#10** A real POSIX child/grandchild fixture proves TERM/grace/KILL/wait cleanup leaves no descendants; injected teardown/deletion failures produce `cleanup_failed` and quarantine behavior. (FR#16, FR#17)
+- **AC#11** Platform tests prove unsupported cleanup platforms do not invoke Claude and report the limitation in human and JSON status/output without affecting deterministic context. (FR#18)
+- **AC#12** Mixed-population tests prove immutable run membership, final candidate dispositions, run-owned attempt limits, coalesced jobs, global abort deferral, stale discards, and zero-attempt reruns reconcile without double ownership. (FR#19)
+- **AC#13** Read-only status tests over current, pre-recap, and intentionally partial schemas prove capability diagnosis occurs before recap SQL and never migrates the DB. (FR#20)
+- **AC#14** Migration interruption and concurrency tests prove the DB exposes either the old schema or the complete claim-capable recap schema, never a usable partial state; fresh and upgraded final shapes match. (FR#21)
+- **AC#15** Large-history tests prove latest-state queries use declared indexes and retention preserves live/current/latest/retry lineage while bounded pruning leaves jobs and materialized recaps intact. (FR#22)
+- **AC#16** Continued-session tests prove re-import changes recap input freshness, retains the old payload, preserves unchanged vectors/chunks, and makes the session refreshable. (FR#23)
+- **AC#17** A committed aggregate evaluation artifact records the private DB/JSONL and Haiku/Sonnet method and de-identified results, selects DB-only input and Sonnet, and contains no transcript excerpts, paths, UUIDs, prompts, raw outputs, or reviewer notes. (FR#3, FR#7)
+- **AC#18** `uv run pytest` and `uvx prek run --all-files` pass with hook hot-path import and stdout invariants intact. (FR#6, FR#8, FR#18)
+- **AC#19** Launch crash-window tests prove every packet has a committed owner, replacement waits for exact process-group death, ambiguous identity blocks admission, and no two provider groups overlap. (FR#11, FR#24)
+- **AC#20** Repeated failure tests prove one automatic timeout retry per unchanged input, no automatic retries for other transcript failures, durable blocked exhaustion, and explicit/new-input reset behavior. (FR#25)
+- **AC#21** Quarantine tests prove count/byte ceilings pause provider admission, status reports count/bytes/oldest age, and maintenance never automatically deletes while liveness is uncertain. (FR#17, FR#26)
+
+## Key Constraints
+
+- Never read transcript JSONL in recap code; transcript knowledge remains at the existing parsing/import boundary.
+- Never invoke Claude, migrate recap schema, or perform recap DB orchestration synchronously on a hook path beyond the minimal durable job upsert.
+- Never emit additional hook stdout.
+- Never hold a DB transaction or connection while Claude runs.
+- Never treat PID files or filesystem markers as authoritative work ownership.
+- Never let retry selectors bypass active-session, current-input, platform, provider cooldown, or cleanup safety.
+- Never delete the last good recap before a guarded replacement succeeds.
+- Never interpret v1 structured envelopes as v2 recaps.
+- Never persist packet content, model stdout, transcript text, or uncapped diagnostics in attempt/run state or logs.
+- Do not retain capability preflight/sidecar, broad `--force`, citations, file-evidence output checks, or rigid continuation sections.
+
+## Dependencies and Assumptions
+
+- Claude Code's installed CLI remains the only provider boundary. Real invocations, not a removed heuristic smoke test, detect compatibility and provider failures.
+- SQLite is authoritative only after ccrecall import. This accepted tradeoff gives up JSONL-only user text and linkage metadata; the private evaluation found no material recognition/work-arc/outcome loss for successful DB recaps. Existing message UUID rows are append-oriented and normally immutable except null `tool_content` backfill. A controlled full reimport/repair path is the authority for parser corrections: it atomically updates recap-relevant message fields, links/order, deterministic summary, current input hash, and job invalidation before recaps resume.
+- Sonnet's accepted cost/latency tradeoff buys materially better observed completion reliability: DB+Sonnet succeeded in 6/6 sampled calls, while DB+Haiku succeeded in 4/6. The sample is directional rather than statistically conclusive, so the model remains overridable.
+- The package has no explicit Windows support contract and CI exercises Ubuntu. This release guarantees automatic provider cleanup on POSIX only; unsupported platforms retain deterministic summaries and visible queued recap state.
+- No daemon means overdue work cannot repair itself after the final failed spawn. Durable visibility plus explicit recovery is the honest guarantee accepted for this scope.
+- Local transcripts may contain sensitive content. Private evaluation bundles stay outside the repository; only aggregate methodology and metrics are committed.
+
+## Architecture
+
+### Minimal recap contract
+
+Replace `summary_enrichment.py`'s continuation schema with a v2 envelope whose model body requires only `summary`; `title` and `outcome` are optional. Unknown fields are ignored, optional defects are dropped, and bounded text is safely truncated. Only unparseable output or a missing/unusable summary fails.
+
+The worker adds version, model, generation timestamp, attempt ID, and `recap_input_hash`. Rendering validates v2, successful state, and current input hash, displays `### Session Recap`, and leaves deterministic context below it. Search hydration may map title/summary preview without ranking changes.
+
+### Canonical DB recap input
+
+Create `recap_input.py` as the only recap projection boundary. In one read transaction it loads the active branch/session/project metadata, deterministic summary, and ordered active non-notification messages. Message records include stable order, role, timestamp, origin, UUID/parent identity as available in imported schema, `content`, and `tool_content`. Tool-only turns remain useful.
+
+Add `position INTEGER` to `branch_messages`. Change branch detection to preserve an ordered root-to-leaf UUID list alongside membership; `diff_branch_messages()` updates positions for retained links and inserts new links from that order. Upgrade backfill orders existing links deterministically by normalized timestamp and message row ID. A uniqueness constraint on `(branch_id, position)` makes order corruption explicit. Existing timestamp-ordered consumers remain unchanged unless they explicitly need recap order.
+
+The projection canonicalizes decoded JSON metadata, explicit nulls, UTF-8, sorted keys, and fixed separators. The exact canonical object is both hashed and serialized to an owner-only packet before the transaction closes:
+
+```text
+recap_input_hash = sha256(canonical_json({
+  input_contract_version,
+  recap_contract_version,
+  eligibility_policy_version,
+  ordered_messages,
+  deterministic_summary,
+  admitted_session_and_branch_metadata
+}))
+```
+
+`summary_source_hash` retains its existing deterministic-summary freshness meaning; it is not recap packet identity. Add separate branch columns `recap_input_hash` (current imported projection) and `summary_enrichment_input_hash` (the projection represented by the materialized recap), plus stored current input-contract and eligibility-policy versions. Import recomputes and stores current hash/versions in the same transaction after message membership/order, metadata, and deterministic summary are finalized. Rendering compares the two stored hashes and validates the materialized recap contract, captured input-contract version, and captured policy version against code constants; a release-time version change therefore fails closed even before re-import. Packet capture recomputes current hash/versions in its snapshot transaction and persists refreshed current values. SessionStart never scans all messages. After Claude returns, rebuild the projection and perform one token/hash/version-guarded materialization. Source paths, import-log proof, source-file safety, UUID packet coverage, and transcript rereads leave the recap subsystem.
+
+### Durable finalization and serialization
+
+Replace the current clear-only SessionEnd command with a lightweight coordinator. It writes clear handoff when applicable, then uses a dedicated no-migrate SQLite connection with a short busy timeout and read-only schema precondition check to upsert/coalesce `session_recap_jobs`. If the DB/schema is absent, outdated, partial, or busy, it writes one owner-only versioned fallback journal entry per validated session UUID using a deterministic filename and atomic temp-file replace. The entry contains requested generation/end timing only; repeated events merge monotonically. Every drainer starts by replaying a bounded journal batch before selecting DB jobs: it quarantines malformed entries, upserts each DB job before deleting its marker, and fsyncs file and directory where supported. Explicit recovery uses the same replay function. SessionEnd then best-effort detaches the drainer and guarantees `{}`. Stop retains incremental sync/summaries/embeddings but removes recap spawning.
+
+The drainer owns the singleton runtime lease and serially processes jobs. It coordinates with current sync, performs final sync through factored non-hook orchestration, refreshes current input hash, evaluates policy/current/cooldown under fenced job ownership, and creates an attempt only after provider admission. It then captures the exact input packet, closes SQLite, invokes Claude, and conditionally materializes the result. Manual backfill creates durable run membership and enqueues selected jobs rather than invoking a parallel worker path.
+
+### Provider boundary and health
+
+`llm_summarizer.py` retains constrained argv, isolated owner-only cwd, `--no-session-persistence`, structured output, budget, and timeout boundaries but no longer knows source files or capability sidecars. POSIX invocation uses a new process session/group with TERM, grace, KILL, wait/reap escalation.
+
+Provider health is installation-global SQLite state. Missing CLI, unsupported CLI, authentication, rate limiting, provider unavailability, and infrastructure failures open capped exponential cooldown; a provider retry-after wins. Ordinary work after expiry supplies one serialized probe. `cleanup_failed` additionally blocks the job and quarantines the packet until maintenance proves cleanup.
+
+### Eligibility, CLI, and status
+
+Create one lightweight `recap_eligibility.py` used by queue selection and status. Absolute prerequisites are an active session branch, current deterministic summary, and non-empty eligible imported messages. Meaningfulness uses substantive user/assistant prose, non-repetitive tool activity, modified files, commits, and elapsed duration. A private local audit freezes policy v1 before implementation of automatic selection.
+
+The implementation plan must begin with a dedicated eligibility-audit task. It commits only a de-identified aggregate artifact containing strata, measures, labels, candidate-rule comparison, selected thresholds, policy version, and reason codes. The subsequent eligibility implementation task depends on that artifact and must not choose thresholds independently. Private labels, identifiers, paths, and transcript content remain outside the repository.
+
+Keep `ccrecall backfill llm-summaries` as a compatibility command while making Session Recap terminology canonical in help. Add a `recap` command group or equivalent thin commands for `recover`, `reset-health`, and `maintain`. Remove `--check-capability` and `--force`; add `--retry-failures`, `--model`, `--max-budget-usd`, and `--timeout-seconds`. Existing session/day/limit selectors remain, with limit counting started attempts.
+
+Status first introspects recap schema capability read-only. When available, it uses shared queries to report opt-in, platform, policy/contracts, Sonnet defaults, provider cooldown, jobs, overdue leases, current/stale/legacy populations, latest attempt outcomes, quarantine budget, and maintenance guidance. Unsupported platforms set durable jobs to `blocked/platform_unsupported`, exclude them from runnable/overdue counts, suppress automatic drainer detachment, and requeue only after detected capability change or targeted action. Status never imports provider or embedding-model boundaries for recap reporting.
+
+### Schema and retention
+
+One new version migration in `llm_summary_db._apply_migrations()` creates/updates all recap objects in one `BEGIN IMMEDIATE`: `branch_messages.position` and backfill, both branch input-hash columns, jobs, attempts, runtime lease, provider health, run/run-candidate accounting, checks, foreign keys, and named indexes. None of these objects may be added to `SCHEMA_CORE` or the existing pre-transaction additive migration block. `user_version` advances only after all postconditions hold. `schema.py` remains supporting baseline DDL only, and `db.py` delegates to the single `llm_summary_db` migration entry point. Workers verify the required object/column/index set before claims.
+
+Required indexes serve jobs by readiness/lease, attempts by job/latest/input/status, one partial unique live attempt, and runs by start time. Diagnostics and payload text are not indexed. Maintenance pruning is explicit, bounded, and lineage-preserving.
+
+## Implementation Preferences
+
+- Retain `llm_summary_db.py` as the sole embedding-free recap migration authority; add a separate no-migrate, bounded connection helper for SessionEnd job upsert.
+- Use SQLite `BEGIN IMMEDIATE`, monotonic integer tokens, conditional updates, and partial unique indexes rather than a new queue dependency.
+- Use plain IDs/dicts/tuples and small local frozen result types; do not introduce cross-module domain dataclasses.
+- Use direct console scripts and `detached_popen_kwargs()` for hook-spawned processes.
+- Use `whenever` timestamps, stdlib logging, owner-only atomic files, and one global CLI `--json` surface.
+- Keep Sonnet, medium effort, evaluated budget, and a 120-second provisional timeout; permit bounded one-run overrides. The successful DB+Sonnet maximum was below 90 seconds, leaving cleanup margin.
+- Apply the smallest compatible internal renaming; user-facing terminology changes immediately.
+
+## Replacement Targets
+
+- `summary_enrichment.py`: replace v1 exact continuation/citation/file-evidence schema and renderer with loose v2 recap plus input-hash freshness.
+- `llm_summarizer.py`: replace source-file packet/capability machinery with canonical DB-packet invocation and POSIX process-group cleanup.
+- `backfill_llm_summaries.py`: replace source readiness, force/capability states, direct scanning/invocation, and success-only output with queue selection, targeted retry, and reconciled accounting.
+- `sync_current.py`: remove per-Stop recap spawning and expose reusable final-sync orchestration.
+- `clear_handoff.py`/SessionEnd hook: replace clear-only behavior with clear handoff plus durable DB job upsert.
+- Mutable branch-only provider failure state: replace as authority with jobs, attempts, runtime lease, and provider health; retain branch columns only as the current materialized recap cache.
+- Existing tests for citations, source files, capability preflight, broad force, strict continuation sections, and Stop generation are removed or rewritten rather than preserved beside v2.
+
+## Migration
+
+Set recap contract version to 2 and input-contract version to 1. Existing v1 payloads and public branch columns remain physically untouched; version mismatch prevents v1 rendering. A successful v2 generation replaces only the materialized current payload/cache.
+
+Advance the DB schema in one atomic recap migration under `llm_summary_db._apply_migrations()`. Unlike current additive migrations that run and commit before the version transaction, recap claim objects cannot be exposed piecemeal. Keep every recap table, recap branch/link column, constraint, backfill, and index out of `SCHEMA_CORE` and the pre-transaction additive migration block. Fresh and upgraded DBs both execute the same versioned recap migration after baseline creation and reach the same verified shape.
+
+Backfill `branch_messages.position` deterministically without changing message membership. No recap generation occurs until schema postconditions pass. Rollback to old code leaves deterministic summaries and v1 payloads functional; old code ignores new tables/columns. Full downgrade support for v2 job/attempt state is not required.
+
+## Convention Examples
+
+### Close DB before detached/model work
+
+**Source:** `src/ccrecall/hooks/sync_current.py`
+
+```python
+with get_connection(settings, load_vec=True) as conn:
+    new_messages = sync_session(conn, session_file, project_dir)
+# Connection is committed and closed before follow-up work.
+```
+
+The DB recap packet is copied and hashed inside its snapshot transaction, then Claude runs only after close.
+
+### Conditional stale-result write
+
+**Source:** `src/ccrecall/hooks/backfill_llm_summaries.py`
+
+```python
+UPDATE branches
+SET summary_enrichment_json = ?, summary_enrichment_source_hash = ?
+WHERE id = ? AND summary_source_hash = ?
+```
+
+V2 extends this pattern with `recap_input_hash`, active claim token, and contract-version predicates.
+
+### Lightweight migration authority
+
+**Source:** `src/ccrecall/llm_summary_db.py`
+
+```python
+conn.execute("BEGIN IMMEDIATE")
+try:
+    # Versioned DDL and backfill.
+    conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+    conn.execute("COMMIT")
+except Exception:
+    conn.execute("ROLLBACK")
+    raise
+```
+
+Recap objects must all live inside this atomic version boundary.
+
+### Read-only status boundary
+
+**Source:** `src/ccrecall/status.py`
+
+```python
+conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+conn.execute("PRAGMA query_only = ON")
+```
+
+Status introspects schema capability before any recap query and never repairs state.
+
+## Alternatives Considered
+
+- **Continue using JSONL packets with a file fingerprint.** Rejected because successful DB recaps were equivalent for recognition and DB-only input removes source discovery, proof, path safety, coverage, and dual-authority races.
+- **Reuse `summary_source_hash` as recap input identity.** Rejected after code inspection: it covers deterministic-summary fields and aggregate content but not the exact ordered recap projection. A separate canonical hash is required.
+- **Use Haiku by default.** Rejected because only 4/6 DB calls completed versus 6/6 for Sonnet; quality of successful outputs was good, but completion reliability was not.
+- **Keep automatic generation on Stop with debounce.** Rejected because Stop is per-turn and repeatedly spends while the session evolves.
+- **Use only PID files and detached workers.** Rejected because skip-on-contention loses work and cannot fence recovered processes.
+- **Allow lease expiry to launch a replacement immediately.** Rejected because fencing protects SQLite state but not duplicate provider cost or sensitive transmission; exact process-group death must be proven first.
+- **Add a daemon or worker pool.** Rejected as unnecessary operational surface for asynchronous local work; one serialized drainer plus durable jobs is sufficient.
+- **Promise automatic deadline recovery.** Rejected because no process can execute a deadline without a scheduler. Durable overdue visibility and explicit maintenance are honest and testable.
+- **Support automatic invocation on every OS immediately.** Rejected because only POSIX cleanup can be proven in current CI; deterministic fallback remains available elsewhere.
+
+## Test Strategy
+
+### Required Test Types
+
+- **Unit:** recap contract, canonical projection/hash, eligibility, failure classification, cooldown math, transition guards, schema capability, CLI validation, and retention selection.
+- **Integration:** SQLite migration, snapshot/packet equivalence, final sync to queue to materialization, rendering/status, stale races, cooldown, recovery, and accounting.
+- **Lifecycle:** repeated mixed-population runs with concurrency, crashes, expired leases, global failures, limits, cleanup failure, repair, and convergence.
+- **Real process fixture:** POSIX child/grandchild timeout and escalation; provider calls remain faked elsewhere.
+- **Manual evidence:** private DB/JSONL and model evaluation, with only aggregate de-identified results committed.
+
+### Existing Tests to Adapt
+
+- `tests/test_summary_enrichment.py`: v2 normalization/input freshness/fallback.
+- `tests/test_llm_summarizer.py`: DB packet invocation and real process cleanup; remove source/capability/citation expectations.
+- `tests/test_backfill_llm_summaries.py`: queue lifecycle, cooldown, targeted retry, recovery, and accounting.
+- `tests/test_llm_summary_cli.py`: recap terminology, commands, selectors, and per-run overrides.
+- `tests/test_sync_hook.py`: remove Stop recap spawn and preserve sync behavior.
+- `tests/test_clear_handoff_contract.py`: SessionEnd durable-job coordinator and stdout.
+- `tests/test_context_injection.py` and `tests/test_search.py`: v2 rendering/preview without ranking changes.
+- `tests/test_status.py`: schema capability, cooldown/jobs/attempts/maintenance output.
+- `tests/test_db.py`: atomic migration, ordering backfill, object/index postconditions.
+
+### New Test Coverage
+
+- Canonical DB input and message-position invariants. (FR#3-FR#6)
+- Fenced job/runtime/provider state transitions. (FR#9-FR#13)
+- Packet/process ownership crash windows and non-overlap. (FR#24)
+- Per-input retry budget/exhaustion. (FR#25)
+- Quarantine capacity and safe maintenance. (FR#26)
+- Eligibility audit scenarios and shared-query parity. (FR#14)
+- POSIX cleanup and quarantine maintenance. (FR#16-FR#18)
+- Stable-denominator lifecycle accounting. (FR#19)
+- Schema interruption/read-only diagnosis. (FR#20-FR#21)
+- Large-history retention and query-budget behavior. (FR#22)
+- Continued-session invalidation with embedding preservation. (FR#23)
+
+### Tests to Remove
+
+- Capability sidecar/fingerprint/smoke-test and `--check-capability` tests.
+- JSONL source readiness, packet coverage, source path/file evidence, and citation tests for recap generation.
+- Exact v1 continuation-section and broad `--force` tests.
+- Stop-triggered automatic generation tests.
+
+## Documentation Updates
+
+- `README.md`: Session Recaps, DB-only data flow, opt-in SessionEnd behavior, Sonnet default, platform support, status/recovery/cooldown/retention, and removed capability/source concepts.
+- CLI help: selectors, targeted retry, overrides, recovery, reset-health, maintenance, accounting, and unsupported-platform messages.
+- `skills/ccr-recall/SKILL.md`: recap as orientation, not authoritative evidence.
+- `skills/ccr-resume/SKILL.md`: tail/pending questions remain authoritative for continuation.
+- `design/specs/008-llm-summary-enrichment/`: retain history and add a superseded pointer.
+- `design/specs/010-session-recaps/evaluation.md`: commit aggregate methodology/results only.
+
+## Impact
+
+### Changed Files
+
+- create `src/ccrecall/recap_input.py`: canonical DB projection, serialization, and hash.
+- create `src/ccrecall/recap_eligibility.py`: shared policy/measures/reasons/queries.
+- create `src/ccrecall/recap_state.py`: jobs, attempts, runtime lease, provider health, accounting, and maintenance transitions.
+- modify `src/ccrecall/summary_enrichment.py`: v2 contract/rendering and input-hash freshness.
+- modify `src/ccrecall/llm_summarizer.py`: DB-packet prompt/invocation, classification, and POSIX cleanup; remove source/capability code.
+- modify `src/ccrecall/hooks/backfill_llm_summaries.py`: queue-backed selectors, retries, overrides, and accounting.
+- modify `src/ccrecall/hooks/sync_current.py`: reusable final sync and no Stop recap spawn.
+- create `src/ccrecall/hooks/session_end.py`: clear handoff plus durable job upsert.
+- create `src/ccrecall/hooks/drain_session_recaps.py`: serialized final sync/eligibility/input/provider/materialization orchestration.
+- modify `src/ccrecall/parsing.py`, `branch_ops.py`, and message-link writes: preserve and persist active-path positions.
+- modify `src/ccrecall/hooks/session_selection.py`, `context_rendering.py`, and `search_hydrate.py`: v2 materialized hash/render/preview.
+- modify `src/ccrecall/status.py`: read-only recap schema/platform/provider/job/attempt status.
+- modify `src/ccrecall/cli/commands.py`: recap recovery/health/maintenance and retry controls.
+- modify `src/ccrecall/config.py`: Sonnet/default controls, opt-in false, and cooldown/lease policy.
+- modify `src/ccrecall/llm_summary_db.py`: sole atomic recap migration entry point, schema postcondition checks, and no-migrate hook connection.
+- modify `src/ccrecall/db.py`: continue delegating main connections to `llm_summary_db` migration authority.
+- do not add recap claim objects to `src/ccrecall/schema.py` baseline DDL in this migration.
+- modify `hooks/hooks.json` and `pyproject.toml`: SessionEnd/drainer direct entry points and compatibility worker.
+- modify affected tests and documentation listed above.
+
+<!-- Gap check 2026-08-12: branch_messages.position dependencies included in T02 — tests/test_parsing.py, tests/test_import_pipeline.py, tests/test_session_ops.py, tests/test_integration.py, tests/test_summarizer.py, tests/test_backfill_embeddings.py, tests/test_backfill_tool_content.py, tests/test_recent_chats.py, tests/test_sync_hook.py, tests/test_status.py, and tests/test_context_alerts.py contain direct two-column inserts, link comparisons, or ordering assumptions. README.md, CHANGELOG.md, tests/test_llm_summary_evaluation.py, and design/specs/008-llm-summary-enrichment references are owned by T10. -->
+
+### Behavioral Invariants
+
+- Hook stdout and hot-path import constraints remain unchanged.
+- Automatic recaps remain explicitly opt-in and detached.
+- Deterministic summaries remain available whenever recap data is absent, stale, malformed, legacy, unsupported, pending, or failed.
+- One active branch per session remains enforced.
+- Existing search ranking, embeddings, chunks, vectors, FTS, and session selection semantics do not change.
+- Existing v1 data remains physically preserved and never renders as v2.
+- Per-run settings never mutate configuration.
+- Transcript content remains user-local and is transmitted only through the explicitly enabled constrained Claude CLI invocation.
+
+### Blast Radius
+
+The change crosses imported branch-path ordering, hook orchestration, detached processes, persistent SQLite state, provider invocation, rendering/search hydration, CLI/status, migration, docs, and extensive tests. It removes recap dependence on JSONL/source files and does not alter JSONL decoding, extracted message content/membership, deterministic summary behavior, embedding/search algorithms, external APIs, or package dependencies. Users who never opt in continue to receive deterministic context without provider invocation.
+
+## Open Questions
+
+None.

--- a/design/specs/010-session-recaps/eligibility-audit.md
+++ b/design/specs/010-session-recaps/eligibility-audit.md
@@ -1,0 +1,108 @@
+# Eligibility Audit
+
+## Purpose
+
+This artifact freezes the de-identified policy evidence for Session Recaps.
+The local review bundle, sample-selection query output, labels, and any
+transcript-derived material remain outside the repository.
+
+## Method
+
+The reviewer drew a reproducible stratified sample from active imported session
+branches in the local SQLite database. Sampling used stable sorted branch order
+within each stratum and a fixed local review worksheet. The worksheet exposed
+only the measures below plus locally rendered conversation context. Labels were
+`meaningful`, `not meaningful`, or `uncertain`: meaningful means a recap would
+help recognize a distinct work arc; it does not imply correctness, completion,
+or user satisfaction. Uncertain labels were excluded from rule scoring.
+
+The sampled population contained 2,317 active branches. The sample contained
+48 branches. Strata overlap because each records a review dimension rather than
+a mutually exclusive population partition.
+
+## Sample strata
+
+| Stratum | Sample count |
+| --- | ---: |
+| One to two exchanges | 12 |
+| Three to eight exchanges | 18 |
+| Nine or more exchanges | 18 |
+| Prose-led activity | 16 |
+| Tool-led activity | 16 |
+| Mixed prose and tool activity | 16 |
+| File or commit evidence present | 24 |
+| No file or commit evidence | 24 |
+| Planning-like work | 16 |
+| Implementation-like work | 16 |
+| Investigation or operational work | 16 |
+
+## Measures
+
+All measures are derived from normalized imported state; none requires reading
+source transcript files.
+
+| Measure | Definition |
+| --- | --- |
+| `exchange_count` | User-led exchanges after eligible-message filtering. |
+| `substantive_prose_chars` | Trimmed user and assistant prose characters after excluding blank and harness-only turns. |
+| `nonrepetitive_tool_actions` | Tool actions after consecutive same-tool runs are collapsed; raw call volume is not used. |
+| `file_count` | Distinct imported modified-file entries. |
+| `commit_count` | Imported commit entries. |
+| `elapsed_seconds` | Non-negative difference between imported start and end timestamps. |
+
+## Labels
+
+| Label | Count |
+| --- | ---: |
+| Meaningful | 29 |
+| Not meaningful | 13 |
+| Uncertain | 6 |
+
+## Candidate-rule comparison
+
+Scores exclude the six uncertain labels. Useful-session recall is prioritized;
+precision is reported as a guardrail against clearly trivial sessions.
+
+| Rule | Eligible | Useful-session recall | Precision |
+| --- | ---: | ---: | ---: |
+| Existing nine-exchange cutoff | 18 | 17/29 | 17/18 |
+| Prose-only: two exchanges and 600 prose characters | 34 | 25/29 | 25/34 |
+| Selected evidence rule | 32 | 28/29 | 28/32 |
+
+The existing nine-exchange cutoff misses planning and focused implementation
+work, so it is not retained as a fallback or secondary threshold.
+
+## Selected policy
+
+`ELIGIBILITY_POLICY_VERSION = 1`
+
+Absolute prerequisites are an active branch, a current deterministic summary,
+and at least one eligible imported message. Given those prerequisites, a branch
+is meaningful when it has at least two exchanges and either selected prose
+threshold is met, or its work-evidence threshold is met. Tool activity alone
+never qualifies a branch.
+
+| Threshold | Value |
+| --- | ---: |
+| Minimum exchanges | 2 |
+| Selected prose threshold | 600 substantive prose characters |
+| Evidence-route prose floor | 240 substantive prose characters |
+| Evidence-route nonrepetitive tool actions | 3 |
+| Evidence-route elapsed duration | 120 seconds |
+
+The evidence route requires the prose floor, elapsed duration, and at least one
+of: three nonrepetitive tool actions, one modified-file entry, or one commit
+entry. Consecutive repeated tool calls count as one collapsed action for this
+purpose.
+
+## Reason codes
+
+| Reason code | Meaning |
+| --- | --- |
+| `missing_active_branch` | No active branch is available. |
+| `missing_current_summary` | The deterministic summary is absent or stale. |
+| `no_eligible_messages` | No eligible imported messages remain after filtering. |
+| `below_min_exchanges` | Fewer than two exchanges are available. |
+| `eligible_substantive_prose` | The selected prose threshold qualifies the branch. |
+| `eligible_work_evidence` | The corroborated evidence route qualifies the branch. |
+| `below_meaningful_threshold` | Neither meaningfulness route qualifies the branch. |

--- a/design/specs/010-session-recaps/evaluation.md
+++ b/design/specs/010-session-recaps/evaluation.md
@@ -1,0 +1,55 @@
+# Session Recap Evaluation
+
+## Scope
+
+This is aggregate evidence from a private local evaluation. The underlying
+review materials remain outside the repository. It evaluates recognition,
+work-arc, and outcome usefulness, not continuation correctness or task
+completion.
+
+## Method
+
+The evaluation compared recap input assembled from normalized imported SQLite
+records with input assembled from the corresponding local JSONL source representation.
+The same bounded recap contract was used for both input forms. Reviewers scored
+whether each successful recap made the session recognizable, captured its work
+arc, and represented its evidenced outcome. Model completion and the three
+quality dimensions were recorded as aggregate counts only.
+
+## Aggregate input results
+
+| Input authority | Completed recaps | Recognition | Work arc | Outcome | Relative packet size |
+| --- | ---: | ---: | ---: | ---: | --- |
+| Imported SQLite | 6/6 | 6/6 | 6/6 | 6/6 | Smaller |
+| JSONL source representation | 6/6 | 6/6 | 6/6 | 6/6 | Larger |
+
+The successful input forms were equivalent on the evaluated recognition,
+work-arc, and outcome dimensions. The imported SQLite projection was smaller
+and removes a second parse and readiness boundary.
+
+## Aggregate model results
+
+| Model | Completed DB-input calls | Recognition | Work arc | Outcome |
+| --- | ---: | ---: | ---: | ---: |
+| Sonnet | 6/6 | 6/6 | 6/6 | 6/6 |
+| Haiku | 4/6 | 4/4 | 4/4 | 4/4 |
+
+The sample is directional rather than a provider benchmark. Sonnet had the
+stronger observed completion reliability; completed outputs from both models
+met the reviewed quality dimensions.
+
+## Decision
+
+Session Recaps use normalized imported SQLite records as their sole canonical
+input authority. Sonnet is the default model, while per-run controls retain a
+user choice of model, budget, and timeout. A 120-second provisional timeout
+leaves cleanup margin above the longest successful DB-plus-Sonnet completion,
+which was below 90 seconds in this evaluation.
+
+The provider budget is an upstream stop threshold, not a guaranteed maximum
+charge. A provider can cross the threshold before stopping.
+
+## Privacy boundary
+
+No transcripts, recap text, prompts, raw outputs, identifiers, local paths,
+per-sample mappings, or reviewer notes are committed with this evidence.

--- a/design/specs/010-session-recaps/retrospective.md
+++ b/design/specs/010-session-recaps/retrospective.md
@@ -1,0 +1,91 @@
+# Retrospective: Session Recaps (attempt 1, abandoned)
+
+**Status:** abandoned, not merged
+**Date:** 2026-08-14
+**Artifact:** PR #118, branch `114-115` (43 commits, ~100 review rounds)
+**Companion:** `design.md` in this directory is the design this was built to. It is still substantially correct — read it first.
+
+## What happened
+
+The feature was built, reviewed to exhaustion, and stopped short of merge. Nothing shipped: `main` was at `SCHEMA_VERSION = 7` with no `session_recap` tables, so the v8/v9 recap schema never reached a released version and no user database carries it. The cost of stopping was sunk effort only.
+
+It was not stopped because the design was wrong or because the remaining bugs were individually hard. It was stopped because the **rate of defect discovery stopped converging**, and the reason turned out to be structural rather than incidental.
+
+## Why it was stopped
+
+The evidence, in the order it accumulated:
+
+- The session before the decision closed 19 defects. **Five of them were introduced by fixes made in that same session.** None of the five was caught by the test suite; all came from reviewers.
+- A final review round produced 57 unresolved threads. Triaging them against the code found four real defects. One of them meant **the drainer could not open its own database on any installation that had ever run embeddings** — that is, the default configuration. The live log carried **69 instances** of that traceback.
+- The full test suite (1,317 tests, all green) never noticed. Every test builds its database through a fixture that loads sqlite-vec, so no test ever saw the shape a real install has.
+- Fixing that round produced two further P1-class findings from reviewers, both against the recovery path. Both were pre-existing rather than regressions, but the second one was the **third instance of the same defect** found in a single afternoon.
+
+That third instance is the one that ended it. The same fact was being destroyed by three different writers, and each fix taught one more writer not to destroy it. That is not a shrinking list of bugs. It is one fault with an unknown number of surface expressions.
+
+## The thesis: what actually went wrong
+
+**One mutable column carried two independent facts, and the invariant tying them together was maintained by convention across a dozen writers.**
+
+`session_recap_attempts.cleanup_state` answered both:
+
+- *Did this attempt ever spawn a provider process?* — monotonic. Once true, true forever.
+- *What phase is packet and process cleanup in?* — mutable, overwritten repeatedly.
+
+Every writer updating the second silently destroyed the first. Recovery then read the **absence** of a spawn marker as positive proof that no process was running, deleted the packet, declared the attempt clean, and allowed the job to be requeued beside a process that may still have been alive.
+
+The three instances found were:
+
+1. `_recover_expired_claims` correctly refused to prove cleanup for an unidentified attempt, then overwrote the field recording why.
+2. `acknowledge_cleanup` flattened the same marker on the direct post-spawn failure path.
+3. `_recover_cleanup_failed_attempts` read the resulting absence as proof the process group was gone.
+
+Every other recurring bug in this subsystem has the same shape — two code paths that must agree about one fact, where nothing forces agreement:
+
+- journal replay honoured the `EXCLUDED_PROJECT` sentinel; the claimed-job path discarded it, so a project excluded after import still had its contents sent to the provider
+- `write_packet` failure stopped the drain when quarantine was the refusing condition, but not when the disk was full
+- the spawn-intent marker was written, and its return value ignored
+- `STATUS_CLEANUP_FAILED` returned success to the drain loop
+- `upsert_job` and `recap_state_changed_input` each hand-write a "resettable" predicate, and **they already disagree** about when to bump `claim_token`
+- `status.py` hardcodes a retry-reason list independent of `recap_state.CONTENT_DEPENDENT_BLOCK_REASONS`
+- `reason='platform_unsupported'` is written by three call sites under two different fencing disciplines, two of them unfenced
+
+## What to keep
+
+The requirements were the expensive part of this work, and they are correct. Attempt 2 should start from them, not re-derive them.
+
+- **The fencing model.** `claim_token` + `retry_lineage` + `active_attempt_id`, with every mutating statement carrying the fence in its `WHERE` clause so a stale writer silently no-ops. This is sound and was not the source of any defect.
+- **Cleanup proof as a correctness property.** Requiring positive proof that a provider process group is gone before starting another, and stopping the drain when that proof cannot be obtained. Right call, and the reason the defects above were dangerous rather than cosmetic.
+- **Packet and quarantine protocol.** Content-free metadata, owner-bound packet paths keyed by a nonce, quarantine rows as the record of packets awaiting cleanup.
+- **Durable intent at SessionEnd.** The journal marker plus replay, so intent survives a hook that cannot wait for sync or the provider.
+- **DB-only recap authority.** Building packets from normalized imported SQLite rather than a second transcript parse. `evaluation.md` in this directory carries the evidence for that choice; it still stands.
+- **Off by default.** `llm_summaries_enabled` defaulting to false is why abandoning this cost nothing.
+- **The clear-first/set-last watermark protocol** for embedding state, which came out of this line of work and is independently correct.
+
+## What attempt 2 must do differently
+
+**Put the facts in the schema on day one.** All of the following are cheap at the start and expensive to retrofit, which is precisely why they never got done here:
+
+1. **A separate, write-once `spawned_at` column.** Not a phase value that a later writer can overwrite. The rule becomes: *only positive proof clears an attempt; absence of evidence never does.* The owner-identity triple (`owner_pid`, `process_group_id`, `process_started_at`) already has this property — it is written once by `record_attempt_launch` and never nulled — which is why identity-present cases were never buggy. Extend that property to cover the window between the spawn and the launch record.
+2. **`CHECK` constraints on every state-like column.** `session_recap_attempts.state` had one and produced no vocabulary bugs. `cleanup_state` and `reason` did not and produced several. Same table, same session, different outcomes.
+3. **One choke-point function per invariant, not a convention.** Where two code paths must agree, they must call the same function. Where a value must be spelled the same in two places, it must be one constant. This sounds obvious and was violated at least six times.
+4. **A test that runs the real thing.** No test in the suite exercised SessionEnd through drain through provider through materialize. `record_attempt_launch` had no real-database coverage at all. A single end-to-end test against a database built the way a real install builds it would have caught the defect that ended this attempt.
+5. **Operational logging from the start.** The only reason the fatal defect was found is that a detached process happened to write tracebacks to a log file. See issue #123.
+
+## Traps
+
+Things that looked fine and were not:
+
+- **Test fixtures that never resemble a real install.** The sqlite-vec fixture masked a total feature failure across 1,317 passing tests.
+- **Tests that pin a value instead of a property.** At least one assertion in this branch passed *while the code was wrong*, because it pinned the exact string the buggy implementation produced. Converting it to a property assertion turned it into a real regression test. Grep for equality assertions on state strings and ask whether the property or the literal is what matters.
+- **Reviewer volume as a substitute for structure.** Roughly 100 review rounds found real bugs, repeatedly, and never made the code safe. Review caught instances; only structure kills classes.
+- **A long-lived branch.** 43 commits and 90 review threads created real pressure to merge that had nothing to do with whether the code was ready. `gh-pr-threads` itself broke on this PR under the volume (Claudefiles #510).
+
+## Where the material is
+
+- `design.md` — the intended design. Still the starting point.
+- `evaluation.md` — the model and data-source evaluation behind the DB-only decision.
+- `eligibility-audit.md` — the meaningful-session eligibility work.
+- PR #118 and branch `114-115` — the full implementation and its review history, preserved unmerged.
+- Issues #120, #124, #125, #126 — catalogued follow-ups from the final review round, most of which describe traps rather than tasks now.
+- Issue #121 — migration tests never exercise vec0 objects. This is the gap that hid the fatal defect.
+- Issue #123 — the subsystem had effectively no operational logging.

--- a/src/ccrecall/db.py
+++ b/src/ccrecall/db.py
@@ -249,7 +249,7 @@ def _apply_migrations(conn: sqlite3.Connection) -> None:
     """Apply the shared migrations, preserving db.py's vec-aware v1 compatibility."""
     llm_summary_db._apply_migrations(
         conn,
-        pre_v1_prepare=vec_available,
+        prepare=vec_available,
         migrate_to_v1=_migrate_to_v1,
         migrate_to_v2=_migrate_to_v2,
     )

--- a/src/ccrecall/hooks/clear_handoff.py
+++ b/src/ccrecall/hooks/clear_handoff.py
@@ -6,7 +6,13 @@ import sys
 from pydantic import ValidationError
 from whenever import Instant
 
-from ccrecall.config import CLEAR_HANDOFF_FILENAME, get_db_path, load_settings, log_hook_exception
+from ccrecall.config import (
+    CLEAR_HANDOFF_FILENAME,
+    atomic_write_json,
+    get_db_path,
+    load_settings,
+    log_hook_exception,
+)
 from ccrecall.models import HookInput
 
 
@@ -29,15 +35,19 @@ def main():
         settings = load_settings()
         db_path = get_db_path(settings)
         handoff_path = db_path.parent / CLEAR_HANDOFF_FILENAME
-        handoff_path.write_text(
-            json.dumps(
-                {
-                    "session_id": session_id,
-                    "cwd": cwd,
-                    "timestamp": Instant.now().format_iso(),
-                }
-            ),
-            encoding="utf-8",
+        # write_text truncates before it writes, so a SessionStart reading
+        # concurrently can see half a document, and two sessions clearing at once
+        # can interleave. atomic_write_json stages through a per-writer temp file
+        # in the same directory and renames, and creates the runtime dir — which
+        # matters on a first run, where the missing directory would otherwise
+        # raise into the broad except below and lose the handoff silently.
+        atomic_write_json(
+            handoff_path,
+            {
+                "session_id": session_id,
+                "cwd": cwd,
+                "timestamp": Instant.now().format_iso(),
+            },
         )
     except Exception:
         log_hook_exception("clear-handoff")

--- a/src/ccrecall/llm_summary_db.py
+++ b/src/ccrecall/llm_summary_db.py
@@ -258,7 +258,7 @@ def _migrate_to_v7(conn: sqlite3.Connection) -> None:
 def _apply_migrations(
     conn: sqlite3.Connection,
     *,
-    pre_v1_prepare: Callable[[sqlite3.Connection], object] | None = None,
+    prepare: Callable[[sqlite3.Connection], object] | None = None,
     migrate_to_v1: Callable[[sqlite3.Connection], None] = _migrate_to_v1,
     migrate_to_v2: Callable[[sqlite3.Connection], None] = _migrate_to_v2,
 ) -> None:
@@ -280,9 +280,17 @@ def _apply_migrations(
         try:
             current = conn.execute("PRAGMA user_version").fetchone()[0]
             if current < SCHEMA_VERSION:
+                # Before any migration, not just v1. Every one of these reshapes
+                # a table, and a reshape reparses the schema — which fails with
+                # "no such module: vec0" on a database carrying vec0 objects
+                # unless the extension is loaded on this connection. A user who
+                # has run embeddings has those objects, so gating this on
+                # `current < 1` means it never fires again once they are past v1,
+                # and the next reshaping migration makes their database
+                # unopenable rather than merely unmigrated.
+                if prepare is not None:
+                    prepare(conn)
                 if current < 1:
-                    if pre_v1_prepare is not None:
-                        pre_v1_prepare(conn)
                     migrate_to_v1(conn)
                 if current < 2:
                     migrate_to_v2(conn)

--- a/src/ccrecall/parsing.py
+++ b/src/ccrecall/parsing.py
@@ -224,7 +224,10 @@ def find_all_branches(all_entries: list[dict]) -> list[dict]:
         return []
     active_uuids: set[str] = set()
     current: str | None = latest["uuid"]
-    while current:
+    # Transcript JSONL is untrusted: a parentUuid cycle (a -> b -> a) from a
+    # partial write, a corrupted sync, or a hand-edited file would walk forever.
+    # The set being built is the visited set, so the guard costs nothing.
+    while current and current not in active_uuids:
         active_uuids.add(current)
         current = uuid_to_parent.get(current)
 

--- a/tests/test_clear_handoff_contract.py
+++ b/tests/test_clear_handoff_contract.py
@@ -106,6 +106,52 @@ class TestClearHandoffWriter:
         assert not hp.exists()
 
 
+class TestClearHandoffAtomicity:
+    """The handoff is written atomically, and creates its directory on a first run."""
+
+    def test_writes_when_the_runtime_directory_does_not_exist_yet(self, tmp_path):
+        """A fresh machine has no ~/.ccrecall yet; the write must create it.
+
+        Without the mkdir this raises into main()'s broad except, which logs and
+        prints an empty object, so the handoff vanishes with no visible failure.
+        """
+        fresh = tmp_path / "not-created-yet"
+        handoff_path, stdout = _run_handoff_main(
+            fresh, {"end_reason": "clear", "session_id": "sid-fresh", "cwd": "/my/project"}
+        )
+
+        assert handoff_path.exists(), "handoff was lost because its directory did not exist"
+        assert json.loads(handoff_path.read_text())["session_id"] == "sid-fresh"
+        assert stdout.strip() == "{}"
+
+    def test_does_not_publish_through_a_shared_temporary_path(self, tmp_path):
+        """Staging must be per-writer, so concurrent clears cannot clobber each other.
+
+        A guard rather than a regression test: the previous implementation wrote
+        the target directly and used no temp file, so this would have passed
+        against it too. It exists because the obvious way to add atomicity is a
+        fixed `.tmp` name beside the target, and two sessions clearing at once
+        then truncate each other's staged bytes — a real bug that was written
+        and shipped on the abandoned recap branch before being caught.
+        """
+        decoy = tmp_path / ".clear-handoff.json.tmp"
+        decoy.write_text("another writer's in-flight payload", encoding="utf-8")
+
+        handoff_path, _ = _run_handoff_main(
+            tmp_path, {"end_reason": "clear", "session_id": "sid-concurrent", "cwd": "/my/project"}
+        )
+
+        assert decoy.read_text(encoding="utf-8") == "another writer's in-flight payload"
+        assert json.loads(handoff_path.read_text())["session_id"] == "sid-concurrent"
+
+    def test_leaves_no_temporary_file_behind(self, tmp_path):
+        handoff_path, _ = _run_handoff_main(
+            tmp_path, {"end_reason": "clear", "session_id": "sid-clean", "cwd": "/my/project"}
+        )
+
+        assert [p.name for p in handoff_path.parent.iterdir()] == ["clear-handoff.json"]
+
+
 class TestClearHandoffStdout:
     """Hook must always print valid JSON to stdout for the harness."""
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -745,6 +745,44 @@ class TestSchemaVersioning:
             assert "summary_enrichment_json" in columns
             assert "summary_source_hash" in columns
 
+    @VEC_SKIP
+    def test_migration_past_v1_still_loads_vec_before_reshaping_a_table(self, tmp_path):
+        """A database that has embeddings and is already past v1 must still migrate.
+
+        Every migration after v1 rebuilds a table, and a rebuild reparses the
+        whole schema — which needs the vec0 module registered on the connection
+        for any database carrying vec0 objects. Loading the extension only when
+        `current < 1` means it never runs again once a user is past v1, so the
+        next reshaping migration makes their database unopenable. Every current
+        user is past v1, so this is the shape that matters.
+        """
+        db_path = tmp_path / "v1_with_embeddings.db"
+        _seed_v1_db_with_orphan_messages(db_path)
+
+        seed = sqlite3.connect(db_path)
+        seed.enable_load_extension(True)
+        sqlite_vec.load(seed)
+        seed.enable_load_extension(False)
+        # The vtab alone is not enough to force the failure: it is the trigger
+        # body referencing chunk_vec that SQLite must reparse, and cannot without
+        # the module. This is the exact pair _ensure_vec_schema leaves behind.
+        seed.execute(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS chunk_vec"
+            f" USING vec0(chunk_id INTEGER PRIMARY KEY, embedding float[{EMBEDDING_DIM}])"
+        )
+        seed.execute(
+            f"CREATE TRIGGER IF NOT EXISTS {db_module.TRIGGER_CHUNKS_VEC_AD}"
+            " AFTER DELETE ON chunks"
+            " BEGIN DELETE FROM chunk_vec WHERE chunk_id = OLD.id; END"
+        )
+        seed.commit()
+        seed.close()
+
+        with get_connection(settings={"db_path": str(db_path)}) as conn:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+            surviving = conn.execute("SELECT COUNT(*) FROM sqlite_master WHERE name = 'chunk_vec'").fetchone()[0]
+            assert surviving == 1, "the migration dropped the embedding table it was supposed to preserve"
+
     def test_migration_from_v1_drops_fork_point_uuid_and_purges_orphans(self, tmp_path):
         """A v1 DB with fork_point_uuid and an orphan message is migrated to v2 on first connection."""
         db_path = tmp_path / "v1_to_v2.db"

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,6 +1,7 @@
 """Tests for ccrecall.parsing — branch detection, JSONL parsing, metadata."""
 
 import sqlite3
+import threading
 from pathlib import Path
 
 from ccrecall.parsing import (
@@ -59,6 +60,27 @@ class TestFindAllBranchesBasics:
     def test_entries_without_uuids(self):
         entries = [{"type": "user", "timestamp": "2025-01-01T00:00:00Z"}]
         assert find_all_branches(entries) == []
+
+    def test_parent_uuid_cycle_terminates(self):
+        """A cycle in untrusted transcript JSONL must not hang the walk.
+
+        Without a visited guard this loops forever rather than failing, so the
+        test runs it on a daemon thread and asserts termination — a regression
+        fails here instead of wedging the whole suite.
+        """
+        entries = [
+            {"uuid": "a", "parentUuid": "b", "type": "user", "timestamp": "2025-01-01T00:00:00Z"},
+            {"uuid": "b", "parentUuid": "a", "type": "assistant", "timestamp": "2025-01-01T00:00:01Z"},
+        ]
+        finished: list[list[dict]] = []
+        worker = threading.Thread(target=lambda: finished.append(find_all_branches(entries)), daemon=True)
+
+        worker.start()
+        worker.join(timeout=10)
+
+        assert not worker.is_alive(), "find_all_branches did not terminate on a parentUuid cycle"
+        assert len(finished[0]) == 1
+        assert finished[0][0]["uuids"] == {"a", "b"}
 
     def test_single_entry(self):
         entries = [{"uuid": "abc", "type": "user", "timestamp": "2025-01-01T00:00:00Z"}]


### PR DESCRIPTION
The Session Recaps feature (#118, branch `114-115`) has been abandoned. This extracts the parts of that branch that were never recap-specific and apply to `main` on their own, so 43 commits of work don't take three real bug fixes down with them.

Everything here was verified against `main` rather than assumed from commit subjects. Two candidates that looked salvageable turned out to be branch-introduced regressions and were dropped.

## Fixes

### The next schema migration would have broken every user who has run embeddings (#129)

`_apply_migrations` loaded the sqlite-vec extension only when `current < 1`:

```python
if current < 1:
    if pre_v1_prepare is not None:
        pre_v1_prepare(conn)     # only ever here
    migrate_to_v1(conn)
if current < 2:
    migrate_to_v2(conn)          # rebuilds `branches`, no extension loaded
```

`_migrate_to_v2` is a full rebuild (`CREATE TABLE branches_new` / `DROP TABLE` / `RENAME`), and a rebuild makes SQLite reparse the whole schema — including the `chunks_vec_ad` trigger that references the `vec0` virtual table. Without the module registered, that reparse fails and the database cannot be opened at all.

Every current user sits at `user_version = 7`, so `current < 1` is permanently false and the loader will never fire for them again. **The next migration this project adds that reshapes a table would have bricked every install that has ever produced embeddings.**

This is not speculative. It is exactly what happened on the abandoned branch: `_migrate_to_v8` reshaped a table, the loader never ran, and the detached worker died with `error in trigger chunks_vec_ad: no such module: vec0` on every run — 69 tracebacks in a live log, while 1,317 tests stayed green.

The loader now runs before any migration. The regression test seeds a v1 database carrying `chunk_vec` and its trigger and migrates it forward; it fails with the exact production error string without the fix.

### `find_all_branches` could loop forever (#130)

The `parentUuid` walk had no visited guard. Transcript JSONL is untrusted input, and a cycle (`a -> b -> a`) from a partial write or a corrupted sync makes the loop non-terminating. The set being built doubles as the visited set, so the guard is one condition. The test runs the walk on a daemon thread and asserts termination, so a regression fails rather than wedging the suite.

### The clear handoff was written non-atomically, and lost on a first run

`clear_handoff.py` used a raw `write_text`, which truncates before writing — so a SessionStart reading concurrently could see half a document — and it never created the runtime directory. On a fresh machine the missing directory raised into `main()`'s broad `except`, which logs and prints `{}`, so the handoff vanished with no visible failure.

It now uses `config.atomic_write_json`, which is already the documented single implementation of this pattern for runtime-dir writers (config.json, the embedding-status sidecar, the snooze ledger). Net reduction in code.

## Docs

- **`design/specs/010-session-recaps/`** — the design, the model/data-source evaluation behind it, the eligibility audit, and a **retrospective** recording why attempt 1 was abandoned, what to keep, and what to avoid. `design.md` carries a banner making clear nothing in it shipped. This lands on `main` so it survives the branch, alongside the existing specs 001-008.
- **README** states the supported platforms (Linux including WSL2, and macOS; Windows unsupported). `main` previously made no platform claim at all, which is why Windows questions kept arriving in review. See #127.
- **`.gitignore`** ignores `.codegraph/`, a local code-index build artifact.

## Not salvaged

Deliberately dropped after checking each against `main`:

- `open_no_migrate_connection`'s URI quoting — that function does not exist on `main`.
- The guarded `fcntl` import — `hooks/durability.py` is branch-only, and #127 removes Windows support anyway.
- `message_ops` duplicated derivation and the `project_ops` double probe — both looked like general findings but are **branch-introduced**, not present on `main`.
- `branch_ops`'s deterministic `position` ordering — reads as generally useful but is wired to recap-only functions with no fallback.
- The CLAUDE.md platform hunk — entirely recap internals; merging it would put dangling architecture claims into main's CLAUDE.md.

Closes #129, closes #130.
