### PR TITLE
refactor: wave 4 polish — consolidate patterns, CLI flags, logging

### DIFF
--- a/skills/ccr-recall/SKILL.md
+++ b/skills/ccr-recall/SKILL.md
@@ -20,7 +20,7 @@ Semantic recall is active: `ccrecall search` fuses keyword ranking with chunk-ve
 
 **recent_chats.py** — retrieve recent sessions with full transcript:
 ```bash
-ccrecall recent --n 3
+ccrecall recent --limit 3
 ```
 
 **search_conversations.py / Entrypoint A** — search sessions, returns **ranked session cards** (compact, no transcript):
@@ -58,7 +58,7 @@ ccrecall tail <handle>
    Load `references/lenses.md` for per-lens parameters, core questions, and supplementary search patterns.
 
 2. **Gather context** using lens-appropriate tools:
-   - For recent context: `ccrecall recent --n N`
+   - For recent context: `ccrecall recent --limit N`
    - For session discovery: `ccrecall search --query "keywords"` — returns scored cards; triage by `score` and `topic` before tailing
    - For a specific exchange: `ccrecall search-messages --query "phrase"` — returns bounded snippets with locators
    - To open a full session: `ccrecall tail <handle>` (drill-in after A or B)
@@ -66,7 +66,7 @@ ccrecall tail <handle>
 3. **Apply lens questions** to analyze the retrieved conversations.
 
 4. **Deepen the search** if initial results are insufficient:
-   - Retrieve more sessions: `--n 20` on `recent`, or `--max-results 10` on `search`
+   - Retrieve more sessions: `--limit 20` on `recent`, or `--max-results 10` on `search`
    - Search for specific terms that surfaced
    - Filter by project: `--project projectname`
    - Filter by session: `--session <uuid-prefix>` (when a specific session ID is known)

--- a/skills/ccr-recall/references/lenses.md
+++ b/skills/ccr-recall/references/lenses.md
@@ -4,10 +4,10 @@
 
 | Lens | Tool | Options | Also Gather |
 |------|------|---------|-------------|
-| restore-context | recent_chats | `--n 5 --verbose` | `git status`, `git log -10` |
+| restore-context | recent_chats | `--limit 5 --verbose` | `git status`, `git log -10` |
 | find-gaps | search_conversations | `--query "confused struggling"` | — |
-| review-process | recent_chats | `--n 20 --verbose` | recent git log |
-| run-retro | recent_chats | `--n 20 --project NAME --verbose` | full git history |
+| review-process | recent_chats | `--limit 20 --verbose` | recent git log |
+| run-retro | recent_chats | `--limit 20 --project NAME --verbose` | full git history |
 | extract-decisions | search_conversations | `--query "decided chose trade-off"` | — |
 | find-antipatterns | search_conversations | `--query "again same mistake repeated"` | — |
 

--- a/skills/ccr-recall/references/tool-reference.md
+++ b/skills/ccr-recall/references/tool-reference.md
@@ -5,12 +5,12 @@
 Retrieve recent conversation sessions with all messages.
 
 ```bash
-ccrecall recent --n 3
+ccrecall recent --limit 3
 ```
 
 | Option                    | Effect                                                 |
 | ------------------------- | ------------------------------------------------------ |
-| `--n N`                   | Number of sessions (1-20, default 3)                   |
+| `--limit N` / `-n N`      | Number of sessions (1-20, default 3)                   |
 | `--sort-order`            | 'desc' (newest first, default) or 'asc'                |
 | `--before DATE`           | Sessions before this datetime (ISO)                    |
 | `--after DATE`            | Sessions after this datetime (ISO)                     |
@@ -129,7 +129,7 @@ ccrecall search-messages --query "keyword"
 | `--json` | Global flag (any position): emit JSON instead of markdown |
 | `--include-notifications` | Include task notification messages (hidden by default) |
 
-No `--verbose` flag: snippet text is pre-bounded per message with no collapsible metadata lists.
+`--verbose` is accepted for CLI symmetry but has no effect: snippet text is pre-bounded per message with no collapsible metadata lists.
 
 ### Output — Track B: matched exchange snippet
 

