### PR TITLE
fix: scope sync-current sidecar clear so model-unavailable alerts survive

### DIFF
--- a/src/ccrecall/health.py
+++ b/src/ccrecall/health.py
@@ -182,11 +182,28 @@ def record_embedding_failure(reason: str, path: Path | None = None) -> None:
     atomic_write_json(path, {"reason": reason, "since": Instant.now().format_iso()})
 
 
-def clear_embedding_failure(path: Path | None = None) -> None:
+def clear_embedding_failure(path: Path | None = None, reasons: set[str | None] | None = None) -> None:
     """Remove the embedding-capability-failure sidecar.
 
-    Called by the embedding process on a successful embed run. No-op if the
-    sidecar is already absent.
+    Called by the embedding process on a successful embed run (backfill) or a
+    successful structural check (sync-current). No-op if the sidecar is
+    already absent.
+
+    ``reasons`` scopes the clear to records whose "reason" field is in the
+    given set — a no-op (record left in place) when the current record's
+    reason is outside that scope. Default (None) clears unconditionally,
+    regardless of reason — this is what backfill wants, since it re-verifies
+    both the vec extension and the model.
+
+    This scoping exists because sync-current's vec-ok clear only proves
+    sqlite-vec is queryable, not that the embedding model itself is healthy —
+    a REASON_MODEL_UNAVAILABLE record written by backfill must survive a
+    vec-ok clear from sync-current, since sync-current never re-verified the
+    model (#164). sync-current passes ``reasons={None, REASON_VEC_UNAVAILABLE}``
+    so it only clears reasons its own check can actually vouch for; None is
+    included so a record with no/malformed "reason" field (which should never
+    happen given record_embedding_failure always writes one, but costs
+    nothing to tolerate) doesn't get stuck forever.
 
     Deliberately does NOT touch the snooze ledger — the ledger is written only
     by SessionStart hooks (design/specs/002-ccrecall-surfacing-model/design.md
@@ -206,6 +223,10 @@ def clear_embedding_failure(path: Path | None = None) -> None:
     """
     if path is None:
         path = EMBEDDING_STATUS_PATH
+    if reasons is not None:
+        current = read_embedding_status(path=path)
+        if current is not None and current.get("reason") not in reasons:
+            return
     path.unlink(missing_ok=True)
 
 

--- a/src/ccrecall/hooks/sync_current.py
+++ b/src/ccrecall/hooks/sync_current.py
@@ -38,6 +38,13 @@ from ccrecall.transcript_sources import discover_session_transcript_files
 
 _UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE)
 
+# Reasons a vec-ok clear here may erase. Scoped to what this hook's own
+# structural check (chunk_vec_queryable) actually verifies — REASON_VEC_UNAVAILABLE
+# and the no-reason/malformed-record case (None) — so a REASON_MODEL_UNAVAILABLE
+# record written by backfill (an orthogonal, unverified-here failure mode)
+# survives instead of being silently clobbered (#164).
+_VEC_OK_CLEAR_REASONS: set[str | None] = {None, REASON_VEC_UNAVAILABLE}
+
 # PID-file concurrency guard: at most one sync-current at a time.
 # Skip (not queue) if another is running — recovered on the next Stop.
 PID_KEY = "ccrecall-sync-current"
@@ -217,9 +224,12 @@ def run(input_file: Path | None = None) -> None:
             # Clear the embedding failure sidecar on a clean sync pass.
             # Only when vec was available — if it wasn't, we already recorded above
             # and must not clear until the next run where embedding can actually run.
+            # Scoped to _VEC_OK_CLEAR_REASONS: this check only verifies sqlite-vec,
+            # not the embedding model, so a model_unavailable record from backfill
+            # must not be erased here (#164).
             if vec_ok:
                 with contextlib.suppress(Exception):  # best-effort; must not affect hook behavior
-                    clear_embedding_failure()
+                    clear_embedding_failure(reasons=_VEC_OK_CLEAR_REASONS)
 
             # Output for hook (continue = True means don't block)
             output = {"continue": True}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,8 +67,12 @@ def patched_record(sidecar: Path):
 
 
 def patched_clear(sidecar: Path):
-    """side_effect redirecting clear_embedding_failure to a tmp sidecar path."""
-    return lambda: clear_embedding_failure(path=sidecar)
+    """side_effect redirecting clear_embedding_failure to a tmp sidecar path.
+
+    Forwards any kwargs (e.g. `reasons=`) so callers that scope the clear —
+    sync_current's vec-ok clear (#164) — still redirect to the tmp sidecar.
+    """
+    return lambda **kwargs: clear_embedding_failure(path=sidecar, **kwargs)
 
 
 def vec_available_in_env() -> bool:

--- a/tests/test_sync_hook.py
+++ b/tests/test_sync_hook.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from conftest import FIXTURE_DIR, patched_clear, patched_record
 
