### PR TITLE
fix: recent --sort-order asc returns oldest sessions instead of recent-oldest-first

### DIFF
--- a/src/ccrecall/recent_chats.py
+++ b/src/ccrecall/recent_chats.py
@@ -48,12 +48,17 @@ def get_recent_sessions(
     scope_sql, params = scope_filter_clause(scope)
     sql += scope_sql
 
-    order = "DESC" if sort_order == "desc" else "ASC"
-    sql += f" ORDER BY b.ended_at {order} LIMIT ?"
+    # Always select the most-recent-N set first; `sort_order` is a
+    # presentation order over that set, applied after fetch (see below),
+    # not a different selection criterion. Selecting with ORDER BY ... ASC
+    # LIMIT n would instead return the oldest n sessions in the whole DB.
+    sql += " ORDER BY b.ended_at DESC LIMIT ?"
     params.append(n)
 
     cursor.execute(sql, params)
     sessions = cursor.fetchall()
+    if sort_order == "asc":
+        sessions = list(reversed(sessions))
 
     results = []
 

--- a/tests/test_recent_chats.py
+++ b/tests/test_recent_chats.py
@@ -131,6 +131,24 @@ class TestRecentChatsInvariant:
         # ended_at should be in descending order
         assert ended_ats == sorted(ended_ats, reverse=True)
 
+    def test_recent_chats_asc_returns_same_set_as_desc_reversed(self, memory_db):
+        """asc is a presentation order over the most-recent-N set, not a select-the-oldest-N query.
+
+        Regression for #176: sorting was applied before the LIMIT, so
+        `sort_order="asc"` returned the oldest N sessions in the whole DB
+        instead of the most recent N sessions, oldest-first.
+        """
+        _seed_sessions(memory_db)
+
+        desc_results = get_recent_sessions(memory_db, n=2, sort_order="desc")
+        asc_results = get_recent_sessions(memory_db, n=2, sort_order="asc")
+
+        desc_uuids = [r["uuid"] for r in desc_results]
+        asc_uuids = [r["uuid"] for r in asc_results]
+
+        assert asc_uuids == list(reversed(desc_uuids))
+        assert set(asc_uuids) == set(desc_uuids)
+
     def test_recent_chats_messages_unaffected(self, memory_db):
         """Messages are loaded correctly regardless of embedding columns on branches."""
         _seed_sessions(memory_db)


### PR DESCRIPTION
## Summary

`ccrecall recent --sort-order asc` returned the N **oldest sessions in the
whole database**, not the N most recent sessions in oldest-first order. The
query in `get_recent_sessions` (`src/ccrecall/recent_chats.py`) applied the
sort before the `LIMIT`:

```sql
ORDER BY b.ended_at {order} LIMIT ?
```

so with `order = "ASC"`, the limit clause cut off the *oldest* rows in the
table instead of the most recent ones — despite the command being named
"recent" and its docstring saying "Get n most recent sessions".

## Fix

Selection is now always `ORDER BY b.ended_at DESC LIMIT n` — the same
most-recent-N set is fetched regardless of `sort_order`. When
`sort_order == "asc"`, the fetched rows are reversed in Python before
formatting/serialization. `sort_order` is now purely a presentation-order
flag over the fixed most-recent-N set, not a different selection criterion.

## Test evidence

Added `test_recent_chats_asc_returns_same_set_as_desc_reversed` to
`tests/test_recent_chats.py`, asserting `recent -n 2 --sort-order asc` and
`recent -n 2 --sort-order desc` return the same set of sessions, with the
`asc` list equal to the reversed `desc` list.

- Confirmed RED against the pre-fix code (`git commit` for the test landed
  first): `AssertionError: assert ['sess-rc-1', 'sess-rc-2'] ==
  ['sess-rc-2', 'sess-rc-3']` — proving `asc` was selecting the oldest
  sessions in the DB, not the most recent ones.
- Confirmed GREEN after the fix: `tests/test_recent_chats.py` — 16 passed.
- Full suite: `uv run pytest -q` — 1315 passed, 2 skipped.
- Lint: `uvx prek run --all-files` — all hooks passed (ruff, pyright, custom
  checks) on the touched files.

Fixes #176
