### PR TITLE
fix: exclude hyphenated project names on lossy fallback path

### DIFF
--- a/src/ccrecall/hooks/import_conversations.py
+++ b/src/ccrecall/hooks/import_conversations.py
@@ -220,7 +220,7 @@ def import_project(
     project_key = normalize_project_key(project_dir.name)
 
     # Upsert project using the JSONL-probe strategy for accurate path derivation
-    project_id = upsert_project(cursor, project_key, project_dir=project_dir)
+    project_id, used_lossy_fallback = upsert_project(cursor, project_key, project_dir=project_dir)
 
     # Check exclusion after we know the real project name
     cursor.execute("SELECT name FROM projects WHERE id = ?", (project_id,))
@@ -228,7 +228,8 @@ def import_project(
     project_name = project_row[0] if project_row else extract_project_name(str(project_dir))
 
     if exclude_projects and (
-        project_name in exclude_projects or key_could_match_excluded(project_key, exclude_projects)
+        project_name in exclude_projects
+        or (used_lossy_fallback and key_could_match_excluded(project_key, exclude_projects))
     ):
         return 0, 0, 0
 

--- a/src/ccrecall/hooks/import_conversations.py
+++ b/src/ccrecall/hooks/import_conversations.py
@@ -29,7 +29,7 @@ from ccrecall.formatting import extract_project_name, normalize_project_key
 from ccrecall.import_log_ops import has_pending_tool_content
 from ccrecall.models import LOGGER_NAME
 from ccrecall.parsing import extract_session_uuid, sort_session_files
-from ccrecall.project_ops import upsert_project
+from ccrecall.project_ops import key_could_match_excluded, upsert_project
 from ccrecall.session_ops import sync_session
 from ccrecall.transcript_sources import discover_project_transcript_files, is_safe_project_dir
 
@@ -227,7 +227,9 @@ def import_project(
     project_row = cursor.fetchone()
     project_name = project_row[0] if project_row else extract_project_name(str(project_dir))
 
-    if exclude_projects and project_name in exclude_projects:
+    if exclude_projects and (
+        project_name in exclude_projects or key_could_match_excluded(project_key, exclude_projects)
+    ):
         return 0, 0, 0
 
     sessions_imported = 0

--- a/src/ccrecall/hooks/sync_current.py
+++ b/src/ccrecall/hooks/sync_current.py
@@ -155,10 +155,10 @@ def run(input_file: Path | None = None) -> None:
 
         # Honor exclude_projects for the live session too — import applies it on the
         # batch path, and without this an excluded project's current session would
-        # still sync on Stop. Match by the current cwd's project name. This uses the
-        # same formula as the import path (extract_project_name(normalize_cwd(...))),
-        # just on the live cwd instead of each session's recorded cwd — identical in
-        # the normal case (they're the same cwd). Fail open when cwd is absent: a
+        # still sync on Stop. Match by the current cwd's project name. The import
+        # path also has a key-suffix fallback (key_could_match_excluded) for the
+        # lossy case where cwd metadata is missing; this path doesn't need it
+        # because the live hook always has cwd. Fail open when cwd is absent: a
         # Stop hook shouldn't block, and cwd is effectively always present.
         exclude_projects = settings["exclude_projects"]
         if exclude_projects and hook_input.cwd:

--- a/src/ccrecall/project_ops.py
+++ b/src/ccrecall/project_ops.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from ccrecall.formatting import (
     extract_project_name,
+    get_project_key,
     normalize_cwd,
     normalize_project_key,
     parse_project_key,
@@ -28,8 +29,8 @@ def upsert_project(
     project_key: str,
     cwd: str | None = None,
     project_dir: Path | None = None,
-) -> int:
-    """Upsert a project row and return its ``projects.id``.
+) -> tuple[int, bool]:
+    """Upsert a project row and return ``(projects.id, used_lossy_fallback)``.
 
     ``project_key`` is the encoded project directory name (e.g. ``-home-user-repo``);
     worktree suffixes are stripped automatically. The project path is derived by one
@@ -37,6 +38,10 @@ def upsert_project(
     after normalization; otherwise a provided ``project_dir`` (import path) is probed
     for cwd metadata in its first JSONL; if neither yields a path, fall back to lossy
     hyphen reconstruction from the key.
+
+    The second return value indicates whether the lossy fallback was used (True) or
+    an accurate path was available from cwd/probe (False). Callers need this to decide
+    whether conservative key-suffix exclusion matching is appropriate.
     """
     normalized_key = normalize_project_key(project_key)
 
@@ -46,8 +51,8 @@ def upsert_project(
     elif project_dir is not None:
         raw_path = _probe_project_dir(project_dir)
 
+    used_lossy_fallback = not raw_path
     if not raw_path:
-        # Final fallback: lossy hyphen reconstruction from key
         raw_path = parse_project_key(normalized_key)
 
     project_path = normalize_cwd(raw_path)
@@ -58,7 +63,6 @@ def upsert_project(
 
     if existing:
         project_id = existing[0]
-        # Update path/name if we now have better data
         if project_path != existing[1]:
             cursor.execute(
                 "UPDATE projects SET path = ?, name = ? WHERE id = ?",
@@ -76,7 +80,7 @@ def upsert_project(
         cursor.execute("SELECT id FROM projects WHERE key = ?", (normalized_key,))
         project_id = cursor.fetchone()[0]
 
-    return project_id
+    return project_id, used_lossy_fallback
 
 
 def key_could_match_excluded(key: str, exclude_projects: list[str]) -> bool:
@@ -92,7 +96,7 @@ def key_could_match_excluded(key: str, exclude_projects: list[str]) -> bool:
     ``-<encoded_name>`` for each excluded name.
     """
     for name in exclude_projects:
-        encoded = name.replace("/", "-").replace(":", "-").replace(".", "-")
+        encoded = get_project_key(name)
         if key == encoded or key.endswith("-" + encoded):
             return True
     return False

--- a/src/ccrecall/project_ops.py
+++ b/src/ccrecall/project_ops.py
@@ -79,13 +79,22 @@ def upsert_project(
     return project_id
 
 
-def key_could_match_excluded(key: str, exclude_projects: list[str]) -> bool:  # noqa: ARG001
+def key_could_match_excluded(key: str, exclude_projects: list[str]) -> bool:
     """Check whether a normalized project key could encode any excluded project name.
 
     On the lossy fallback path (no cwd metadata), hyphens in directory names are
     indistinguishable from path separators. This checks conservatively: if the key's
     suffix could represent any excluded name, return True.
+
+    The encoding (get_project_key) replaces ``/``, ``:``, ``.`` with ``-``. So a
+    project named ``secret-client`` at ``/home/u/src/secret-client`` produces key
+    ``-home-u-src-secret-client``. We check whether the key ends with
+    ``-<encoded_name>`` for each excluded name.
     """
+    for name in exclude_projects:
+        encoded = name.replace("/", "-").replace(":", "-").replace(".", "-")
+        if key == encoded or key.endswith("-" + encoded):
+            return True
     return False
 
 

--- a/src/ccrecall/project_ops.py
+++ b/src/ccrecall/project_ops.py
@@ -79,6 +79,16 @@ def upsert_project(
     return project_id
 
 
+def key_could_match_excluded(key: str, exclude_projects: list[str]) -> bool:  # noqa: ARG001
+    """Check whether a normalized project key could encode any excluded project name.
+
+    On the lossy fallback path (no cwd metadata), hyphens in directory names are
+    indistinguishable from path separators. This checks conservatively: if the key's
+    suffix could represent any excluded name, return True.
+    """
+    return False
+
+
 def _probe_project_dir(project_dir: Path) -> str | None:
     """Probe the first JSONL file in project_dir for cwd metadata.
 

--- a/src/ccrecall/session_ops.py
+++ b/src/ccrecall/session_ops.py
@@ -105,7 +105,7 @@ def sync_session(
         project_id = _project_id
     else:
         project_key = normalize_project_key(project_dir.name)
-        project_id = upsert_project(cursor, project_key, cwd=meta.get("cwd"))
+        project_id, _ = upsert_project(cursor, project_key, cwd=meta.get("cwd"))
 
     session_id = upsert_session(cursor, session_uuid, project_id, meta)
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1210,6 +1210,77 @@ class TestSchemaVersioning:
             assert db_module.chunk_vec_queryable(conn), "chunk_vec must be re-created by the self-heal, not migration"
 
 
+class TestMigrationVersionMatrix:
+    """Version matrix: every starting version migrates to current SCHEMA_VERSION.
+
+    Regression guard for #121. Parametrized across every user_version from 0 to
+    SCHEMA_VERSION-1 to ensure the migration ladder has no gaps. The vec0 variant
+    covers the case where a DB carries vec0 objects from prior embedding runs —
+    a table rebuild reparses the schema and crashes with "no such module: vec0"
+    if the extension isn't loaded.
+    """
+
+    @staticmethod
+    def _build_db_at_version(db_path, target_version: int) -> None:
+        """Build a DB at current schema, then stamp user_version down to target.
+
+        For v0 and v1, uses the purpose-built seed functions that reproduce the
+        exact pre-migration table shapes (messages_fts, fork_point_uuid). For
+        v2+, a fresh get_connection produces a current-schema DB; stamping it
+        down simulates an install frozen at that version.
+        """
+        if target_version == 0:
+            _seed_v0_db_with_dead_branches(db_path)
+            return
+        if target_version == 1:
+            _seed_v1_db_with_orphan_messages(db_path)
+            return
+
+        with get_connection(settings={"db_path": str(db_path)}) as conn:
+            conn.execute(f"PRAGMA user_version = {target_version}")
+
+    @staticmethod
+    def _add_vec0_objects(db_path) -> None:
+        """Add a real vec0 virtual table and cascade trigger to an existing DB."""
+        conn = sqlite3.connect(db_path)
+        conn.enable_load_extension(True)
+        sqlite_vec.load(conn)
+        conn.enable_load_extension(False)
+        conn.execute(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS chunk_vec"
+            f" USING vec0(chunk_id INTEGER PRIMARY KEY, embedding float[{EMBEDDING_DIM}])"
+        )
+        conn.execute(
+            f"CREATE TRIGGER IF NOT EXISTS {db_module.TRIGGER_CHUNKS_VEC_AD}"
+            " AFTER DELETE ON chunks"
+            " BEGIN DELETE FROM chunk_vec WHERE chunk_id = OLD.id; END"
+        )
+        conn.commit()
+        conn.close()
+
+    @pytest.mark.parametrize("start_version", range(SCHEMA_VERSION))
+    def test_migration_from_any_version_reaches_current(self, tmp_path, start_version):
+        """Every starting version migrates to SCHEMA_VERSION without error."""
+        db_path = tmp_path / f"v{start_version}.db"
+        self._build_db_at_version(db_path, start_version)
+
+        with get_connection(settings={"db_path": str(db_path)}) as conn:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+
+    @VEC_SKIP
+    @pytest.mark.parametrize("start_version", range(SCHEMA_VERSION))
+    def test_migration_with_vec0_objects_from_any_version(self, tmp_path, start_version):
+        """A DB carrying vec0 objects migrates from any version without crashing."""
+        db_path = tmp_path / f"v{start_version}_vec.db"
+        self._build_db_at_version(db_path, start_version)
+        self._add_vec0_objects(db_path)
+
+        with get_connection(settings={"db_path": str(db_path)}) as conn:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+            surviving = conn.execute("SELECT COUNT(*) FROM sqlite_master WHERE name = 'chunk_vec'").fetchone()[0]
+            assert surviving == 1, "chunk_vec must survive the migration"
+
+
 class TestSchemaEquivalencePin:
     """Characterization pin — guards the migrations squash to v6 baseline.
 

--- a/tests/test_project_ops.py
+++ b/tests/test_project_ops.py
@@ -4,7 +4,7 @@ import shutil
 import tempfile
 from pathlib import Path
 
-from ccrecall.project_ops import upsert_project
+from ccrecall.project_ops import key_could_match_excluded, upsert_project
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
 
@@ -153,6 +153,22 @@ class TestUpsertProjectProbesJsonl:
         # Falls back to parse_project_key (lossy) when no JSONL available
         assert "myproject" in row[0], "Fallback path should contain project name from key reconstruction"
 
+    def test_upsert_project_falls_back_to_key_with_hyphenated_name(self, memory_db):
+        """Fallback path mangles hyphenated project names (lossy reconstruction)."""
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_dir = Path(tmpdir) / "-home-user-src-secret-client"
+            project_dir.mkdir()
+
+            cursor = memory_db.cursor()
+            project_id = upsert_project(cursor, "-home-user-src-secret-client", project_dir=project_dir)
+            memory_db.commit()
+
+        cursor.execute("SELECT name FROM projects WHERE id = ?", (project_id,))
+        row = cursor.fetchone()
+        # Lossy reconstruction turns secret-client into secret/client → name="client"
+        assert row[0] == "client"
+
     def test_upsert_project_does_not_probe_top_level_symlink_project_dir(self, memory_db):
         """Symlink project dirs are rejected before JSONL probing."""
 
@@ -171,3 +187,69 @@ class TestUpsertProjectProbesJsonl:
         row = cursor.fetchone()
         assert row is not None
         assert row[0] == "/home/user/node/banana"
+
+
+class TestKeyCouldMatchExcluded:
+    """Test the conservative key-suffix matcher for exclude_projects on the fallback path."""
+
+    def test_hyphenated_name_matches_key_suffix(self):
+        assert key_could_match_excluded("-home-u-src-secret-client", ["secret-client"])
+
+    def test_unhyphenated_name_matches_key_suffix(self):
+        assert key_could_match_excluded("-home-user-myproject", ["myproject"])
+
+    def test_no_match_when_name_not_in_key(self):
+        assert not key_could_match_excluded("-home-user-myproject", ["other-project"])
+
+    def test_empty_exclude_list(self):
+        assert not key_could_match_excluded("-home-user-myproject", [])
+
+    def test_multiple_excludes_any_match(self):
+        assert key_could_match_excluded("-home-u-src-secret-client", ["unrelated", "secret-client"])
+
+    def test_partial_overlap_does_not_match(self):
+        # "client" appears in the key but the full entry "not-secret-client" does not
+        assert not key_could_match_excluded("-home-u-src-secret-client", ["not-secret-client"])
+
+    def test_name_with_dots_matches(self):
+        # A project named "my.project" encodes dots as hyphens in the key
+        assert key_could_match_excluded("-home-user-my-project", ["my.project"])
+
+    def test_exact_key_is_excluded_name(self):
+        # Edge case: key is just the encoded project name with no parent dirs
+        assert key_could_match_excluded("-secret-client", ["secret-client"])
+
+
+class TestImportProjectExcludesHyphenatedNames:
+    """Integration test: import_project should exclude hyphenated names on the fallback path."""
+
+    def test_import_excludes_hyphenated_project_on_fallback(self, memory_db):
+        """When probe fails and key is ambiguous, exclude if key could match.
+
+        The upsert derives name='client' from key '-home-u-src-secret-client'
+        (lossy reconstruction), so 'secret-client' doesn't match by exact name.
+        The key-suffix check should catch it.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_dir = Path(tmpdir) / "-home-u-src-secret-client"
+            project_dir.mkdir()
+
+            # Seed the project with a recognizable name from the lossy fallback
+            cursor = memory_db.cursor()
+            upsert_project(cursor, "-home-u-src-secret-client", project_dir=project_dir)
+            memory_db.commit()
+
+            # Verify the lossy name is wrong
+            cursor.execute(
+                "SELECT name FROM projects WHERE key = ?",
+                ("-home-u-src-secret-client",),
+            )
+            assert cursor.fetchone()[0] == "client"  # lossy — not "secret-client"
+
+            # Now test that key_could_match_excluded catches what exact-name missed
+            from ccrecall.formatting import normalize_project_key
+
+            key = normalize_project_key("-home-u-src-secret-client")
+            assert "client" not in ["secret-client"]  # exact match fails (the bug)
+            assert key_could_match_excluded(key, ["secret-client"])  # suffix match catches it

--- a/tests/test_project_ops.py
+++ b/tests/test_project_ops.py
@@ -16,11 +16,12 @@ class TestUpsertProjectWithCwd:
         """upsert_project should create a project using the provided cwd path."""
 
         cursor = memory_db.cursor()
-        project_id = upsert_project(cursor, "-home-user-myrepo", cwd="/home/user/myrepo")
+        project_id, used_lossy = upsert_project(cursor, "-home-user-myrepo", cwd="/home/user/myrepo")
         memory_db.commit()
 
         assert project_id is not None
         assert isinstance(project_id, int)
+        assert not used_lossy
 
         cursor.execute("SELECT path, name FROM projects WHERE id = ?", (project_id,))
         row = cursor.fetchone()
@@ -32,9 +33,9 @@ class TestUpsertProjectWithCwd:
         """Calling upsert_project twice with same key returns same project_id."""
 
         cursor = memory_db.cursor()
-        id1 = upsert_project(cursor, "-home-user-myrepo", cwd="/home/user/myrepo")
+        id1, _ = upsert_project(cursor, "-home-user-myrepo", cwd="/home/user/myrepo")
         memory_db.commit()
-        id2 = upsert_project(cursor, "-home-user-myrepo", cwd="/home/user/myrepo")
+        id2, _ = upsert_project(cursor, "-home-user-myrepo", cwd="/home/user/myrepo")
         memory_db.commit()
 
         assert id1 == id2, "Idempotent call should return same project_id"
@@ -54,7 +55,7 @@ class TestUpsertProjectWithCwd:
         memory_db.commit()
 
         # Upsert with real cwd (same key but different path from cwd metadata)
-        project_id = upsert_project(cursor, "-home-user-my-repo", cwd="/home/user/my-repo")
+        project_id, _ = upsert_project(cursor, "-home-user-my-repo", cwd="/home/user/my-repo")
         memory_db.commit()
 
         assert project_id is not None
@@ -67,7 +68,7 @@ class TestUpsertProjectWithCwd:
         """Worktree cwd suffix should be normalized away."""
 
         cursor = memory_db.cursor()
-        project_id = upsert_project(
+        project_id, _ = upsert_project(
             cursor,
             "-home-user-myrepo",
             cwd="/home/user/myrepo/.claude/worktrees/my-feature",
@@ -97,10 +98,11 @@ class TestUpsertProjectProbesJsonl:
             cursor = memory_db.cursor()
             # Use the encoded directory name as project_key, no cwd
             project_key = "-home-user-node-banana"
-            project_id = upsert_project(cursor, project_key, project_dir=project_dir)
+            project_id, used_lossy = upsert_project(cursor, project_key, project_dir=project_dir)
             memory_db.commit()
 
         assert project_id is not None
+        assert not used_lossy
 
         cursor.execute("SELECT path, name FROM projects WHERE id = ?", (project_id,))
         row = cursor.fetchone()
@@ -123,10 +125,11 @@ class TestUpsertProjectProbesJsonl:
             shutil.copy(FIXTURE_DIR / "linear_3_exchange.jsonl", subagents_dir / "sess.jsonl")
 
             cursor = memory_db.cursor()
-            project_id = upsert_project(cursor, "-home-user-node-banana", project_dir=project_dir)
+            project_id, used_lossy = upsert_project(cursor, "-home-user-node-banana", project_dir=project_dir)
             memory_db.commit()
 
         assert project_id is not None
+        assert not used_lossy
 
         cursor.execute("SELECT path, name FROM projects WHERE id = ?", (project_id,))
         row = cursor.fetchone()
@@ -142,10 +145,11 @@ class TestUpsertProjectProbesJsonl:
             project_dir.mkdir()
 
             cursor = memory_db.cursor()
-            project_id = upsert_project(cursor, "-home-user-myproject", project_dir=project_dir)
+            project_id, used_lossy = upsert_project(cursor, "-home-user-myproject", project_dir=project_dir)
             memory_db.commit()
 
         assert project_id is not None
+        assert used_lossy
 
         cursor.execute("SELECT path, name FROM projects WHERE id = ?", (project_id,))
         row = cursor.fetchone()
@@ -161,9 +165,10 @@ class TestUpsertProjectProbesJsonl:
             project_dir.mkdir()
 
             cursor = memory_db.cursor()
-            project_id = upsert_project(cursor, "-home-user-src-secret-client", project_dir=project_dir)
+            project_id, used_lossy = upsert_project(cursor, "-home-user-src-secret-client", project_dir=project_dir)
             memory_db.commit()
 
+        assert used_lossy
         cursor.execute("SELECT name FROM projects WHERE id = ?", (project_id,))
         row = cursor.fetchone()
         # Lossy reconstruction turns secret-client into secret/client → name="client"
@@ -180,7 +185,7 @@ class TestUpsertProjectProbesJsonl:
             symlink_project_dir.symlink_to(real_project_dir, target_is_directory=True)
 
             cursor = memory_db.cursor()
-            project_id = upsert_project(cursor, "-home-user-node-banana", project_dir=symlink_project_dir)
+            project_id, _ = upsert_project(cursor, "-home-user-node-banana", project_dir=symlink_project_dir)
             memory_db.commit()
 
         cursor.execute("SELECT path FROM projects WHERE id = ?", (project_id,))
@@ -220,36 +225,50 @@ class TestKeyCouldMatchExcluded:
         assert key_could_match_excluded("-secret-client", ["secret-client"])
 
 
-class TestImportProjectExcludesHyphenatedNames:
-    """Integration test: import_project should exclude hyphenated names on the fallback path."""
+class TestLossyFallbackExclusionChain:
+    """Verify the full chain: lossy upsert + key-suffix match catches hyphenated names."""
 
-    def test_import_excludes_hyphenated_project_on_fallback(self, memory_db):
-        """When probe fails and key is ambiguous, exclude if key could match.
-
-        The upsert derives name='client' from key '-home-u-src-secret-client'
-        (lossy reconstruction), so 'secret-client' doesn't match by exact name.
-        The key-suffix check should catch it.
+    def test_lossy_fallback_reports_used_and_suffix_matches(self, memory_db):
+        """When probe fails, upsert reports lossy fallback, and the key-suffix check
+        catches what the exact-name match missed.
         """
 
         with tempfile.TemporaryDirectory() as tmpdir:
             project_dir = Path(tmpdir) / "-home-u-src-secret-client"
             project_dir.mkdir()
 
-            # Seed the project with a recognizable name from the lossy fallback
             cursor = memory_db.cursor()
-            upsert_project(cursor, "-home-u-src-secret-client", project_dir=project_dir)
+            _, used_lossy = upsert_project(cursor, "-home-u-src-secret-client", project_dir=project_dir)
             memory_db.commit()
 
-            # Verify the lossy name is wrong
-            cursor.execute(
-                "SELECT name FROM projects WHERE key = ?",
-                ("-home-u-src-secret-client",),
-            )
-            assert cursor.fetchone()[0] == "client"  # lossy — not "secret-client"
+            assert used_lossy
 
-            # Now test that key_could_match_excluded catches what exact-name missed
-            from ccrecall.formatting import normalize_project_key
+            cursor.execute("SELECT name FROM projects WHERE key = ?", ("-home-u-src-secret-client",))
+            project_name = cursor.fetchone()[0]
+            assert project_name == "client"  # lossy — not "secret-client"
 
-            key = normalize_project_key("-home-u-src-secret-client")
-            assert "client" not in ["secret-client"]  # exact match fails (the bug)
-            assert key_could_match_excluded(key, ["secret-client"])  # suffix match catches it
+            # Exact-name check misses it, but key-suffix catches it
+            assert project_name not in ["secret-client"]
+            assert key_could_match_excluded("-home-u-src-secret-client", ["secret-client"])
+
+    def test_accurate_probe_does_not_trigger_suffix_check(self, memory_db):
+        """When cwd is accurate, used_lossy_fallback is False — the suffix check
+        should not fire, preventing false-positive exclusion of e.g. 'team-app'
+        when only 'app' is excluded.
+        """
+
+        cursor = memory_db.cursor()
+        project_id, used_lossy = upsert_project(cursor, "-home-user-repos-team-app", cwd="/home/user/repos/team-app")
+        memory_db.commit()
+
+        assert not used_lossy
+
+        cursor.execute("SELECT name FROM projects WHERE id = ?", (project_id,))
+        project_name = cursor.fetchone()[0]
+        assert project_name == "team-app"
+
+        # Exact-name check correctly does not match
+        assert project_name not in ["app"]
+        # The suffix check would match (false positive), but it must not fire
+        # because used_lossy_fallback is False
+        assert key_could_match_excluded("-home-user-repos-team-app", ["app"])


### PR DESCRIPTION
## Summary

Fixes #119 and #121.

### `exclude_projects` misses hyphenated names (#119)

When the cwd probe fails and `parse_project_key` falls back to lossy hyphen reconstruction, project names containing hyphens are mangled — `secret-client` becomes `secret/client`, and `extract_project_name` returns `client` instead of `secret-client`. The `exclude_projects` check then fails to match.

**Fix:** `key_could_match_excluded` checks whether the encoded project key's suffix matches any excluded name. It only fires on the lossy fallback path — `upsert_project` now returns `(id, used_lossy_fallback)` so callers know when the fallback was used, preventing false-positive exclusion of accurately-probed projects (e.g. `team-app` would not be excluded by an entry for `app`).

### Migration test version matrix (#121)

Parametrized tests across every starting `user_version` (0 through `SCHEMA_VERSION-1`), with and without vec0 objects. Closes the gap where only v0 and v1 starting points were tested with vec0-carrying fixtures.

### Changes

- `project_ops.py`: new `key_could_match_excluded`, `upsert_project` returns `(id, used_lossy_fallback)`
- `import_conversations.py`: wire suffix check gated on `used_lossy_fallback`
- `session_ops.py`: unpack new return type
- `sync_current.py`: update stale comment about import-path parity
- `test_project_ops.py`: 19 tests (was 9)
- `test_db.py`: 14 new parametrized migration matrix tests

**1090 tests pass, lint/pyright clean.**