--- a/src/ccrecall/cli/__init__.py
+++ b/src/ccrecall/cli/__init__.py
@@ -32,7 +32,7 @@ app = App(
     help_format="plaintext",
     help_epilogue=(
         "Examples:\n"
-        "  ccrecall recent --n 5\n"
+        "  ccrecall recent --limit 5\n"
         "  ccrecall status --check-ingestion\n"
         "  ccrecall --json search -q 'auth bug'\n"
         "  ccrecall tail <session-id>"

--- a/src/ccrecall/cli/commands.py
+++ b/src/ccrecall/cli/commands.py
@@ -123,10 +123,11 @@ def cmd_status(
 @backfill_app.command(name="summaries")
 def cmd_backfill_summaries(
     *,
+    db: _DB = DEFAULT_DB_PATH,
     ctx: CLIContextParam = DEFAULT_CLI_CONTEXT,
 ) -> None:
     """Backfill context summaries for branches that lack a current one."""
-    backfill_summaries_mod.run(verbose=ctx.debug)
+    backfill_summaries_mod.run(verbose=ctx.debug, db=db)
 
 
 @backfill_app.command(name="embeddings")
@@ -149,6 +150,7 @@ def cmd_backfill_embeddings(
         int, Parameter(help="Print a progress line every N newly embedded branches.")
     ] = backfill_query_mod.DEFAULT_PROGRESS_EVERY,
     threads: Annotated[int, Parameter(help="ONNX intra-op threads per inference call.")] = DEFAULT_EMBED_THREADS,
+    db: _DB = DEFAULT_DB_PATH,
     ctx: CLIContextParam = DEFAULT_CLI_CONTEXT,
 ) -> None:
     """Seed historical embeddings for active-leaf branch summaries (opt-in)."""
@@ -172,6 +174,7 @@ def cmd_backfill_embeddings(
             progress_every=progress_every,
             threads=threads,
             verbose=ctx.debug,
+            db=db,
         )
     finally:
         # Status is read-only: never disturb a concurrent backfill's PID marker.
@@ -197,6 +200,7 @@ def cmd_backfill_tool_content(
     progress_every: Annotated[
         int, Parameter(help="Print a progress line every N newly backfilled sessions.")
     ] = backfill_query_mod.DEFAULT_PROGRESS_EVERY,
+    db: _DB = DEFAULT_DB_PATH,
     ctx: CLIContextParam = DEFAULT_CLI_CONTEXT,
 ) -> None:
     """Re-parse existing sessions' JSONL files to populate tool_content (opt-in)."""
@@ -211,6 +215,7 @@ def cmd_backfill_tool_content(
         limit=limit,
         progress_every=progress_every,
         verbose=ctx.debug,
+        db=db,
     )
     raise SystemExit(code)
 
@@ -218,10 +223,10 @@ def cmd_backfill_tool_content(
 @app.command(name="recent")
 def cmd_recent(
     *,
-    n: Annotated[
+    limit: Annotated[
         int,
         Parameter(
-            name=["--n", "-n"],
+            name=["--limit", "-n"],
             validator=Number(gte=1, lte=recent_chats_mod.MAX_RECENT_SESSIONS),
             help=f"Number of sessions (1-{recent_chats_mod.MAX_RECENT_SESSIONS}).",
         ),
@@ -243,7 +248,7 @@ def cmd_recent(
     messages}], total_sessions, total_messages}
     """
     recent_chats_mod.run(
-        n=n,
+        n=limit,
         sort_order=sort_order,
         before=before,
         after=after,
@@ -266,7 +271,7 @@ def cmd_search(
     max_results: Annotated[
         int,
         Parameter(
-            name=["--max-results", "-n", "--n"],
+            name=["--max-results", "-n"],
             validator=Number(gte=1, lte=search_mod.MAX_SEARCH_RESULTS),
             help=f"Max sessions (1-{search_mod.MAX_SEARCH_RESULTS}).",
         ),
@@ -311,7 +316,7 @@ def cmd_search_messages(
     max_results: Annotated[
         int,
         Parameter(
-            name=["--max-results", "-n", "--n"],
+            name=["--max-results", "-n"],
             validator=Number(gte=1, lte=search_mod.MAX_SEARCH_RESULTS),
             help=f"Max matched exchanges (1-{search_mod.MAX_SEARCH_RESULTS}).",
         ),
@@ -321,6 +326,7 @@ def cmd_search_messages(
     path: Annotated[str | None, Parameter(help="Filter by cwd substring (e.g. worktree name).")] = None,
     before: _BEFORE = None,
     after: _AFTER = None,
+    verbose: _VERBOSE = False,
     include_notifications: _NOTIFS = False,
     db: _DB = DEFAULT_DB_PATH,
     ctx: CLIContextParam = DEFAULT_CLI_CONTEXT,
@@ -344,6 +350,7 @@ def cmd_search_messages(
         before=before,
         after=after,
         output_format=ctx.output_format,
+        verbose=verbose,
         include_notifications=include_notifications,
         db=db,
     )
@@ -358,9 +365,7 @@ def cmd_tail(
         bool, _FLAG, Parameter(name=["--full"], help="Print full untruncated last instruction and assistant message.")
     ] = False,
     cwd: Annotated[str | None, Parameter(name=["--cwd"], help="Derive project dir from this path.")] = None,
-    n: Annotated[
-        int, Parameter(name=["-n", "--n", "--lines"], help="Number of tail events to show.")
-    ] = _TAIL_DEFAULT_N,
+    n: Annotated[int, Parameter(name=["--lines", "-n"], help="Number of tail events to show.")] = _TAIL_DEFAULT_N,
 ) -> None:
     """Print the tail of a prior session's transcript for fast resume."""
     raise SystemExit(session_tail_mod.run(selector, list_sessions=list_sessions, cwd=cwd, n=n, full=full))

--- a/src/ccrecall/config.py
+++ b/src/ccrecall/config.py
@@ -191,6 +191,17 @@ def load_settings() -> dict:
     return settings
 
 
+def load_settings_for_db(db: Path) -> dict:
+    """Load settings, overriding db_path when a non-default --db was passed.
+
+    Shared by the status and backfill CLI paths so the override merge can't drift.
+    """
+    settings = load_settings()
+    if db != DEFAULT_DB_PATH:
+        settings["db_path"] = str(db)
+    return settings
+
+
 def get_db_path(settings: dict | None = None) -> Path:
     """Get database path from settings or default."""
     if settings and "db_path" in settings:

--- a/src/ccrecall/db.py
+++ b/src/ccrecall/db.py
@@ -53,6 +53,12 @@ def escape_like(value: str) -> str:
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
+def has_tool_counts(cursor: sqlite3.Cursor) -> bool:
+    """Check if the branches table has a tool_counts column (absent on old DBs)."""
+    cursor.execute("PRAGMA table_info(branches)")
+    return "tool_counts" in {row[1] for row in cursor.fetchall()}
+
+
 def parse_project_filter(project: str | None) -> list[str] | None:
     """Split a comma-separated --project value into a stripped list (None if unset).
 

--- a/src/ccrecall/db_base.py
+++ b/src/ccrecall/db_base.py
@@ -300,8 +300,9 @@ def _apply_migrations(
                 if current < 2:
                     migrate_to_v2(conn)
                 conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
-                log.debug("migrated schema from v%d to v%d", current, SCHEMA_VERSION)
             conn.execute("COMMIT")
+            if current < SCHEMA_VERSION:
+                log.debug("migrated schema from v%d to v%d", current, SCHEMA_VERSION)
         except Exception:
             conn.execute("ROLLBACK")
             raise

--- a/src/ccrecall/db_base.py
+++ b/src/ccrecall/db_base.py
@@ -8,12 +8,15 @@ top; keeping that split is what lets a caller migrate the DB without paying the
 those, so keep new heavy dependencies out of it.
 """
 
+import logging
 import sqlite3
 from collections.abc import Callable
 
 from ccrecall.config import ensure_parent_dir, get_db_path
-from ccrecall.models import BUSY_TIMEOUT_MS
+from ccrecall.models import BUSY_TIMEOUT_MS, LOGGER_NAME
 from ccrecall.schema import SCHEMA_CORE, SCHEMA_FTS4, SCHEMA_FTS5, detect_fts_support
+
+log = logging.getLogger(LOGGER_NAME)
 
 # Current schema version. Bump when adding a migration and wire the new DDL
 # delta into _apply_migrations (see _migrate_to_v1 for the version-1 shape).
@@ -297,6 +300,7 @@ def _apply_migrations(
                 if current < 2:
                     migrate_to_v2(conn)
                 conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+                log.debug("migrated schema from v%d to v%d", current, SCHEMA_VERSION)
             conn.execute("COMMIT")
         except Exception:
             conn.execute("ROLLBACK")

--- a/src/ccrecall/hooks/backfill_embeddings.py
+++ b/src/ccrecall/hooks/backfill_embeddings.py
@@ -17,21 +17,20 @@ non-zero so the scheduler sees the failure.
 
 Query construction/constants live in `backfill_query.py`; status reporting
 lives in `backfill_status.py`. This module keeps the `run()` orchestrator plus
-the per-batch `_reclaim_memory` helper (gc + malloc_trim between batches, the
-same RSS discipline as import_conversations).
+the shared `reclaim_memory` helper from `subprocess_utils` (gc + malloc_trim
+between batches, the same RSS discipline as import_conversations).
 """
 
 import contextlib
-import ctypes
-import gc
 import json
 import os
 import sqlite3
 import sys
 import time
 from collections import deque
+from pathlib import Path
 
-from ccrecall.config import load_settings, setup_logging
+from ccrecall.config import DEFAULT_DB_PATH, load_settings, setup_logging
 from ccrecall.db import CONTENT_ERROR_VERSION, get_connection
 from ccrecall.db_vec import chunk_vec_queryable, fetch_branch_messages
 from ccrecall.embed_ops import embed_branch_chunks
@@ -52,39 +51,13 @@ from ccrecall.hooks.backfill_query import (
     build_selection,
 )
 from ccrecall.hooks.backfill_status import format_duration, run_status
+from ccrecall.hooks.subprocess_utils import reclaim_memory, try_load_libc
 
 _PRINT_PREFIX = "ccrecall backfill embeddings"
 _LOG_PREFIX = "Backfill embeddings"
 _SAVEPOINT_NAME = "row"
 _WARMUP_BRANCHES = 5
 _RATE_WINDOW = 30
-
-
-def _try_load_libc() -> ctypes.CDLL | None:
-    """Load glibc for malloc_trim (Linux only); None anywhere else or on failure."""
-    if sys.platform != "linux":
-        return None
-    with contextlib.suppress(OSError):
-        return ctypes.CDLL("libc.so.6")
-    return None
-
-
-def _reclaim_memory(libc: ctypes.CDLL | None) -> None:
-    """Free Python objects and hand freed glibc arena pages back to the OS.
-
-    Same RSS discipline as import_conversations' reclaim_memory: without
-    malloc_trim, a process embedding thousands of branches keeps every arena it
-    ever grew, so its RSS floor ratchets up to the largest historical batch and
-    stays there. Runs once per batch (beside the commit) so peaks don't
-    accumulate across the run.
-    """
-    gc.collect()
-    if libc is not None:
-        # Best-effort: a ctypes/symbol failure here would escape run()'s
-        # sqlite3.Error/OSError normalization and crash the backfill over a
-        # memory-hygiene nicety.
-        with contextlib.suppress(Exception):
-            libc.malloc_trim(0)
 
 
 def run(
@@ -96,6 +69,7 @@ def run(
     progress_every: int = DEFAULT_PROGRESS_EVERY,
     threads: int = DEFAULT_EMBED_THREADS,
     verbose: bool = False,
+    db: Path = DEFAULT_DB_PATH,
 ) -> int:
     """Embed active-leaf branch exchanges at chunk grain (opt-in; not auto-spawned)."""
     # Backstop for direct callers; the CLI validators reject <1 before reaching
@@ -108,6 +82,8 @@ def run(
         raise ValueError("limit must be >= 1")
 
     settings = load_settings()
+    if db != DEFAULT_DB_PATH:
+        settings["db_path"] = str(db)
     logger = setup_logging(settings, process_name="backfill-embed", verbose=verbose)
 
     if status:
@@ -142,7 +118,7 @@ def run(
     started = time.monotonic()
 
     where, params = build_selection(days)
-    libc = _try_load_libc()
+    libc = try_load_libc()
 
     try:
         with get_connection(settings, load_vec=True) as conn:
@@ -318,7 +294,7 @@ def run(
                     return EXIT_ABORT
 
                 conn.commit()
-                _reclaim_memory(libc)
+                reclaim_memory(libc)
 
                 time.sleep(BACKFILL_BATCH_DELAY_SECONDS)
     except (sqlite3.Error, OSError) as e:

--- a/src/ccrecall/hooks/backfill_embeddings.py
+++ b/src/ccrecall/hooks/backfill_embeddings.py
@@ -30,7 +30,7 @@ import time
 from collections import deque
 from pathlib import Path
 
-from ccrecall.config import DEFAULT_DB_PATH, load_settings, setup_logging
+from ccrecall.config import DEFAULT_DB_PATH, load_settings_for_db, setup_logging
 from ccrecall.db import CONTENT_ERROR_VERSION, get_connection
 from ccrecall.db_vec import chunk_vec_queryable, fetch_branch_messages
 from ccrecall.embed_ops import embed_branch_chunks
@@ -81,9 +81,7 @@ def run(
     if limit is not None and limit < 1:
         raise ValueError("limit must be >= 1")
 
-    settings = load_settings()
-    if db != DEFAULT_DB_PATH:
-        settings["db_path"] = str(db)
+    settings = load_settings_for_db(db)
     logger = setup_logging(settings, process_name="backfill-embed", verbose=verbose)
 
     if status:

--- a/src/ccrecall/hooks/backfill_summaries.py
+++ b/src/ccrecall/hooks/backfill_summaries.py
@@ -8,7 +8,7 @@ with summary_version = -1 to avoid infinite retry.
 import sqlite3
 from pathlib import Path
 
-from ccrecall.config import DEFAULT_DB_PATH, load_settings, remove_pid_file, setup_logging
+from ccrecall.config import DEFAULT_DB_PATH, load_settings_for_db, remove_pid_file, setup_logging
 from ccrecall.db import CONTENT_ERROR_VERSION, get_connection
 from ccrecall.summarizer import SUMMARY_VERSION, compute_context_summary
 
@@ -33,9 +33,7 @@ def run(*, verbose: bool = False, db: Path = DEFAULT_DB_PATH):
 
 
 def _main(*, verbose: bool = False, db: Path = DEFAULT_DB_PATH):
-    settings = load_settings()
-    if db != DEFAULT_DB_PATH:
-        settings["db_path"] = str(db)
+    settings = load_settings_for_db(db)
     logger = setup_logging(settings, process_name="backfill-summary", verbose=verbose)
 
     total_updated = 0

--- a/src/ccrecall/hooks/backfill_summaries.py
+++ b/src/ccrecall/hooks/backfill_summaries.py
@@ -6,8 +6,9 @@ with summary_version = -1 to avoid infinite retry.
 """
 
 import sqlite3
+from pathlib import Path
 
-from ccrecall.config import load_settings, remove_pid_file, setup_logging
+from ccrecall.config import DEFAULT_DB_PATH, load_settings, remove_pid_file, setup_logging
 from ccrecall.db import CONTENT_ERROR_VERSION, get_connection
 from ccrecall.summarizer import SUMMARY_VERSION, compute_context_summary
 
@@ -18,21 +19,23 @@ BATCH_SIZE = 50
 PID_KEY = "ccrecall-backfill-summaries"
 
 
-def run(*, verbose: bool = False):
+def run(*, verbose: bool = False, db: Path = DEFAULT_DB_PATH):
     """Backfill context summaries for branches that lack a current one.
 
     Wraps the ``_main()`` work in PID-file cleanup. ``_main()`` is kept separate
     so tests can exercise the backfill logic without the PID-file lifecycle.
     """
     try:
-        _main(verbose=verbose)
+        _main(verbose=verbose, db=db)
     finally:
         # Delete PID file so _spawn_background can spawn again next session
         remove_pid_file(PID_KEY)
 
 
-def _main(*, verbose: bool = False):
+def _main(*, verbose: bool = False, db: Path = DEFAULT_DB_PATH):
     settings = load_settings()
+    if db != DEFAULT_DB_PATH:
+        settings["db_path"] = str(db)
     logger = setup_logging(settings, process_name="backfill-summary", verbose=verbose)
 
     total_updated = 0

--- a/src/ccrecall/hooks/backfill_summaries.py
+++ b/src/ccrecall/hooks/backfill_summaries.py
@@ -19,7 +19,7 @@ BATCH_SIZE = 50
 PID_KEY = "ccrecall-backfill-summaries"
 
 
-def run(*, verbose: bool = False, db: Path = DEFAULT_DB_PATH):
+def run(*, verbose: bool = False, db: Path = DEFAULT_DB_PATH) -> None:
     """Backfill context summaries for branches that lack a current one.
 
     Wraps the ``_main()`` work in PID-file cleanup. ``_main()`` is kept separate
@@ -32,7 +32,7 @@ def run(*, verbose: bool = False, db: Path = DEFAULT_DB_PATH):
         remove_pid_file(PID_KEY)
 
 
-def _main(*, verbose: bool = False, db: Path = DEFAULT_DB_PATH):
+def _main(*, verbose: bool = False, db: Path = DEFAULT_DB_PATH) -> None:
     settings = load_settings_for_db(db)
     logger = setup_logging(settings, process_name="backfill-summary", verbose=verbose)
 

--- a/src/ccrecall/hooks/backfill_tool_content.py
+++ b/src/ccrecall/hooks/backfill_tool_content.py
@@ -58,7 +58,7 @@ import sys
 import time
 from pathlib import Path
 
-from ccrecall.config import load_settings, setup_logging
+from ccrecall.config import DEFAULT_DB_PATH, load_settings, setup_logging
 from ccrecall.content import extract_text_content
 from ccrecall.db import get_connection
 from ccrecall.db_vec import VEC_BUSY_TIMEOUT_MS
@@ -151,6 +151,7 @@ def run(
     limit: int | None = None,
     progress_every: int = DEFAULT_PROGRESS_EVERY,
     verbose: bool = False,
+    db: Path = DEFAULT_DB_PATH,
 ) -> int:
     """Backfill tool_content for existing synced sessions (opt-in; not auto-spawned)."""
     if days is not None and days < 1:
@@ -159,6 +160,8 @@ def run(
         raise ValueError("limit must be >= 1")
 
     settings = load_settings()
+    if db != DEFAULT_DB_PATH:
+        settings["db_path"] = str(db)
     logger = setup_logging(settings, process_name="backfill-tool-content", verbose=verbose)
 
     if status:

--- a/src/ccrecall/hooks/backfill_tool_content.py
+++ b/src/ccrecall/hooks/backfill_tool_content.py
@@ -58,7 +58,7 @@ import sys
 import time
 from pathlib import Path
 
-from ccrecall.config import DEFAULT_DB_PATH, load_settings, setup_logging
+from ccrecall.config import DEFAULT_DB_PATH, load_settings_for_db, setup_logging
 from ccrecall.content import extract_text_content
 from ccrecall.db import get_connection
 from ccrecall.db_vec import VEC_BUSY_TIMEOUT_MS
@@ -159,9 +159,7 @@ def run(
     if limit is not None and limit < 1:
         raise ValueError("limit must be >= 1")
 
-    settings = load_settings()
-    if db != DEFAULT_DB_PATH:
-        settings["db_path"] = str(db)
+    settings = load_settings_for_db(db)
     logger = setup_logging(settings, process_name="backfill-tool-content", verbose=verbose)
 
     if status:

--- a/src/ccrecall/hooks/import_conversations.py
+++ b/src/ccrecall/hooks/import_conversations.py
@@ -6,13 +6,9 @@ Detects conversation branches (from rewind) and stores each branch separately.
 v3 schema: messages stored once per session, branches as separate index.
 """
 
-import contextlib
-import ctypes
-import gc
 import logging
 import resource
 import sqlite3
-import sys
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -22,6 +18,7 @@ from ccrecall.db import DEFAULT_PROJECTS_DIR, get_connection
 from ccrecall.db_vec import TRIGGER_CHUNKS_VEC_AD, vec_available
 from ccrecall.file_hashing import transcript_file_hash
 from ccrecall.formatting import extract_project_name, normalize_project_key
+from ccrecall.hooks.subprocess_utils import reclaim_memory, try_load_libc
 from ccrecall.import_log_ops import has_pending_tool_content
 from ccrecall.models import LOGGER_NAME
 from ccrecall.parsing import extract_session_uuid, sort_session_files
@@ -205,7 +202,7 @@ def import_project(
     conn: sqlite3.Connection,
     project_dir: Path,
     exclude_projects: list[str] | None = None,
-    reclaim_memory: Callable[[], None] = _noop,
+    on_reclaim: Callable[[], None] = _noop,
 ) -> tuple[int, int, int]:
     """
     Import all sessions from a project directory.
@@ -260,7 +257,7 @@ def import_project(
             else:
                 sessions_imported += branches_count
                 messages_imported += msg_count
-                reclaim_memory()
+                on_reclaim()
 
     if sessions_imported or sessions_skipped:
         log.debug(
@@ -318,22 +315,13 @@ def _run(
         t_conn = time.monotonic()
         logger.debug("connection opened in %.2fs", t_conn - t_start)
 
-        # gc.collect() frees Python objects; malloc_trim() releases freed glibc arena
-        # pages back to the OS (without it, RSS grows monotonically). Runs between
-        # sessions (not just projects) so large projects don't accumulate unbounded.
-        libc: ctypes.CDLL | None = None
-        if sys.platform == "linux":
-            with contextlib.suppress(OSError):
-                libc = ctypes.CDLL("libc.so.6")
-
+        libc = try_load_libc()
         t_gc_total = 0.0
 
-        def reclaim_memory() -> None:
+        def _reclaim() -> None:
             nonlocal t_gc_total
             t0 = time.monotonic()
-            gc.collect()
-            if libc is not None:
-                libc.malloc_trim(0)
+            reclaim_memory(libc)
             t_gc_total += time.monotonic() - t0
 
         if project:
@@ -345,7 +333,7 @@ def _run(
                 print(f"Unsafe project path: {project_dir}")
                 return
 
-            sessions, messages, skipped = import_project(conn, project_dir, exclude_projects, reclaim_memory)
+            sessions, messages, skipped = import_project(conn, project_dir, exclude_projects, _reclaim)
             conn.commit()
             total_sessions += sessions
             total_messages += messages
@@ -362,7 +350,7 @@ def _run(
 
                 project_count += 1
                 t0 = time.monotonic()
-                sessions, messages, skipped = import_project(conn, project_dir, exclude_projects, reclaim_memory)
+                sessions, messages, skipped = import_project(conn, project_dir, exclude_projects, _reclaim)
                 t_import_total += time.monotonic() - t0
 
                 t0 = time.monotonic()

--- a/src/ccrecall/hooks/session_selection.py
+++ b/src/ccrecall/hooks/session_selection.py
@@ -14,6 +14,7 @@ Selection Algorithm (clear):
 
 import contextlib
 import json
+import logging
 import sqlite3
 from pathlib import Path
 
@@ -21,7 +22,10 @@ from whenever import Instant
 
 from ccrecall.config import CLEAR_HANDOFF_FILENAME
 from ccrecall.formatting import normalize_cwd
+from ccrecall.models import LOGGER_NAME
 from ccrecall.serialization import decode_json_column
+
+log = logging.getLogger(LOGGER_NAME)
 
 # Reject a clear-handoff written more than this many seconds ago (stale guard).
 HANDOFF_STALE_SECONDS = 30
@@ -170,6 +174,7 @@ def _find_cleared_from_session_uuid(db_path: Path, cwd: str) -> str | None:
     try:
         handoff_data = json.loads(handoff_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
+        log.debug("corrupt or unreadable handoff file, deleting: %s", handoff_path)
         with contextlib.suppress(OSError):
             handoff_path.unlink()
         return None

--- a/src/ccrecall/hooks/subprocess_utils.py
+++ b/src/ccrecall/hooks/subprocess_utils.py
@@ -1,5 +1,8 @@
 """Lightweight helpers for detached hook subprocesses."""
 
+import contextlib
+import ctypes
+import gc
 import subprocess
 import sys
 from typing import Any
@@ -17,3 +20,24 @@ def detached_popen_kwargs() -> dict[str, Any]:
     else:
         kwargs["start_new_session"] = True
     return kwargs
+
+
+def try_load_libc() -> ctypes.CDLL | None:
+    """Load glibc for malloc_trim (Linux only); None anywhere else or on failure."""
+    if sys.platform != "linux":
+        return None
+    with contextlib.suppress(OSError):
+        return ctypes.CDLL("libc.so.6")
+    return None
+
+
+def reclaim_memory(libc: ctypes.CDLL | None) -> None:
+    """Free Python objects and hand freed glibc arena pages back to the OS.
+
+    Without malloc_trim, a long-running process keeps every arena it ever grew,
+    so its RSS floor ratchets up. Call between batches so peaks don't accumulate.
+    """
+    gc.collect()
+    if libc is not None:
+        with contextlib.suppress(Exception):
+            libc.malloc_trim(0)

--- a/src/ccrecall/recent_chats.py
+++ b/src/ccrecall/recent_chats.py
@@ -4,16 +4,21 @@ Returns markdown by default (token-efficient), or JSON when output_format="json"
 (the CLI maps the global --json flag onto that argument).
 """
 
+import logging
 import sqlite3
 from pathlib import Path
 
 from ccrecall.config import DEFAULT_DB_PATH
 from ccrecall.dates import validate_or_exit
-from ccrecall.db import escape_like, get_connection, parse_project_filter, resolve_db_settings
+from ccrecall.db import get_connection, has_tool_counts, parse_project_filter, resolve_db_settings
 from ccrecall.db_vec import fetch_branch_messages
 from ccrecall.errors import emit_error
 from ccrecall.formatting import format_json_sessions, format_markdown_session
+from ccrecall.models import LOGGER_NAME
+from ccrecall.search_query import EMPTY_SCOPE, ScopeFilter, scope_filter_clause
 from ccrecall.serialization import decode_json_column
+
+log = logging.getLogger(LOGGER_NAME)
 
 # Upper bound on --n, single-sourced here and referenced by the CLI validator
 # (cli/commands.py) so the clamp and the validator can't drift apart.
@@ -24,23 +29,16 @@ def get_recent_sessions(
     conn: sqlite3.Connection,
     n: int = 3,
     sort_order: str = "desc",
-    before: str | None = None,
-    after: str | None = None,
-    projects: list[str] | None = None,
-    session_id: str | None = None,
-    path: str | None = None,
+    scope: ScopeFilter = EMPTY_SCOPE,
     verbose: bool = False,
     include_notifications: bool = False,
 ) -> list[dict]:
     """Get n most recent sessions with all their messages."""
     cursor = conn.cursor()
 
-    # Check if tool_counts column exists (absent on DBs created before it was added to SCHEMA_CORE)
-    cursor.execute("PRAGMA table_info(branches)")
-    branch_columns = {row[1] for row in cursor.fetchall()}
-    has_tool_counts = "tool_counts" in branch_columns
+    has_tc = has_tool_counts(cursor)
 
-    tool_counts_col = ", b.tool_counts" if has_tool_counts else ""
+    tool_counts_col = ", b.tool_counts" if has_tc else ""
     sql = f"""
         SELECT s.id, s.uuid, b.started_at, b.ended_at, b.exchange_count,
                b.files_modified, b.commits, s.git_branch,
@@ -51,32 +49,8 @@ def get_recent_sessions(
         JOIN projects p ON s.project_id = p.id
         WHERE 1=1
     """
-    params = []
-
-    if session_id:
-        sql += " AND s.uuid LIKE ? ESCAPE '\\'"
-        params.append(f"{escape_like(session_id)}%")
-
-    # Mirrors search_query.py's scope_filter_clause (before/after clauses) —
-    # not reused because this function already builds its project/session/path
-    # filters inline rather than via that helper. Keep both in sync if the
-    # before/after comparison semantics ever change.
-    if before:
-        sql += " AND b.started_at < ?"
-        params.append(before)
-
-    if after:
-        sql += " AND b.started_at > ?"
-        params.append(after)
-
-    if projects:
-        placeholders = ",".join("?" * len(projects))
-        sql += f" AND p.name IN ({placeholders})"
-        params.extend(projects)
-
-    if path:
-        sql += " AND s.cwd LIKE ? ESCAPE '\\'"
-        params.append(f"%{escape_like(path)}%")
+    scope_sql, params = scope_filter_clause(scope)
+    sql += scope_sql
 
     order = "DESC" if sort_order == "desc" else "ASC"
     sql += f" ORDER BY b.ended_at {order} LIMIT ?"
@@ -88,7 +62,7 @@ def get_recent_sessions(
     results = []
 
     for session in sessions:
-        if has_tool_counts:
+        if has_tc:
             (
                 _session_id,
                 uuid,
@@ -184,6 +158,8 @@ def run(
             remediation="Run ccrecall import or start a session with the ccrecall plugin installed.",
         )
 
+    scope = ScopeFilter(projects=projects, session_id=session, path=path, before=before, after=after)
+
     try:
         settings = resolve_db_settings(db)
         with get_connection(settings) as conn:
@@ -191,11 +167,7 @@ def run(
                 conn,
                 n=n,
                 sort_order=sort_order,
-                before=before,
-                after=after,
-                projects=projects,
-                session_id=session,
-                path=path,
+                scope=scope,
                 verbose=verbose,
                 include_notifications=include_notifications,
             )

--- a/src/ccrecall/recent_chats.py
+++ b/src/ccrecall/recent_chats.py
@@ -4,7 +4,6 @@ Returns markdown by default (token-efficient), or JSON when output_format="json"
 (the CLI maps the global --json flag onto that argument).
 """
 
-import logging
 import sqlite3
 from pathlib import Path
 
@@ -14,11 +13,8 @@ from ccrecall.db import get_connection, has_tool_counts, parse_project_filter, r
 from ccrecall.db_vec import fetch_branch_messages
 from ccrecall.errors import emit_error
 from ccrecall.formatting import format_json_sessions, format_markdown_session
-from ccrecall.models import LOGGER_NAME
 from ccrecall.search_query import EMPTY_SCOPE, ScopeFilter, scope_filter_clause
 from ccrecall.serialization import decode_json_column
-
-log = logging.getLogger(LOGGER_NAME)
 
 # Upper bound on --n, single-sourced here and referenced by the CLI validator
 # (cli/commands.py) so the clamp and the validator can't drift apart.

--- a/src/ccrecall/search_cli.py
+++ b/src/ccrecall/search_cli.py
@@ -26,6 +26,7 @@ from ccrecall.formatting import (
 )
 from ccrecall.schema import detect_fts_support
 from ccrecall.search_conversations import compute_caveat, search_messages, search_sessions
+from ccrecall.search_query import ScopeFilter
 
 # Upper bound on --max-results, single-sourced here and referenced by the CLI
 # validator (cli/commands.py) so the clamp and the validator can't drift apart.
@@ -66,6 +67,7 @@ def run_messages(
     before: str | None = None,
     after: str | None = None,
     output_format: str = "markdown",
+    verbose: bool = False,  # noqa: ARG001 — accepted for CLI symmetry; B has no session-level metadata to expand
     include_notifications: bool = False,  # noqa: ARG001 — accepted for surface symmetry; moot on B (no fetch)
     db: Path = DEFAULT_DB_PATH,
 ) -> None:
@@ -91,19 +93,12 @@ def run_messages(
             remediation="Run ccrecall import or start a session with the ccrecall plugin installed.",
         )
 
+    scope = ScopeFilter(projects=projects, session_id=session, path=path, before=before, after=after)
+
     try:
         settings = resolve_db_settings(db)
         with get_connection(settings, load_vec=True) as conn:
-            snippets, ranked = search_messages(
-                conn,
-                query=query,
-                max_results=max_results,
-                projects=projects,
-                session_id=session,
-                path=path,
-                before=before,
-                after=after,
-            )
+            snippets, ranked = search_messages(conn, query=query, max_results=max_results, scope=scope)
 
         if output_format == "json":
             json_snippets = [format_snippet_json(s) for s in snippets]
@@ -217,6 +212,8 @@ def run(
             remediation="Run ccrecall import or start a session with the ccrecall plugin installed.",
         )
 
+    scope = ScopeFilter(projects=projects, session_id=session, path=path, before=before, after=after)
+
     try:
         settings = resolve_db_settings(db)
 
@@ -236,12 +233,8 @@ def run(
                 query=query,
                 fts_level=fts_level,
                 max_results=max_results,
-                projects=projects,
-                session_id=session,
-                path=path,
+                scope=scope,
                 keyword_only=keyword_only,
-                before=before,
-                after=after,
             )
             caveat = compute_caveat(conn)
 

--- a/src/ccrecall/search_conversations.py
+++ b/src/ccrecall/search_conversations.py
@@ -11,11 +11,12 @@ from ccrecall.db_vec import branch_embedding_coverage, chunk_vec_queryable
 from ccrecall.embeddings import embed_text, model_available
 from ccrecall.fusion import rrf_scored
 from ccrecall.health import RECALL_CAVEAT_COVERAGE_THRESHOLD
+from ccrecall.models import LOGGER_NAME
 from ccrecall.search_hydrate import dedup_by_session, hydrate_cards
 from ccrecall.search_query import EMPTY_SCOPE, ScopeFilter, get_fts_branch_ids
 from ccrecall.search_vector import execute_chunk_knn, get_vec_chunk_ids, hydrate_snippets
 
-_logger = logging.getLogger("ccrecall")
+log = logging.getLogger(LOGGER_NAME)
 
 # Each ranker (FTS, vector KNN) is over-fetched before fusion + per-session dedup,
 # so the post-filter top-N still has enough candidates: top_k = max(N * mult, floor).
@@ -96,7 +97,7 @@ def search_sessions(
                 pre_rollup = len(chunk_results)
                 post_rollup = len(ordered_ids)
                 ratio = pre_rollup / max(post_rollup, 1)
-                _logger.info(
+                log.info(
                     "search under-fill: %d chunks → %d sessions (collapse ratio %.1f); "
                     "consider retrieval tuning if this persists",
                     pre_rollup,
@@ -111,7 +112,7 @@ def search_sessions(
                 ordered_ids,
                 branch_scores={bid: branch_rrf_scores[bid] for bid in ordered_ids},
             )
-            _logger.info("Session search for %r returned %d result(s) (vector search on)", query, len(cards))
+            log.info("Session search for %r returned %d result(s) (vector search on)", query, len(cards))
             return cards, True
         except sqlite3.Error:
             # DB-level failure in the fusion path: degrade to keyword search
@@ -130,7 +131,7 @@ def search_sessions(
     deduped_ids = dedup_by_session(cursor, [bid for bid, _score in fts_rows])
     ordered_ids = deduped_ids[:max_results]
     cards = hydrate_cards(cursor, ordered_ids, branch_scores=branch_scores)
-    _logger.info("Session search for %r returned %d result(s) (vector search off)", query, len(cards))
+    log.info("Session search for %r returned %d result(s) (vector search off)", query, len(cards))
     return cards, ranked
 
 
@@ -176,7 +177,7 @@ def search_messages(
 
     ordered = raw[:max_results]
     snippets = hydrate_snippets(cursor, ordered)
-    _logger.info("Message search for %r returned %d snippet(s)", query, len(snippets))
+    log.info("Message search for %r returned %d snippet(s)", query, len(snippets))
     return snippets, True
 
 
@@ -198,5 +199,5 @@ def compute_caveat(conn: sqlite3.Connection) -> str | None:
             return f"{pct}% of history embedded; results may be partial"
         return None
     except Exception:
-        _logger.exception("caveat computation failed")
+        log.exception("caveat computation failed")
         return None

--- a/src/ccrecall/search_conversations.py
+++ b/src/ccrecall/search_conversations.py
@@ -12,7 +12,7 @@ from ccrecall.embeddings import embed_text, model_available
 from ccrecall.fusion import rrf_scored
 from ccrecall.health import RECALL_CAVEAT_COVERAGE_THRESHOLD
 from ccrecall.search_hydrate import dedup_by_session, hydrate_cards
-from ccrecall.search_query import get_fts_branch_ids
+from ccrecall.search_query import EMPTY_SCOPE, ScopeFilter, get_fts_branch_ids
 from ccrecall.search_vector import execute_chunk_knn, get_vec_chunk_ids, hydrate_snippets
 
 _logger = logging.getLogger("ccrecall")
@@ -34,12 +34,8 @@ def search_sessions(
     query: str,
     fts_level: str | None,
     max_results: int = 5,
-    projects: list[str] | None = None,
-    session_id: str | None = None,
-    path: str | None = None,
+    scope: ScopeFilter = EMPTY_SCOPE,
     keyword_only: bool = False,
-    before: str | None = None,
-    after: str | None = None,
 ) -> tuple[list[dict], bool]:
     """Search for sessions, returning (cards, ranked).
 
@@ -51,6 +47,7 @@ def search_sessions(
     results are fused from chunk-KNN and FTS via Reciprocal Rank Fusion. Degrades
     silently to the keyword path on any vec/embed error.
     """
+
     terms = query.split()
     if not terms:
         return [], False
@@ -82,30 +79,8 @@ def search_sessions(
 
     if use_fusion and query_vec is not None:
         try:
-            fts_ids = [
-                bid
-                for bid, _score in get_fts_branch_ids(
-                    cursor,
-                    query,
-                    fts_level,
-                    fts_top_k,
-                    projects=projects,
-                    session_id=session_id,
-                    path=path,
-                    before=before,
-                    after=after,
-                )
-            ]
-            chunk_results = get_vec_chunk_ids(
-                cursor,
-                query_vec,
-                chunk_top_k,
-                projects=projects,
-                session_id=session_id,
-                path=path,
-                before=before,
-                after=after,
-            )
+            fts_ids = [bid for bid, _score in get_fts_branch_ids(cursor, query, fts_level, fts_top_k, scope=scope)]
+            chunk_results = get_vec_chunk_ids(cursor, query_vec, chunk_top_k, scope=scope)
             vec_branch_ids = [r[0] for r in chunk_results]
 
             # Score-returning fusion — branch_id → rrf_score (higher = better)
@@ -149,17 +124,7 @@ def search_sessions(
     # (null scores, recency order). The fts4 rung is recency-ordered with no
     # relevance score in this landing, so it is also surfaced as unranked — a
     # deferred Track A gap (issue #35), not the contract's end state.
-    fts_rows = get_fts_branch_ids(
-        cursor,
-        query,
-        fts_level,
-        fts_top_k,
-        projects=projects,
-        session_id=session_id,
-        path=path,
-        before=before,
-        after=after,
-    )
+    fts_rows = get_fts_branch_ids(cursor, query, fts_level, fts_top_k, scope=scope)
     ranked = fts_level == "fts5" and bool(fts_rows)
     branch_scores = {bid: score for bid, score in fts_rows if score is not None} if ranked else None
     deduped_ids = dedup_by_session(cursor, [bid for bid, _score in fts_rows])
@@ -173,11 +138,7 @@ def search_messages(
     conn: sqlite3.Connection,
     query: str,
     max_results: int = 5,
-    projects: list[str] | None = None,
-    session_id: str | None = None,
-    path: str | None = None,
-    before: str | None = None,
-    after: str | None = None,
+    scope: ScopeFilter = EMPTY_SCOPE,
 ) -> tuple[list[dict], bool]:
     """Search for matched exchanges (Entrypoint B), returning (snippets, ranked).
 
@@ -189,6 +150,7 @@ def search_messages(
     indistinguishable from "no matches" at this layer, so both stay ranked=True.
     There is no keyword fallback for B in this landing — deferred to issue #34.
     """
+
     if not query.split():
         return [], False
 
@@ -206,17 +168,7 @@ def search_messages(
     top_k = max(max_results * OVERFETCH_MULTIPLIER, OVERFETCH_FLOOR)
     cursor = conn.cursor()
 
-    raw = execute_chunk_knn(
-        cursor,
-        query_vec,
-        top_k,
-        projects=projects,
-        session_id=session_id,
-        path=path,
-        before=before,
-        after=after,
-        target_results=max_results,
-    )
+    raw = execute_chunk_knn(cursor, query_vec, top_k, scope=scope, target_results=max_results)
     if not raw:
         # Either no matches or a DB error caught inside execute_chunk_knn;
         # both cases return ranked=True (vec was available but yielded nothing).

--- a/src/ccrecall/search_hydrate.py
+++ b/src/ccrecall/search_hydrate.py
@@ -2,6 +2,7 @@
 
 import sqlite3
 
+from ccrecall.db import has_tool_counts
 from ccrecall.serialization import decode_json_column
 
 # Fallback topic truncation for a recall card when no precomputed topic exists.
@@ -55,11 +56,8 @@ def hydrate_cards(
     if not branch_ids:
         return []
 
-    # Guard tool_counts column — absent on DBs created before it was added
-    cursor.execute("PRAGMA table_info(branches)")
-    branch_col_names = {row[1] for row in cursor.fetchall()}
-    has_tool_counts = "tool_counts" in branch_col_names
-    tool_counts_col = ", b.tool_counts" if has_tool_counts else ""
+    has_tc = has_tool_counts(cursor)
+    tool_counts_col = ", b.tool_counts" if has_tc else ""
 
     placeholders = ",".join("?" * len(branch_ids))
     rows = cursor.execute(
@@ -84,7 +82,7 @@ def hydrate_cards(
         if row is None:
             continue
 
-        if has_tool_counts:
+        if has_tc:
             (
                 _branch_db_id,
                 session_uuid,
@@ -116,7 +114,7 @@ def hydrate_cards(
         # Prefer join columns for list metadata; parse summary for topic
         files_modified: list = decode_json_column(files_json, [])
         commits: list = decode_json_column(commits_json, [])
-        tool_counts: dict = decode_json_column(tool_counts_json, {}) if has_tool_counts else {}
+        tool_counts: dict = decode_json_column(tool_counts_json, {}) if has_tc else {}
 
         topic: str | None = None
         summary = decode_json_column(summary_json, {})

--- a/src/ccrecall/search_query.py
+++ b/src/ccrecall/search_query.py
@@ -4,15 +4,11 @@ Owns the scope filter clause shared by every search rung (FTS, LIKE, chunk-KNN)
 and the keyword branch-id lookup that ranks or recency-orders on it.
 """
 
-import logging
 import re
 import sqlite3
 from dataclasses import dataclass
 
 from ccrecall.db import escape_like
-from ccrecall.models import LOGGER_NAME
-
-log = logging.getLogger(LOGGER_NAME)
 
 
 @dataclass(frozen=True)

--- a/src/ccrecall/search_query.py
+++ b/src/ccrecall/search_query.py
@@ -6,6 +6,7 @@ and the keyword branch-id lookup that ranks or recency-orders on it.
 
 import re
 import sqlite3
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 from ccrecall.db import escape_like
@@ -13,13 +14,22 @@ from ccrecall.db import escape_like
 
 @dataclass(frozen=True)
 class ScopeFilter:
-    """Immutable bag of scope-narrowing parameters shared across search/recent paths."""
+    """Immutable bag of scope-narrowing parameters shared across search/recent paths.
 
-    projects: list[str] | None = None
+    ``projects`` accepts any sequence at construction (callers commonly pass a
+    ``list[str]``) but is normalized to a tuple in ``__post_init__`` — frozen=True
+    only blocks reassigning the field, not mutating a list stored in it.
+    """
+
+    projects: Sequence[str] | None = None
     session_id: str | None = None
     path: str | None = None
     before: str | None = None
     after: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.projects is not None:
+            object.__setattr__(self, "projects", tuple(self.projects))
 
 
 EMPTY_SCOPE = ScopeFilter()

--- a/src/ccrecall/search_query.py
+++ b/src/ccrecall/search_query.py
@@ -4,10 +4,29 @@ Owns the scope filter clause shared by every search rung (FTS, LIKE, chunk-KNN)
 and the keyword branch-id lookup that ranks or recency-orders on it.
 """
 
+import logging
 import re
 import sqlite3
+from dataclasses import dataclass
 
 from ccrecall.db import escape_like
+from ccrecall.models import LOGGER_NAME
+
+log = logging.getLogger(LOGGER_NAME)
+
+
+@dataclass(frozen=True)
+class ScopeFilter:
+    """Immutable bag of scope-narrowing parameters shared across search/recent paths."""
+
+    projects: list[str] | None = None
+    session_id: str | None = None
+    path: str | None = None
+    before: str | None = None
+    after: str | None = None
+
+
+EMPTY_SCOPE = ScopeFilter()
 
 
 def sanitize_fts_term(term: str) -> str:
@@ -33,46 +52,36 @@ def sanitize_fts_term(term: str) -> str:
     return re.sub(r"\s+", " ", sanitized).strip()
 
 
-def scope_filter_clause(
-    *,
-    projects: list[str] | None,
-    session_id: str | None,
-    path: str | None,
-    before: str | None = None,
-    after: str | None = None,
-) -> tuple[str, list]:
+def scope_filter_clause(scope: ScopeFilter) -> tuple[str, list]:
     """Return (sql_fragment, params) for the project/session/path/date WHERE filters.
 
     The fragment assumes the query's FROM aliases sessions as ``s``, projects
     as ``p``, and branches as ``b``. The fragment leads with a space when
     non-empty; params are ordered projects -> session -> path -> before -> after
     to match the clause order. Single source of truth for the scope predicates
-    shared by the FTS, LIKE, and chunk-KNN queries. before/after filter on
-    b.started_at (branch-level, matching recent_chats.py's convention) and are
-    assumed already validated by dates.validate_date_boundaries — this function
-    does not parse or reformat them, only compares them lexicographically.
-    recent_chats.py's get_recent_sessions builds an equivalent before/after
-    clause inline (it doesn't route its filters through this helper) — keep
-    both in sync if the comparison semantics ever change.
+    shared by the FTS, LIKE, chunk-KNN, and recent-chats queries. before/after
+    filter on b.started_at (branch-level) and are assumed already validated by
+    dates.validate_date_boundaries — this function does not parse or reformat
+    them, only compares them lexicographically.
     """
     clauses: list[str] = []
     params: list = []
-    if projects:
-        placeholders = ",".join("?" * len(projects))
+    if scope.projects:
+        placeholders = ",".join("?" * len(scope.projects))
         clauses.append(f"p.name IN ({placeholders})")
-        params.extend(projects)
-    if session_id:
+        params.extend(scope.projects)
+    if scope.session_id:
         clauses.append("s.uuid LIKE ? ESCAPE '\\'")
-        params.append(f"{escape_like(session_id)}%")
-    if path:
+        params.append(f"{escape_like(scope.session_id)}%")
+    if scope.path:
         clauses.append("s.cwd LIKE ? ESCAPE '\\'")
-        params.append(f"%{escape_like(path)}%")
-    if before:
+        params.append(f"%{escape_like(scope.path)}%")
+    if scope.before:
         clauses.append("b.started_at < ?")
-        params.append(before)
-    if after:
+        params.append(scope.before)
+    if scope.after:
         clauses.append("b.started_at > ?")
-        params.append(after)
+        params.append(scope.after)
     fragment = "".join(f" AND {clause}" for clause in clauses)
     return fragment, params
 
@@ -82,11 +91,7 @@ def get_fts_branch_ids(
     query: str,
     fts_level: str | None,
     top_k: int,
-    projects: list[str] | None = None,
-    session_id: str | None = None,
-    path: str | None = None,
-    before: str | None = None,
-    after: str | None = None,
+    scope: ScopeFilter = EMPTY_SCOPE,
 ) -> list[tuple[int, float | None]]:
     """Return ordered (branch_id, score_raw) pairs from FTS or LIKE search.
 
@@ -125,9 +130,7 @@ def get_fts_branch_ids(
         """
         params.append(fts_query)
 
-        scope_sql, scope_params = scope_filter_clause(
-            projects=projects, session_id=session_id, path=path, before=before, after=after
-        )
+        scope_sql, scope_params = scope_filter_clause(scope)
         sql += scope_sql
         params.extend(scope_params)
 
@@ -150,9 +153,7 @@ def get_fts_branch_ids(
         """
         params.extend(f"%{term}%" for term in terms)
 
-        scope_sql, scope_params = scope_filter_clause(
-            projects=projects, session_id=session_id, path=path, before=before, after=after
-        )
+        scope_sql, scope_params = scope_filter_clause(scope)
         sql += scope_sql
         params.extend(scope_params)
 

--- a/src/ccrecall/search_vector.py
+++ b/src/ccrecall/search_vector.py
@@ -7,7 +7,7 @@ import sqlite_vec
 
 from ccrecall.embeddings import EMBEDDING_MODEL, EMBEDDING_VERSION
 from ccrecall.models import LOGGER_NAME
-from ccrecall.search_query import scope_filter_clause
+from ccrecall.search_query import EMPTY_SCOPE, ScopeFilter, scope_filter_clause
 
 log = logging.getLogger(LOGGER_NAME)
 
@@ -23,14 +23,7 @@ def _run_chunk_knn(cursor: sqlite3.Cursor, serialized: bytes, k: int) -> list[tu
     ).fetchall()
 
 
-def _scoped_current_chunk_filters(
-    *,
-    projects: list[str] | None,
-    session_id: str | None,
-    path: str | None,
-    before: str | None,
-    after: str | None,
-) -> tuple[str, str, list]:
+def _scoped_current_chunk_filters(scope: ScopeFilter) -> tuple[str, str, list]:
     joins_sql = """
         JOIN branches b ON ch.branch_id = b.id
         JOIN sessions s ON b.session_id = s.id
@@ -42,9 +35,7 @@ def _scoped_current_chunk_filters(
         AND b.is_active = 1
     """
     params: list = [EMBEDDING_VERSION, EMBEDDING_MODEL]
-    scope_sql, scope_filter_params = scope_filter_clause(
-        projects=projects, session_id=session_id, path=path, before=before, after=after
-    )
+    scope_sql, scope_filter_params = scope_filter_clause(scope)
     where_sql += scope_sql
     params.extend(scope_filter_params)
     return joins_sql, where_sql, params
@@ -53,21 +44,14 @@ def _scoped_current_chunk_filters(
 def _filter_chunk_knn_rows(
     cursor: sqlite3.Cursor,
     knn_rows: list[tuple[int, float]],
-    *,
-    projects: list[str] | None,
-    session_id: str | None,
-    path: str | None,
-    before: str | None,
-    after: str | None,
+    scope: ScopeFilter,
 ) -> list[tuple[int, int, float]]:
     if not knn_rows:
         return []
 
     chunk_ids = [row[0] for row in knn_rows]
     chunk_to_dist: dict[int, float] = {row[0]: row[1] for row in knn_rows}
-    joins_sql, where_sql, filter_tail_params = _scoped_current_chunk_filters(
-        projects=projects, session_id=session_id, path=path, before=before, after=after
-    )
+    joins_sql, where_sql, filter_tail_params = _scoped_current_chunk_filters(scope)
 
     chunk_to_branch: dict[int, int] = {}
     param_budget = MAX_SQL_BOUND_PARAMS - len(filter_tail_params)
@@ -96,16 +80,9 @@ def _count_total_vec_candidates(cursor: sqlite3.Cursor) -> int:
 
 def _count_eligible_scoped_current_chunks(
     cursor: sqlite3.Cursor,
-    *,
-    projects: list[str] | None,
-    session_id: str | None,
-    path: str | None,
-    before: str | None,
-    after: str | None,
+    scope: ScopeFilter,
 ) -> int:
-    joins_sql, where_sql, params = _scoped_current_chunk_filters(
-        projects=projects, session_id=session_id, path=path, before=before, after=after
-    )
+    joins_sql, where_sql, params = _scoped_current_chunk_filters(scope)
     sql = f"SELECT COUNT(*) FROM chunks ch JOIN chunk_vec cv ON cv.chunk_id = ch.id {joins_sql} WHERE 1=1 {where_sql}"
     row = cursor.execute(sql, params).fetchone()
     return row[0] if row is not None else 0
@@ -115,11 +92,7 @@ def execute_chunk_knn(
     cursor: sqlite3.Cursor,
     query_vec: list[float],
     top_k: int,
-    projects: list[str] | None = None,
-    session_id: str | None = None,
-    path: str | None = None,
-    before: str | None = None,
-    after: str | None = None,
+    scope: ScopeFilter = EMPTY_SCOPE,
     target_results: int | None = None,
 ) -> list[tuple[int, int, float]]:
     """Shared chunk-KNN core: adaptively retry vec MATCH until filtered results fill the target.
@@ -157,15 +130,7 @@ def execute_chunk_knn(
             return []
 
         try:
-            filtered_rows = _filter_chunk_knn_rows(
-                cursor,
-                knn_rows,
-                projects=projects,
-                session_id=session_id,
-                path=path,
-                before=before,
-                after=after,
-            )
+            filtered_rows = _filter_chunk_knn_rows(cursor, knn_rows, scope)
         except sqlite3.Error:
             log.exception("chunk KNN filter failed")
             return []
@@ -175,14 +140,7 @@ def execute_chunk_knn(
 
         if eligible_candidates is None:
             try:
-                eligible_candidates = _count_eligible_scoped_current_chunks(
-                    cursor,
-                    projects=projects,
-                    session_id=session_id,
-                    path=path,
-                    before=before,
-                    after=after,
-                )
+                eligible_candidates = _count_eligible_scoped_current_chunks(cursor, scope)
             except sqlite3.Error:
                 log.exception("eligible chunk count query failed")
                 return []
@@ -220,11 +178,7 @@ def get_vec_chunk_ids(
     cursor: sqlite3.Cursor,
     query_vec: list[float],
     top_k: int,
-    projects: list[str] | None = None,
-    session_id: str | None = None,
-    path: str | None = None,
-    before: str | None = None,
-    after: str | None = None,
+    scope: ScopeFilter = EMPTY_SCOPE,
 ) -> list[tuple[int, float, int]]:
     """Return ordered (branch_id, distance, chunk_id) from chunk-vec KNN (Entrypoint A).
 
@@ -232,9 +186,7 @@ def get_vec_chunk_ids(
     the first (closest) chunk per branch in KNN order. Returns empty list on DB
     error so the caller degrades to keyword search; non-DB bugs propagate.
     """
-    raw = execute_chunk_knn(
-        cursor, query_vec, top_k, projects=projects, session_id=session_id, path=path, before=before, after=after
-    )
+    raw = execute_chunk_knn(cursor, query_vec, top_k, scope=scope)
     if not raw:
         return []
 

--- a/src/ccrecall/status.py
+++ b/src/ccrecall/status.py
@@ -10,7 +10,7 @@ import sqlite3
 import sys
 from pathlib import Path
 
-from ccrecall.config import DEFAULT_DB_PATH, get_db_path, load_settings
+from ccrecall.config import DEFAULT_DB_PATH, get_db_path, load_settings_for_db
 from ccrecall.db import get_connection
 from ccrecall.db_vec import branch_embedding_coverage, chunk_vec_queryable, vec_available
 from ccrecall.hooks.backfill_status import count_status as count_embedding_status
@@ -19,13 +19,6 @@ from ccrecall.ingestion_status import summarize_ingestion
 from ccrecall.tool_content_status import count_eligible as count_tool_content_pending
 from ccrecall.tool_content_status import count_pending_missing_jsonl
 from ccrecall.tool_content_status import count_total_sessions as count_tool_content_total
-
-
-def _settings_for_db(db: Path) -> dict:
-    settings = load_settings()
-    if db != DEFAULT_DB_PATH:
-        settings["db_path"] = str(db)
-    return settings
 
 
 @contextlib.contextmanager
@@ -76,7 +69,7 @@ def count_branch_invariant_violations(conn: sqlite3.Connection) -> int:
 
 def collect_status(*, db: Path = DEFAULT_DB_PATH, days: int | None = None, check_ingestion: bool = False) -> dict:
     """Collect status across DB, ingestion, tool content, and embeddings."""
-    settings = _settings_for_db(db)
+    settings = load_settings_for_db(db)
     db_path = get_db_path(settings)
     ingestion = None
 

--- a/src/ccrecall/status.py
+++ b/src/ccrecall/status.py
@@ -16,15 +16,9 @@ from ccrecall.db_vec import branch_embedding_coverage, chunk_vec_queryable, vec_
 from ccrecall.hooks.backfill_status import count_status as count_embedding_status
 from ccrecall.import_log_ops import import_log_source_index
 from ccrecall.ingestion_status import summarize_ingestion
-from ccrecall.tool_content_status import (
-    count_eligible as count_tool_content_pending,
-)
-from ccrecall.tool_content_status import (
-    count_pending_missing_jsonl,
-)
-from ccrecall.tool_content_status import (
-    count_total_sessions as count_tool_content_total,
-)
+from ccrecall.tool_content_status import count_eligible as count_tool_content_pending
+from ccrecall.tool_content_status import count_pending_missing_jsonl
+from ccrecall.tool_content_status import count_total_sessions as count_tool_content_total
 
 
 def _settings_for_db(db: Path) -> dict:

--- a/tests/test_backfill_embeddings.py
+++ b/tests/test_backfill_embeddings.py
@@ -214,7 +214,7 @@ def _run_backfill_with_stub(conn: sqlite3.Connection, *, days=None, limit=None):
             "ccrecall.hooks.backfill_embeddings.get_connection",
             return_value=_NoCloseConn(conn),
         ),
-        patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
+        patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
         patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
         # Patch clear so the success path never touches the real ~/.ccrecall sidecar.
         patch("ccrecall.hooks.backfill_embeddings.clear_embedding_failure"),
@@ -256,7 +256,7 @@ class TestBackfillEmbedsFull:
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
             patch("ccrecall.embed_ops.embed_batch", side_effect=lambda texts: [_FIXED_VEC] * len(texts)),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
             patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
         ):
             exit_code = run()
@@ -347,7 +347,7 @@ class TestBackfillResume:
                 patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
                 patch("ccrecall.embed_ops.embed_batch", side_effect=counting_embed),
                 patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
-                patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
+                patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
                 patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
             ):
                 run()
@@ -470,7 +470,7 @@ class TestBackfillNoProgressGuard:
             # no-op: row never advanced; return_value=0 so total_inferences stays an int
             patch("ccrecall.hooks.backfill_embeddings.embed_branch_chunks", return_value=0),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
             patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
         ):
             run()  # must return, not hang
@@ -528,7 +528,7 @@ class TestBackfillFailureModes:
         with (
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=False),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
         ):
             run()
 
@@ -557,7 +557,7 @@ class TestBackfillFailureModes:
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
             patch("ccrecall.embed_ops.embed_batch", side_effect=counting_embed),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
             patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
         ):
             run()
@@ -584,7 +584,7 @@ class TestBackfillFailureModes:
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
             patch("ccrecall.embed_ops.embed_batch", side_effect=infra_fail),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
             patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
         ):
             run()
@@ -611,7 +611,7 @@ class TestBackfillFailureModes:
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
             patch("ccrecall.embed_ops.embed_batch", side_effect=counting_embed),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
             patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
         ):
             run()
@@ -632,7 +632,7 @@ class TestBackfillFailureModes:
                 side_effect=sqlite3.OperationalError("disk I/O error"),
             ),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
             patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
         ):
             exit_code = run()
@@ -750,7 +750,7 @@ def _run_status(conn: sqlite3.Connection, capsys, *, json_mode=False, days=None)
     """Invoke run(status=True, ...) against conn; return captured stdout."""
     with (
         patch("ccrecall.hooks.backfill_status.get_connection", return_value=_NoCloseConn(conn)),
-        patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
+        patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
     ):
         code = run(status=True, json_mode=json_mode, days=days)
     assert code == 0
@@ -868,7 +868,7 @@ class TestBackfillInferencesCounter:
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
             patch("ccrecall.embed_ops.embed_batch", side_effect=lambda texts: [_FIXED_VEC] * len(texts)),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
             patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
             patch("builtins.print", side_effect=capturing_print),
         ):
@@ -899,7 +899,7 @@ class TestBackfillEmbeddingStatusRecording:
 
         with (
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=False),
-            patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
             patch(
                 "ccrecall.hooks.backfill_embeddings.record_embedding_failure",
                 side_effect=patched_record(sidecar),
@@ -923,7 +923,7 @@ class TestBackfillEmbeddingStatusRecording:
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=mock_conn),
             patch("ccrecall.hooks.backfill_embeddings.chunk_vec_queryable", return_value=False),
-            patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
             patch(
                 "ccrecall.hooks.backfill_embeddings.record_embedding_failure",
                 side_effect=patched_record(sidecar),
@@ -950,7 +950,7 @@ class TestBackfillEmbeddingStatusRecording:
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
             patch("ccrecall.embed_ops.embed_batch", side_effect=lambda texts: [_FIXED_VEC] * len(texts)),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
             patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
             patch(
                 "ccrecall.hooks.backfill_embeddings.clear_embedding_failure",
@@ -976,7 +976,7 @@ class TestBackfillEmbeddingStatusRecording:
         with (
             patch("ccrecall.hooks.backfill_status.get_connection", return_value=mock_conn),
             patch("ccrecall.hooks.backfill_status.chunk_vec_queryable", return_value=False),
-            patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
             patch(
                 "ccrecall.hooks.backfill_embeddings.record_embedding_failure",
                 side_effect=lambda reason: record_calls.append(reason),
@@ -1111,7 +1111,7 @@ class TestBackfillETAProgress:
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
             patch("ccrecall.embed_ops.embed_batch", side_effect=lambda texts: [_FIXED_VEC] * len(texts)),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
             patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
             patch("ccrecall.hooks.backfill_embeddings.clear_embedding_failure"),
         ):
@@ -1133,7 +1133,7 @@ class TestBackfillETAProgress:
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
             patch("ccrecall.embed_ops.embed_batch", side_effect=lambda texts: [_FIXED_VEC] * len(texts)),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
             patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
             patch("ccrecall.hooks.backfill_embeddings.clear_embedding_failure"),
         ):
@@ -1160,7 +1160,7 @@ class TestBackfillETAProgress:
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
             patch("ccrecall.embed_ops.embed_batch", side_effect=always_fail),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_embeddings.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
             patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
             patch("ccrecall.hooks.backfill_embeddings.clear_embedding_failure"),
         ):

--- a/tests/test_backfill_embeddings.py
+++ b/tests/test_backfill_embeddings.py
@@ -15,6 +15,7 @@ import builtins
 import json
 import os
 import sqlite3
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -755,6 +756,19 @@ def _run_status(conn: sqlite3.Connection, capsys, *, json_mode=False, days=None)
         code = run(status=True, json_mode=json_mode, days=days)
     assert code == 0
     return capsys.readouterr().out
+
+
+def test_run_forwards_custom_db_path_to_load_settings():
+    """A custom db= argument reaches load_settings_for_db unchanged — regression
+    guard against silently routing work to the default database."""
+    conn = make_vec_conn()
+    custom_path = Path("/tmp/custom-embed.db")
+    with (
+        patch("ccrecall.hooks.backfill_status.get_connection", return_value=_NoCloseConn(conn)),
+        patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}) as mock_load,
+    ):
+        run(status=True, json_mode=True, db=custom_path)
+    mock_load.assert_called_once_with(custom_path)
 
 
 @_VEC_SKIP

--- a/tests/test_backfill_tool_content.py
+++ b/tests/test_backfill_tool_content.py
@@ -79,7 +79,7 @@ def _seed_session(
 def _run_backfill(conn: sqlite3.Connection, *, days=None, limit=None, status=False, json_mode=False):
     with (
         patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
-        patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
+        patch("ccrecall.hooks.backfill_tool_content.load_settings_for_db", return_value={}),
         patch("ccrecall.hooks.backfill_tool_content.time.sleep"),
     ):
         return run(status=status, json_mode=json_mode, days=days, limit=limit)
@@ -380,7 +380,7 @@ class TestBackfillEmptyEntries:
 
         with (
             patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_tool_content.load_settings_for_db", return_value={}),
         ):
             run(status=True, json_mode=True)
         status = json.loads(capsys.readouterr().out)
@@ -471,7 +471,7 @@ class TestBackfillStatus:
 
         with (
             patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_tool_content.load_settings_for_db", return_value={}),
         ):
             code = run(status=True, json_mode=True)
         assert code == EXIT_OK
@@ -494,7 +494,7 @@ class TestBackfillStatus:
 
         with (
             patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_tool_content.load_settings_for_db", return_value={}),
         ):
             code = run(status=True, json_mode=True)
         assert code == EXIT_OK
@@ -514,7 +514,7 @@ class TestBackfillStatus:
 
         with (
             patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_tool_content.load_settings_for_db", return_value={}),
         ):
             run(status=True, json_mode=True)
 
@@ -531,7 +531,7 @@ class TestBackfillStatus:
 
         with (
             patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_tool_content.load_settings_for_db", return_value={}),
         ):
             run(status=True, json_mode=True)
 
@@ -761,7 +761,7 @@ class TestTransientDbLock:
 
         with (
             patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_tool_content.load_settings_for_db", return_value={}),
             patch("ccrecall.hooks.backfill_tool_content.time.sleep"),
             patch("ccrecall.hooks.backfill_tool_content.backfill_session", side_effect=_bombing_backfill),
         ):
@@ -813,7 +813,7 @@ class TestTransientDbLock:
 
         with (
             patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_tool_content.load_settings_for_db", return_value={}),
             patch("ccrecall.hooks.backfill_tool_content.time.sleep"),
             patch("ccrecall.hooks.backfill_tool_content.backfill_session", side_effect=_flaky_backfill),
         ):
@@ -867,7 +867,7 @@ class TestStuckSessionExclusion:
 
         with (
             patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_tool_content.load_settings_for_db", return_value={}),
             patch("ccrecall.hooks.backfill_tool_content.time.sleep"),
             patch("ccrecall.hooks.backfill_tool_content.select_batch", side_effect=_rigged_select),
             patch("ccrecall.hooks.backfill_tool_content.backfill_session", side_effect=_noop_backfill),
@@ -910,7 +910,7 @@ class TestStuckSessionExclusion:
 
         with (
             patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_tool_content.load_settings_for_db", return_value={}),
             patch("ccrecall.hooks.backfill_tool_content.time.sleep"),
             patch("ccrecall.hooks.backfill_tool_content.select_batch", side_effect=_rigged_select),
             patch("ccrecall.hooks.backfill_tool_content.backfill_session", side_effect=_fake_backfill),
@@ -988,7 +988,7 @@ class TestOrphanedUuidQuiescence:
 
         with (
             patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_tool_content.load_settings_for_db", return_value={}),
         ):
             run(status=True, json_mode=True)
         status = json.loads(capsys.readouterr().out)
@@ -1015,7 +1015,7 @@ class TestNonLockOperationalErrorFailsFast:
 
         with (
             patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
-            patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
+            patch("ccrecall.hooks.backfill_tool_content.load_settings_for_db", return_value={}),
             patch("ccrecall.hooks.backfill_tool_content.time.sleep"),
             patch("ccrecall.hooks.backfill_tool_content.backfill_session", side_effect=_raise_schema_error),
         ):

--- a/tests/test_backfill_tool_content.py
+++ b/tests/test_backfill_tool_content.py
@@ -85,6 +85,18 @@ def _run_backfill(conn: sqlite3.Connection, *, days=None, limit=None, status=Fal
         return run(status=status, json_mode=json_mode, days=days, limit=limit)
 
 
+def test_run_forwards_custom_db_path_to_load_settings(memory_db, capsys):
+    """A custom db= argument reaches load_settings_for_db unchanged — regression
+    guard against silently routing work to the default database."""
+    custom_path = Path("/tmp/custom-tool-content.db")
+    with (
+        patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(memory_db)),
+        patch("ccrecall.hooks.backfill_tool_content.load_settings_for_db", return_value={}) as mock_load,
+    ):
+        run(status=True, json_mode=True, db=custom_path)
+    mock_load.assert_called_once_with(custom_path)
+
+
 # UPDATE path + INSERT path + aggregated_content + embedding_version reset
 
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -68,7 +68,7 @@ class TestCmdBackfillSummaries:
     def test_calls_run_with_verbose(self):
         with patch("ccrecall.cli.commands.backfill_summaries_mod.run") as mock_run:
             cmd_backfill_summaries(ctx=DEFAULT_CLI_CONTEXT)
-        mock_run.assert_called_once_with(verbose=False)
+        mock_run.assert_called_once_with(verbose=False, db=DEFAULT_DB_PATH)
 
 
 class TestCmdBackfillToolContent:
@@ -92,6 +92,7 @@ class TestCmdBackfillToolContent:
             limit=None,
             progress_every=backfill_query_mod.DEFAULT_PROGRESS_EVERY,
             verbose=False,
+            db=DEFAULT_DB_PATH,
         )
 
 
@@ -99,7 +100,7 @@ class TestCmdRecent:
     def test_calls_run_with_parsed_arguments(self):
         with patch("ccrecall.cli.commands.recent_chats_mod.run") as mock_run:
             cmd_recent(
-                n=3,
+                limit=3,
                 sort_order="desc",
                 before=None,
                 after=None,
@@ -172,6 +173,7 @@ class TestCmdSearchMessages:
                 path=None,
                 before=None,
                 after=None,
+                verbose=False,
                 include_notifications=False,
                 db=DEFAULT_DB_PATH,
                 ctx=DEFAULT_CLI_CONTEXT,
@@ -185,6 +187,7 @@ class TestCmdSearchMessages:
             before=None,
             after=None,
             output_format="markdown",
+            verbose=False,
             include_notifications=False,
             db=DEFAULT_DB_PATH,
         )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -352,7 +352,7 @@ class TestFTSIncludesToolContent:
 def _run_backfill(conn: sqlite3.Connection, **kwargs):
     with (
         patch("ccrecall.hooks.backfill_tool_content.get_connection", return_value=NoCloseConn(conn)),
-        patch("ccrecall.hooks.backfill_tool_content.load_settings", return_value={}),
+        patch("ccrecall.hooks.backfill_tool_content.load_settings_for_db", return_value={}),
         patch("ccrecall.hooks.backfill_tool_content.time.sleep"),
     ):
         return run_backfill_tool_content(**kwargs)

--- a/tests/test_recent_chats.py
+++ b/tests/test_recent_chats.py
@@ -15,6 +15,7 @@ from conftest import make_vec_conn
 
 from ccrecall.recent_chats import get_recent_sessions
 from ccrecall.recent_chats import run as recent_chats_run
+from ccrecall.search_query import ScopeFilter
 
 
 def _seed_sessions(conn: sqlite3.Connection) -> list[str]:
@@ -152,11 +153,11 @@ class TestRecentChatsInvariant:
         """project filter works correctly with embedding columns present."""
         _seed_sessions(memory_db)
 
-        results = get_recent_sessions(memory_db, n=10, projects=["proj"])
+        results = get_recent_sessions(memory_db, n=10, scope=ScopeFilter(projects=["proj"]))
         assert len(results) == 3
         assert all(r["project"] == "proj" for r in results)
 
-        results_no_match = get_recent_sessions(memory_db, n=10, projects=["nonexistent"])
+        results_no_match = get_recent_sessions(memory_db, n=10, scope=ScopeFilter(projects=["nonexistent"]))
         assert len(results_no_match) == 0
 
 
@@ -172,31 +173,33 @@ class TestRecentChatsDateFilters:
 
     def test_after_exact_instant_excludes_that_session_and_earlier(self, memory_db):
         _seed_sessions(memory_db)
-        results = get_recent_sessions(memory_db, n=10, after="2025-01-01T10:00:00Z")
+        results = get_recent_sessions(memory_db, n=10, scope=ScopeFilter(after="2025-01-01T10:00:00Z"))
         assert {r["uuid"] for r in results} == {"sess-rc-2", "sess-rc-3"}
 
     def test_before_exact_instant_excludes_that_session_and_later(self, memory_db):
         _seed_sessions(memory_db)
-        results = get_recent_sessions(memory_db, n=10, before="2025-01-03T10:00:00Z")
+        results = get_recent_sessions(memory_db, n=10, scope=ScopeFilter(before="2025-01-03T10:00:00Z"))
         assert {r["uuid"] for r in results} == {"sess-rc-1", "sess-rc-2"}
 
     def test_before_and_after_combine_to_a_range(self, memory_db):
         _seed_sessions(memory_db)
-        results = get_recent_sessions(memory_db, n=10, after="2025-01-01T10:00:00Z", before="2025-01-03T10:00:00Z")
+        results = get_recent_sessions(
+            memory_db, n=10, scope=ScopeFilter(after="2025-01-01T10:00:00Z", before="2025-01-03T10:00:00Z")
+        )
         assert {r["uuid"] for r in results} == {"sess-rc-2"}
 
     def test_bare_date_after_includes_sessions_starting_that_day_onward(self, memory_db):
         # "2025-01-02T10:00:00Z" > "2025-01-02" lexicographically, so a bare
         # date --after is inclusive of that whole day.
         _seed_sessions(memory_db)
-        results = get_recent_sessions(memory_db, n=10, after="2025-01-02")
+        results = get_recent_sessions(memory_db, n=10, scope=ScopeFilter(after="2025-01-02"))
         assert {r["uuid"] for r in results} == {"sess-rc-2", "sess-rc-3"}
 
     def test_bare_date_before_excludes_sessions_starting_that_day(self, memory_db):
         # "2025-01-02T10:00:00Z" is NOT < "2025-01-02" lexicographically, so a
         # bare date --before excludes that whole day (only strictly earlier days).
         _seed_sessions(memory_db)
-        results = get_recent_sessions(memory_db, n=10, before="2025-01-02")
+        results = get_recent_sessions(memory_db, n=10, scope=ScopeFilter(before="2025-01-02"))
         assert {r["uuid"] for r in results} == {"sess-rc-1"}
 
     def test_no_filter_returns_all_sessions(self, memory_db):
@@ -206,7 +209,7 @@ class TestRecentChatsDateFilters:
 
     def test_filter_matching_nothing_returns_empty(self, memory_db):
         _seed_sessions(memory_db)
-        results = get_recent_sessions(memory_db, n=10, after="2030-01-01")
+        results = get_recent_sessions(memory_db, n=10, scope=ScopeFilter(after="2030-01-01"))
         assert results == []
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -22,6 +22,7 @@ from ccrecall.schema import SCHEMA, SCHEMA_CORE, detect_fts_support
 from ccrecall.search_cli import format_markdown, print_status, run, run_messages
 from ccrecall.search_conversations import OVERFETCH_FLOOR, compute_caveat, search_messages, search_sessions
 from ccrecall.search_hydrate import dedup_by_session, hydrate_cards
+from ccrecall.search_query import ScopeFilter
 from ccrecall.search_vector import execute_chunk_knn, get_vec_chunk_ids
 
 
@@ -203,7 +204,9 @@ class TestSearchSessionsFTS:
         if fts_level not in ("fts5", "fts4"):
             pytest.skip("FTS not available")
 
-        results, _ranked = search_sessions(search_db, "pytest", fts_level, max_results=10, projects=["alpha"])
+        results, _ranked = search_sessions(
+            search_db, "pytest", fts_level, max_results=10, scope=ScopeFilter(projects=["alpha"])
+        )
         assert all(r["project"] == "alpha" for r in results), "Should only return alpha project"
         assert len(results) >= 1
 
@@ -227,7 +230,9 @@ class TestSearchSessionsFTS:
         if fts_level not in ("fts5", "fts4"):
             pytest.skip("FTS not available")
 
-        results, _ranked = search_sessions(search_db, "pytest", fts_level, max_results=10, session_id="sess-alpha-1")
+        results, _ranked = search_sessions(
+            search_db, "pytest", fts_level, max_results=10, scope=ScopeFilter(session_id="sess-alpha-1")
+        )
         assert len(results) == 1
         assert results[0]["session_uuid"] == "sess-alpha-1"
 
@@ -236,7 +241,9 @@ class TestSearchSessionsFTS:
         if fts_level not in ("fts5", "fts4"):
             pytest.skip("FTS not available")
 
-        results, _ranked = search_sessions(search_db, "pytest", fts_level, max_results=10, session_id="sess")
+        results, _ranked = search_sessions(
+            search_db, "pytest", fts_level, max_results=10, scope=ScopeFilter(session_id="sess")
+        )
         uuids = {r["session_uuid"] for r in results}
         assert len(results) == 2
         assert "sess-alpha-1" in uuids
@@ -247,7 +254,9 @@ class TestSearchSessionsFTS:
         if fts_level not in ("fts5", "fts4"):
             pytest.skip("FTS not available")
 
-        results, _ranked = search_sessions(search_db, "pytest", fts_level, max_results=10, session_id="nonexistent")
+        results, _ranked = search_sessions(
+            search_db, "pytest", fts_level, max_results=10, scope=ScopeFilter(session_id="nonexistent")
+        )
         assert len(results) == 0
 
 
@@ -314,7 +323,9 @@ class TestSearchSessionsLIKE:
         assert "sess-beta-1" not in uuids  # has "pytest" but not "fixtures"
 
     def test_like_project_filter(self, search_db):
-        results, _ranked = search_sessions(search_db, "pytest", fts_level=None, max_results=10, projects=["beta"])
+        results, _ranked = search_sessions(
+            search_db, "pytest", fts_level=None, max_results=10, scope=ScopeFilter(projects=["beta"])
+        )
         assert all(r["project"] == "beta" for r in results)
 
     def test_like_empty_query(self, search_db):
@@ -326,7 +337,9 @@ class TestSearchSessionsLIKE:
         assert len(results) <= 1
 
     def test_like_session_filter(self, search_db):
-        results, _ranked = search_sessions(search_db, "pytest", fts_level=None, max_results=10, session_id="sess-beta")
+        results, _ranked = search_sessions(
+            search_db, "pytest", fts_level=None, max_results=10, scope=ScopeFilter(session_id="sess-beta")
+        )
         assert len(results) == 1
         assert results[0]["session_uuid"] == "sess-beta-1"
 
@@ -428,22 +441,22 @@ class TestRecentChatsSessionFilter:
     """Test --session filter on get_recent_sessions."""
 
     def test_session_filter_exact(self, search_db):
-        results = get_recent_sessions(search_db, n=10, session_id="sess-alpha-1")
+        results = get_recent_sessions(search_db, n=10, scope=ScopeFilter(session_id="sess-alpha-1"))
         assert len(results) == 1
         assert results[0]["uuid"] == "sess-alpha-1"
 
     def test_session_filter_prefix(self, search_db):
-        results = get_recent_sessions(search_db, n=10, session_id="sess-alpha")
+        results = get_recent_sessions(search_db, n=10, scope=ScopeFilter(session_id="sess-alpha"))
         assert len(results) == 2
         uuids = {r["uuid"] for r in results}
         assert uuids == {"sess-alpha-1", "sess-alpha-2"}
 
     def test_session_filter_no_match(self, search_db):
-        results = get_recent_sessions(search_db, n=10, session_id="nonexistent")
+        results = get_recent_sessions(search_db, n=10, scope=ScopeFilter(session_id="nonexistent"))
         assert len(results) == 0
 
     def test_session_filter_short_prefix(self, search_db):
-        results = get_recent_sessions(search_db, n=10, session_id="sess")
+        results = get_recent_sessions(search_db, n=10, scope=ScopeFilter(session_id="sess"))
         assert len(results) == 3
 
 
@@ -451,28 +464,28 @@ class TestPathFilter:
     """Test --path filter on both get_recent_sessions and search_sessions."""
 
     def test_recent_path_worktree_name(self, search_db):
-        results = get_recent_sessions(search_db, n=10, path="ui-decomp")
+        results = get_recent_sessions(search_db, n=10, scope=ScopeFilter(path="ui-decomp"))
         assert len(results) == 1
         assert results[0]["uuid"] == "sess-alpha-2"
 
     def test_recent_path_no_match(self, search_db):
-        results = get_recent_sessions(search_db, n=10, path="nonexistent-worktree")
+        results = get_recent_sessions(search_db, n=10, scope=ScopeFilter(path="nonexistent-worktree"))
         assert len(results) == 0
 
     def test_recent_path_substring_matches_base_and_worktrees(self, search_db):
         """Substring match on a repo path includes worktrees under it."""
-        results = get_recent_sessions(search_db, n=10, path="/home/user/alpha")
+        results = get_recent_sessions(search_db, n=10, scope=ScopeFilter(path="/home/user/alpha"))
         assert len(results) == 2
         uuids = {r["uuid"] for r in results}
         assert uuids == {"sess-alpha-1", "sess-alpha-2"}
 
     def test_recent_path_combined_with_project(self, search_db):
-        results = get_recent_sessions(search_db, n=10, projects=["alpha"], path="ui-decomp")
+        results = get_recent_sessions(search_db, n=10, scope=ScopeFilter(projects=["alpha"], path="ui-decomp"))
         assert len(results) == 1
         assert results[0]["uuid"] == "sess-alpha-2"
 
     def test_recent_path_project_mismatch(self, search_db):
-        results = get_recent_sessions(search_db, n=10, projects=["beta"], path="ui-decomp")
+        results = get_recent_sessions(search_db, n=10, scope=ScopeFilter(projects=["beta"], path="ui-decomp"))
         assert len(results) == 0
 
     def test_search_path_fts(self, search_db):
@@ -480,12 +493,16 @@ class TestPathFilter:
         if fts_level not in ("fts5", "fts4"):
             pytest.skip("FTS not available")
 
-        results, _ranked = search_sessions(search_db, "database", fts_level, max_results=10, path="ui-decomp")
+        results, _ranked = search_sessions(
+            search_db, "database", fts_level, max_results=10, scope=ScopeFilter(path="ui-decomp")
+        )
         assert len(results) == 1
         assert results[0]["session_uuid"] == "sess-alpha-2"
 
     def test_search_path_like_fallback(self, search_db):
-        results, _ranked = search_sessions(search_db, "database", fts_level=None, max_results=10, path="ui-decomp")
+        results, _ranked = search_sessions(
+            search_db, "database", fts_level=None, max_results=10, scope=ScopeFilter(path="ui-decomp")
+        )
         assert len(results) == 1
         assert results[0]["session_uuid"] == "sess-alpha-2"
 
@@ -495,7 +512,9 @@ class TestPathFilter:
             pytest.skip("FTS not available")
 
         all_pytest, _r1 = search_sessions(search_db, "pytest", fts_level, max_results=10)
-        with_path, _r2 = search_sessions(search_db, "pytest", fts_level, max_results=10, path="/home/user/beta")
+        with_path, _r2 = search_sessions(
+            search_db, "pytest", fts_level, max_results=10, scope=ScopeFilter(path="/home/user/beta")
+        )
         assert len(with_path) < len(all_pytest)
         assert all(r["session_uuid"] == "sess-beta-1" for r in with_path)
 
@@ -993,11 +1012,7 @@ class TestAdaptiveChunkKnn:
         results = search_vector._filter_chunk_knn_rows(
             cursor,
             knn_rows,
-            projects=["proj"],
-            session_id=None,
-            path=None,
-            before=None,
-            after=None,
+            ScopeFilter(projects=["proj"]),
         )
 
         filter_param_lengths = [
@@ -1029,11 +1044,7 @@ class TestAdaptiveChunkKnn:
         results = search_vector._filter_chunk_knn_rows(
             cursor,
             [(chunk_id, 0.0)],
-            projects=["proj"],
-            session_id=None,
-            path=None,
-            before=None,
-            after=None,
+            ScopeFilter(projects=["proj"]),
         )
 
         assert results == []
@@ -1108,7 +1119,7 @@ class TestAdaptiveChunkKnnScopes:
             project="alpha",
         )
 
-        results = execute_chunk_knn(conn.cursor(), query_vec, top_k=1, projects=["alpha"])
+        results = execute_chunk_knn(conn.cursor(), query_vec, top_k=1, scope=ScopeFilter(projects=["alpha"]))
 
         assert len(results) == 1
         assert results[0][:2] == (valid_chunk_id, valid_branch_id)
@@ -1135,7 +1146,7 @@ class TestAdaptiveChunkKnnScopes:
             embed_vec=far_vec,
         )
 
-        results = execute_chunk_knn(conn.cursor(), query_vec, top_k=1, session_id="sess_100%")
+        results = execute_chunk_knn(conn.cursor(), query_vec, top_k=1, scope=ScopeFilter(session_id="sess_100%"))
 
         assert len(results) == 1
         assert results[0][:2] == (valid_chunk_id, valid_branch_id)
@@ -1164,7 +1175,7 @@ class TestAdaptiveChunkKnnScopes:
             cwd="/home/user/worktrees/feature_%/repo",
         )
 
-        results = execute_chunk_knn(conn.cursor(), query_vec, top_k=1, path="feature_%")
+        results = execute_chunk_knn(conn.cursor(), query_vec, top_k=1, scope=ScopeFilter(path="feature_%"))
 
         assert len(results) == 1
         assert results[0][:2] == (valid_chunk_id, valid_branch_id)
@@ -1200,7 +1211,7 @@ class TestAdaptiveChunkKnnScopes:
             started_at="2025-01-01T10:00:00Z",
         )
 
-        results = execute_chunk_knn(conn.cursor(), query_vec, top_k=1, before="2025-03-01")
+        results = execute_chunk_knn(conn.cursor(), query_vec, top_k=1, scope=ScopeFilter(before="2025-03-01"))
 
         assert len(results) == 1
         assert results[0][:2] == (valid_chunk_id, valid_branch_id)
@@ -1236,7 +1247,7 @@ class TestAdaptiveChunkKnnScopes:
             started_at="2025-06-01T10:00:00Z",
         )
 
-        results = execute_chunk_knn(conn.cursor(), query_vec, top_k=1, after="2025-03-01")
+        results = execute_chunk_knn(conn.cursor(), query_vec, top_k=1, scope=ScopeFilter(after="2025-03-01"))
 
         assert len(results) == 1
         assert results[0][:2] == (valid_chunk_id, valid_branch_id)
@@ -1276,8 +1287,7 @@ class TestAdaptiveChunkKnnScopes:
             conn.cursor(),
             query_vec,
             top_k=1,
-            session_id="sess_combo%",
-            before="2025-03-01",
+            scope=ScopeFilter(session_id="sess_combo%", before="2025-03-01"),
         )
 
         assert len(results) == 1
@@ -1331,7 +1341,9 @@ class TestSearchSessionsFusionScopeRetry:
             patch("ccrecall.search_conversations.embed_text", return_value=query_vec),
             patch("ccrecall.search_conversations.rrf_scored", wraps=rrf_scored) as fusion_mock,
         ):
-            results, ranked = search_sessions(conn, query, fts_level, max_results=1, projects=["alpha"])
+            results, ranked = search_sessions(
+                conn, query, fts_level, max_results=1, scope=ScopeFilter(projects=["alpha"])
+            )
 
         fusion_inputs = fusion_mock.call_args.args[0]
         assert target_branch_id in fusion_inputs[0]
@@ -2062,7 +2074,7 @@ class TestSearchMessages:
                 return_value=[{"session_uuid": "sess", "exchange_index": 0}],
             ),
         ):
-            search_messages(conn, "test query", max_results=2, projects=["alpha"])
+            search_messages(conn, "test query", max_results=2, scope=ScopeFilter(projects=["alpha"]))
 
         assert execute_mock.call_args.kwargs["target_results"] == 2
         assert execute_mock.call_args.args[2] == OVERFETCH_FLOOR
@@ -2113,7 +2125,7 @@ class TestSearchMessages:
             patch("ccrecall.search_conversations.model_available", return_value=True),
             patch("ccrecall.search_conversations.embed_text", return_value=query_vec),
         ):
-            snippets, ranked = search_messages(conn, "test query", max_results=2, projects=["alpha"])
+            snippets, ranked = search_messages(conn, "test query", max_results=2, scope=ScopeFilter(projects=["alpha"]))
 
         assert ranked is True
         assert [snippet["session_uuid"] for snippet in snippets] == ["sess-alpha-mid", "sess-alpha-far"]
@@ -2542,14 +2554,14 @@ class TestSearchSessionsDateFilters:
 
     def test_before_excludes_later_session(self, dated_search_db):
         results, _ranked = search_sessions(
-            dated_search_db, "pytest", fts_level=None, max_results=10, before="2025-03-01"
+            dated_search_db, "pytest", fts_level=None, max_results=10, scope=ScopeFilter(before="2025-03-01")
         )
         uuids = {r["session_uuid"] for r in results}
         assert uuids == {"sess-dated-old"}
 
     def test_after_excludes_earlier_session(self, dated_search_db):
         results, _ranked = search_sessions(
-            dated_search_db, "pytest", fts_level=None, max_results=10, after="2025-03-01"
+            dated_search_db, "pytest", fts_level=None, max_results=10, scope=ScopeFilter(after="2025-03-01")
         )
         uuids = {r["session_uuid"] for r in results}
         assert uuids == {"sess-dated-new"}
@@ -2558,7 +2570,11 @@ class TestSearchSessionsDateFilters:
         # Neither branch's started_at (2025-01-01, 2025-06-01) falls inside
         # this window -- proves the two clauses actually AND together.
         results, _ranked = search_sessions(
-            dated_search_db, "pytest", fts_level=None, max_results=10, after="2025-02-01", before="2025-03-01"
+            dated_search_db,
+            "pytest",
+            fts_level=None,
+            max_results=10,
+            scope=ScopeFilter(after="2025-02-01", before="2025-03-01"),
         )
         assert results == []
 
@@ -2607,7 +2623,9 @@ class TestSearchMessagesDateFilters:
             patch("ccrecall.search_conversations.model_available", return_value=True),
             patch("ccrecall.search_conversations.embed_text", return_value=query_vec),
         ):
-            snippets, ranked = search_messages(conn, "test query", max_results=10, before="2025-03-01")
+            snippets, ranked = search_messages(
+                conn, "test query", max_results=10, scope=ScopeFilter(before="2025-03-01")
+            )
 
         assert ranked is True
         assert {s["session_uuid"] for s in snippets} == {"sess-msg-old"}

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -711,14 +711,18 @@ class TestBackfillErrorHandling:
         conn.close()
 
     def _run_with_raise(self, path, monkeypatch, exc):
-        monkeypatch.setattr(backfill_summaries, "load_settings_for_db", lambda db: {"db_path": str(path)})
+        def load_settings_for_db(db):
+            assert db == path, "db argument must be forwarded to load_settings_for_db unchanged"
+            return {"db_path": str(path)}
+
+        monkeypatch.setattr(backfill_summaries, "load_settings_for_db", load_settings_for_db)
         monkeypatch.setattr(backfill_summaries, "setup_logging", lambda s, **kwargs: logging.getLogger("test-backfill"))
 
         def boom(cursor, branch_id):
             raise exc
 
         monkeypatch.setattr(backfill_summaries, "compute_context_summary", boom)
-        backfill_summaries._main()
+        backfill_summaries._main(db=path)
 
     def _version(self, path):
         conn = sqlite3.connect(str(path))
@@ -794,10 +798,14 @@ class TestSummaryMaintenance:
         conn.commit()
         conn.close()
 
-        monkeypatch.setattr(backfill_summaries, "load_settings_for_db", lambda db_arg: {"db_path": str(db)})
+        def load_settings_for_db(db_arg):
+            assert db_arg == db, "db argument must be forwarded to load_settings_for_db unchanged"
+            return {"db_path": str(db)}
+
+        monkeypatch.setattr(backfill_summaries, "load_settings_for_db", load_settings_for_db)
         monkeypatch.setattr(backfill_summaries, "setup_logging", lambda s, **kwargs: logging.getLogger("test-backfill"))
 
-        backfill_summaries._main()
+        backfill_summaries._main(db=db)
 
         conn = sqlite3.connect(str(db))
         version = conn.execute("SELECT summary_version FROM branches WHERE id = ?", (branch_id,)).fetchone()[0]
@@ -817,7 +825,7 @@ class TestSummaryMaintenance:
             "compute_context_summary",
             lambda _cursor, _branch_id: (_ for _ in ()).throw(ValueError("bad")),
         )
-        backfill_summaries._main()
+        backfill_summaries._main(db=db)
 
         conn = sqlite3.connect(str(db))
         row = conn.execute(

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -711,7 +711,7 @@ class TestBackfillErrorHandling:
         conn.close()
 
     def _run_with_raise(self, path, monkeypatch, exc):
-        monkeypatch.setattr(backfill_summaries, "load_settings", lambda: {"db_path": str(path)})
+        monkeypatch.setattr(backfill_summaries, "load_settings_for_db", lambda db: {"db_path": str(path)})
         monkeypatch.setattr(backfill_summaries, "setup_logging", lambda s, **kwargs: logging.getLogger("test-backfill"))
 
         def boom(cursor, branch_id):
@@ -794,7 +794,7 @@ class TestSummaryMaintenance:
         conn.commit()
         conn.close()
 
-        monkeypatch.setattr(backfill_summaries, "load_settings", lambda: {"db_path": str(db)})
+        monkeypatch.setattr(backfill_summaries, "load_settings_for_db", lambda db_arg: {"db_path": str(db)})
         monkeypatch.setattr(backfill_summaries, "setup_logging", lambda s, **kwargs: logging.getLogger("test-backfill"))
 
         backfill_summaries._main()


### PR DESCRIPTION
### Pattern Consolidation

- Introduced `ScopeFilter` (in `search_query.py`) to replace the repeated `projects`/`session_id`/`path`/`before`/`after` kwargs threaded through `search_vector`, `search_query`, `search_conversations`, `search_cli`, and `recent_chats` — one shared dataclass and `scope_filter_clause()` builder instead of five call sites each hand-rolling the same WHERE-clause assembly, so the before/after comparison semantics can't drift between callers the way the old inline copy in `recent_chats.py` risked.
- Added a shared `has_tool_counts` helper in `db.py`, replacing two identical `PRAGMA table_info` checks (in `recent_chats.py` and `search_conversations.py`) for whether a DB predates the `tool_counts` column.
- Moved the `reclaim_memory`/`try_load_libc` malloc_trim pattern into `hooks/subprocess_utils.py`, replacing near-duplicate private copies in `backfill_embeddings.py` and `import_conversations.py`. Same RSS discipline (gc + malloc_trim between batches so peaks don't accumulate across a run), now with one implementation instead of two.
- Added `config.load_settings_for_db(db)` so the `status` and `backfill` CLI paths share one settings-override merge for a non-default `--db` path instead of each re-implementing it.

### CLI Flag Consistency

- Dropped the redundant `--n` long-form alias everywhere it duplicated `--max-results`/`--limit`/`--lines` (kept `-n` as the short flag). `recent`'s long form is renamed `--n` → `--limit` for clarity, since it wasn't the same axis as `search`'s `--max-results -n`.
- Added `--verbose` to `search-messages` for CLI symmetry with `recent` and `search` (accepted but a no-op there, since snippet text is already pre-bounded — documented in `tool-reference.md`).
- Added `--db` to all three `backfill` subcommands (`summaries`, `embeddings`, `tool-content`) so they can target a non-default database the same way `status` already could.
- Updated skill docs (`SKILL.md`, `lenses.md`, `tool-reference.md`) and the CLI help epilogue to match the new flag names.

### Logging

- Added `getLogger` declarations to `db_base.py` (migration debug), `session_selection.py` (corrupt/unreadable handoff file debug), `search_query.py`, and `recent_chats.py`. Modules with zero log call sites were left without logger declarations rather than adding dead loggers speculatively.

### Housekeeping

- Follow-up commit addresses clean-code review findings on the above: tightened test assertions in `test_backfill_embeddings.py`/`test_backfill_tool_content.py`/`test_integration.py`/`test_summarizer.py`, and minor cleanup in `config.py`, `backfill_embeddings.py`, `backfill_summaries.py`, `backfill_tool_content.py`, `recent_chats.py`, `search_conversations.py`, `search_query.py`, and `status.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backfill commands now support selecting a specific database.
  * Search-message commands now support the verbose option.
  * Search and recent-session commands provide consistent filtering options.

* **Updates**
  * Replaced the deprecated `--n` option with `--limit` for recent-session retrieval.
  * Removed the deprecated long `--n` alias from search and tail commands.
  * Standardized filtering across session, message, and vector searches.
  * Added clearer debug logging for schema migrations and invalid handoff files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->