-from ccrecall.health import REASON_VEC_UNAVAILABLE
+from ccrecall.health import REASON_MODEL_UNAVAILABLE, REASON_VEC_UNAVAILABLE
 from ccrecall.hooks import memory_setup, memory_sync, sync_current
 from ccrecall.hooks.sync_current import sync_session, validate_session_id
 from ccrecall.recent_chats import run as recent_chats_run
@@ -1073,6 +1073,33 @@ class TestSyncEmbeddingStatusRecording:
 
         assert clear_calls == [], "clear must not be called when vec is unavailable"
         assert sidecar.exists(), "pre-seeded sidecar should remain when vec is unavailable"
+
+    def test_vec_ok_clear_does_not_erase_model_unavailable_reason(self, tmp_path, monkeypatch):
+        """Regression for #164: a vec-ok clear must not erase a model_unavailable record.
+
+        Scenario: backfill detects a broken fastembed install and records
+        REASON_MODEL_UNAVAILABLE. The next Stop hook's sync-current finds vec
+        queryable (an orthogonal check — sync-current never re-verifies the
+        model itself; embed failures there are swallowed by branch_ops and
+        never call record_embedding_failure). sync-current's clear must only
+        clear reasons its own vec check can actually verify, so the
+        model_unavailable record must survive.
+        """
+        sidecar = tmp_path / "embedding-status.json"
+        sidecar.write_text(json.dumps({"reason": REASON_MODEL_UNAVAILABLE, "since": "2026-01-01T00:00:00Z"}))
+
+        self._run_with_mock_conn(
+            tmp_path,
+            monkeypatch,
+            vec_queryable=True,
+            extra_patches={
+                "clear_embedding_failure": patched_clear(sidecar),
+            },
+        )
+
+        assert sidecar.exists(), "model_unavailable record must survive a vec-ok clear (#164)"
+        data = json.loads(sidecar.read_text())
+        assert data["reason"] == REASON_MODEL_UNAVAILABLE
 
     def test_recording_failure_does_not_break_hook(self, tmp_path, monkeypatch):
         """A sidecar write failure must not affect the hook's continue=true output."""


### PR DESCRIPTION
## Bug

`clear_embedding_failure()` took no reason argument, so sync-current's vec-ok clear could erase a `REASON_MODEL_UNAVAILABLE` alert that backfill correctly recorded.

**Scenario:**
1. Backfill detects a broken fastembed install and records `REASON_MODEL_UNAVAILABLE` in the embedding-status sidecar.
2. The next Stop hook's sync-current finds vec queryable (orthogonal to the model issue).
3. sync-current's `embed_branch_chunks` call fails with the same model issue, but `sync_branch`'s broad `except Exception` logs and swallows it — never calls `record_embedding_failure`.
4. sync-current calls `clear_embedding_failure()` unconditionally because `vec_ok` is true.
5. The next SessionStart shows no alert even though embeddings are still broken.

## Fix

`clear_embedding_failure()` in `health.py` gains an optional `reasons` scope parameter:

- Default (`None`) clears unconditionally — preserves backfill's full-clear behavior, since backfill re-verifies both the vec extension and the model.
- When provided, the clear is a no-op if the sidecar's current `reason` is outside the given set.

`sync_current.py` now passes `reasons={None, REASON_VEC_UNAVAILABLE}` on its vec-ok clear — scoped to what its own structural check (`chunk_vec_queryable`) actually verifies. A `model_unavailable` record now survives until backfill re-verifies the model and clears it.

`health.py` still imports nothing from vec/fastembed/onnxruntime (hot-path invariant #3 in `CLAUDE.md`) — the reason-code constants already lived there, so no new import was needed.

## Test evidence

Commit sequence follows RED → GREEN:

1. `test: reproduce #164 cross-reason sidecar clobber` — adds `TestSyncEmbeddingStatusRecording::test_vec_ok_clear_does_not_erase_model_unavailable_reason` in `tests/test_sync_hook.py`, which pre-seeds the sidecar with `REASON_MODEL_UNAVAILABLE` and asserts it survives a vec-ok sync-current run. Confirmed failing before the fix (asserted `sidecar.exists()` → `False`).
2. `fix: scope sync-current sidecar clear so model-unavailable alerts survive` — implements the `reasons` scope; the same test now passes.

Also updates `tests/conftest.py`'s `patched_clear` helper to forward kwargs so it can redirect the new `reasons=` argument to a tmp sidecar path (needed by the new test and by any future scoped-clear test).

Verification run on this branch:

```
uv run pytest tests/test_sync_hook.py tests/test_health.py tests/test_backfill_embeddings.py tests/test_context_injection.py -q
# 217 passed

uv run pytest -q
# 1314 passed, 2 skipped, 1 failed (tests/test_db.py::TestClaudeConfigDir::test_empty_env_var_falls_back_to_dot_claude)
# — confirmed unrelated: a subprocess-spawn timing flake under full-suite
#   parallel load (10s timeout), passes standalone in 1.02s.

uvx prek run --all-files
# all hooks passed
```

Fixes #164
