### PR TITLE
fix: warn when database schema is ahead of SCHEMA_VERSION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ## 2026-08-24
 
 - fix a memory spike in sync-current that could freeze the machine (7.5 GB observed) by capping sync-path embedding at 4096 tokens, dropping the worst-case peak to ~4 GB (#166)
+- warn when a database's schema version is ahead of what the running code expects, instead of silently treating it as fully migrated (#167)
 
 ## 2026-08-19
 

--- a/src/ccrecall/db_base.py
+++ b/src/ccrecall/db_base.py
@@ -270,6 +270,27 @@ def _migrate_to_v8(conn: sqlite3.Connection) -> None:
     conn.execute("CREATE INDEX IF NOT EXISTS idx_chunks_cap_tokens ON chunks(cap_tokens) WHERE cap_tokens IS NOT NULL")
 
 
+def _warn_if_schema_ahead(current: int) -> None:
+    """Log a WARNING if the database's stored version exceeds this code's SCHEMA_VERSION.
+
+    A database ahead of SCHEMA_VERSION (e.g. from a reverted feature branch that
+    bumped it and stamped a real database) is otherwise indistinguishable from a
+    fully-migrated one, and its actual structure may not match what its stored
+    version implies — see #156.
+    """
+    if current <= SCHEMA_VERSION:
+        return
+    log.warning(
+        "database schema is ahead of this code's SCHEMA_VERSION — skipping the "
+        "version-gated reshape migrations (v1/v2) rather than rebuild a table "
+        "this code doesn't know the shape of; additive column/table checks "
+        "(v3-v8) still run as no-ops. If this wasn't intentional (e.g. a reverted "
+        "feature branch that bumped SCHEMA_VERSION), this database's actual "
+        "structure may not match what its stored version implies",
+        extra={"db_user_version": current, "code_schema_version": SCHEMA_VERSION},
+    )
+
+
 def _apply_migrations(
     conn: sqlite3.Connection,
     *,
@@ -277,24 +298,9 @@ def _apply_migrations(
     migrate_to_v1: Callable[[sqlite3.Connection], None] = _migrate_to_v1,
     migrate_to_v2: Callable[[sqlite3.Connection], None] = _migrate_to_v2,
 ) -> None:
-    """Apply version-gated schema migrations up to SCHEMA_VERSION, atomically.
-
-    If the database's stored version is already ahead of SCHEMA_VERSION, logs a
-    WARNING and skips the version-gated reshape migrations (v1/v2) rather than
-    touch a schema shape this code doesn't know about — see #156.
-    """
+    """Apply version-gated schema migrations up to SCHEMA_VERSION, atomically."""
     current = conn.execute("PRAGMA user_version").fetchone()[0]
-
-    if current > SCHEMA_VERSION:
-        log.warning(
-            "database schema is ahead of this code's SCHEMA_VERSION — skipping the "
-            "version-gated reshape migrations (v1/v2) rather than rebuild a table "
-            "this code doesn't know the shape of; additive column/table checks "
-            "(v3-v8) still run as no-ops. If this wasn't intentional (e.g. a reverted "
-            "feature branch that bumped SCHEMA_VERSION), this database's actual "
-            "structure may not match what its stored version implies",
-            extra={"db_user_version": current, "code_schema_version": SCHEMA_VERSION},
-        )
+    _warn_if_schema_ahead(current)
 
     _migrate_to_v3(conn)
     _migrate_to_v4(conn)

--- a/src/ccrecall/db_base.py
+++ b/src/ccrecall/db_base.py
@@ -277,8 +277,24 @@ def _apply_migrations(
     migrate_to_v1: Callable[[sqlite3.Connection], None] = _migrate_to_v1,
     migrate_to_v2: Callable[[sqlite3.Connection], None] = _migrate_to_v2,
 ) -> None:
-    """Apply version-gated schema migrations up to SCHEMA_VERSION, atomically."""
+    """Apply version-gated schema migrations up to SCHEMA_VERSION, atomically.
+
+    If the database's stored version is already ahead of SCHEMA_VERSION, logs a
+    WARNING and skips the version-gated reshape migrations (v1/v2) rather than
+    touch a schema shape this code doesn't know about — see #156.
+    """
     current = conn.execute("PRAGMA user_version").fetchone()[0]
+
+    if current > SCHEMA_VERSION:
+        log.warning(
+            "database schema is ahead of this code's SCHEMA_VERSION — skipping the "
+            "version-gated reshape migrations (v1/v2) rather than rebuild a table "
+            "this code doesn't know the shape of; additive column/table checks "
+            "(v3-v8) still run as no-ops. If this wasn't intentional (e.g. a reverted "
+            "feature branch that bumped SCHEMA_VERSION), this database's actual "
+            "structure may not match what its stored version implies",
+            extra={"db_user_version": current, "code_schema_version": SCHEMA_VERSION},
+        )
 
     _migrate_to_v3(conn)
     _migrate_to_v4(conn)

--- a/src/ccrecall/db_base.py
+++ b/src/ccrecall/db_base.py
@@ -284,9 +284,12 @@ def _warn_if_schema_ahead(current: int) -> None:
         "database schema is ahead of this code's SCHEMA_VERSION — skipping the "
         "version-gated reshape migrations (v1/v2) rather than rebuild a table "
         "this code doesn't know the shape of; additive column/table checks "
-        "(v3-v8) still run as no-ops. If this wasn't intentional (e.g. a reverted "
-        "feature branch that bumped SCHEMA_VERSION), this database's actual "
-        "structure may not match what its stored version implies",
+        "(v3-v8) still run — they're guarded (IF NOT EXISTS / duplicate-column "
+        "handling) so they're safe regardless of this database's actual shape, "
+        "but are only true no-ops if it already has those columns/tables. If "
+        "this wasn't intentional (e.g. a reverted feature branch that bumped "
+        "SCHEMA_VERSION), this database's actual structure may not match what "
+        "its stored version implies",
         extra={"db_user_version": current, "code_schema_version": SCHEMA_VERSION},
     )
 
@@ -300,7 +303,6 @@ def _apply_migrations(
 ) -> None:
     """Apply version-gated schema migrations up to SCHEMA_VERSION, atomically."""
     current = conn.execute("PRAGMA user_version").fetchone()[0]
-    _warn_if_schema_ahead(current)
 
     _migrate_to_v3(conn)
     _migrate_to_v4(conn)
@@ -353,6 +355,14 @@ def open_connection(
     ensure_parent_dir(db_path)
     conn = sqlite3.connect(db_path)
     apply_base_pragmas(conn)
+
+    # Warn before running any schema DDL: an ahead-of-code database's actual
+    # structure may not match what SCHEMA_CORE expects (e.g. a column its
+    # CREATE INDEX statements reference could be gone), which would raise
+    # before _apply_migrations ever runs. Checking version first means the
+    # warning fires even in exactly the incompatible-schema case it exists
+    # to diagnose — see #156.
+    _warn_if_schema_ahead(conn.execute("PRAGMA user_version").fetchone()[0])
 
     fts = detect_fts_support(conn)
     conn.executescript(SCHEMA_CORE)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,6 +1,7 @@
 """Tests for ccrecall.db — schema creation, settings, and vec operations."""
 
 import json
+import logging
 import os
 import sqlite3
 import subprocess
@@ -1567,6 +1568,90 @@ class TestMigrationVersionMatrix:
             self._assert_post_migration(conn, start_version)
             surviving = conn.execute("SELECT COUNT(*) FROM sqlite_master WHERE name = 'chunk_vec'").fetchone()[0]
             assert surviving == 1, "chunk_vec must survive the migration"
+
+    def test_migration_at_current_version_is_noop(self, tmp_path, caplog):
+        """A DB already at SCHEMA_VERSION opens without touching the schema or warning.
+
+        Regression guard for #156: range(SCHEMA_VERSION) in the parametrized tests
+        above never exercises user_version == SCHEMA_VERSION, the normal steady state
+        every database reaches after its first full migration.
+        """
+        db_path = tmp_path / "current.db"
+        with get_connection(settings={"db_path": str(db_path)}) as conn:
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+
+        with (
+            caplog.at_level(logging.WARNING, logger="ccrecall"),
+            get_connection(settings={"db_path": str(db_path)}) as conn,
+        ):
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+
+        assert not any("ahead" in r.message for r in caplog.records)
+
+    def test_migration_ahead_of_code_warns_and_skips(self, tmp_path, caplog):
+        """A DB stamped ahead of SCHEMA_VERSION is left untouched and logs a WARNING.
+
+        Regression guard for #156: a DB whose user_version exceeds this code's
+        SCHEMA_VERSION (e.g. from a reverted feature branch that bumped it and
+        stamped a real database) must be detected and reported, not silently
+        treated as fully migrated.
+        """
+        db_path = tmp_path / "ahead.db"
+        with get_connection(settings={"db_path": str(db_path)}):
+            pass
+
+        raw = sqlite3.connect(db_path)
+        ahead_version = SCHEMA_VERSION + 2
+        raw.execute(f"PRAGMA user_version = {ahead_version}")
+        raw.commit()
+        raw.close()
+
+        with (
+            caplog.at_level(logging.WARNING, logger="ccrecall"),
+            get_connection(settings={"db_path": str(db_path)}) as conn,
+        ):
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == ahead_version
+            assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "ahead" in r.message
+            and getattr(r, "db_user_version", None) == ahead_version
+            and getattr(r, "code_schema_version", None) == SCHEMA_VERSION
+            for r in warnings
+        ), (
+            f"expected an ahead-of-code WARNING naming v{ahead_version}, got: {[(r.message, r.__dict__) for r in warnings]}"
+        )
+
+    def test_partial_migration_failure_rolls_back_cleanly(self, tmp_path):
+        """A migration that raises partway through leaves user_version and schema untouched.
+
+        Regression guard for #156: the reshape migrations (v1/v2) and their final
+        PRAGMA user_version stamp all run inside one BEGIN IMMEDIATE transaction.
+        If _migrate_to_v2 raises after _migrate_to_v1 already rebuilt `branches`,
+        the whole transaction must still roll back atomically — not leave the
+        database half-migrated with a version that lies about its actual shape
+        (the exact failure mode #156 is about).
+        """
+        db_path = tmp_path / "partial_fail.db"
+        self._build_db_at_version(db_path, 0)
+
+        def failing_migrate_to_v2(conn: sqlite3.Connection) -> None:
+            raise RuntimeError("boom")
+
+        def apply_migrations_callback(conn: sqlite3.Connection) -> None:
+            db_module.db_base._apply_migrations(conn, migrate_to_v2=failing_migrate_to_v2)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            db_module.db_base.open_connection(
+                settings={"db_path": str(db_path)}, apply_migrations_callback=apply_migrations_callback
+            )
+
+        raw = sqlite3.connect(db_path)
+        assert raw.execute("PRAGMA user_version").fetchone()[0] == 0
+        columns = {row[1] for row in raw.execute("PRAGMA table_info(branches)").fetchall()}
+        assert "fork_point_uuid" in columns, "v1's table rebuild must have rolled back"
+        raw.close()
 
 
 class TestSchemaEquivalencePin:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1601,7 +1601,7 @@ class TestMigrationVersionMatrix:
             pass
 
         raw = sqlite3.connect(db_path)
-        ahead_version = SCHEMA_VERSION + 2
+        ahead_version = SCHEMA_VERSION + 1  # smallest value that proves "ahead", not "equal"
         raw.execute(f"PRAGMA user_version = {ahead_version}")
         raw.commit()
         raw.close()


### PR DESCRIPTION
### Warn when database schema is ahead of SCHEMA_VERSION

`_apply_migrations` silently returned when a database's `PRAGMA user_version` was at or above `SCHEMA_VERSION`, with no logging — a database ahead of the running code's `SCHEMA_VERSION` (e.g. from a reverted feature branch that had bumped it and stamped a real database) was indistinguishable from a fully migrated one. This masked the incident behind #155, where a stranded database lost `branch_messages` links for 1,136 branches with no signal until search broke.

- Added `_warn_if_schema_ahead`, logging a WARNING (with structured `db_user_version`/`code_schema_version` extras) when the stored version exceeds `SCHEMA_VERSION`, explaining that the version-gated reshape migrations (v1/v2) are skipped while additive checks (v3-v8) still run as no-ops.
- Extracted the check into its own helper (rather than inlining it in `_apply_migrations`) per clean-code review, keeping the migration-gating function focused on sequencing.
- Added three regression tests: the steady-state at-current-version no-op (never previously exercised by the parametrized matrix, which stops at `range(SCHEMA_VERSION)`), the ahead-of-code warn-and-skip case, and atomic rollback verification when a migration raises partway through.

Closes #156


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added warnings when a database schema is newer than the running application expects.
  * Prevented newer schemas from being incorrectly treated as fully migrated.
  * Preserved additive migrations while safely skipping incompatible version-gated changes.
  * Ensured migration failures roll back earlier schema changes atomically.

* **Documentation**
  * Added a changelog entry describing the updated schema-version handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->