### PR TITLE
fix: emit envelope and can't-persist alert when ~/.ccrecall is unwritable

### DIFF
--- a/src/ccrecall/hooks/memory_context.py
+++ b/src/ccrecall/hooks/memory_context.py
@@ -16,12 +16,14 @@ Output: JSON with hookSpecificOutput for context injection
 
 import contextlib
 import json
+import logging
 import sys
 from typing import TYPE_CHECKING
 
 from pydantic import ValidationError
 
 from ccrecall.config import (
+    DEFAULT_SETTINGS,
     get_db_path,
     load_settings,
     log_hook_exception,
@@ -36,7 +38,7 @@ from ccrecall.hooks.context_rendering import (
     pending_question_block,
 )
 from ccrecall.hooks.session_selection import select_sessions
-from ccrecall.models import HookInput
+from ccrecall.models import LOGGER_NAME, HookInput
 
 if TYPE_CHECKING:
     import sqlite3
@@ -73,8 +75,24 @@ def _emit_with_proactive(proactive_block: str) -> None:
 
 
 def main():
-    settings = load_settings()
-    logger = setup_logging(settings, process_name="context")
+    settings = None
+    try:
+        settings = load_settings()
+        logger = setup_logging(settings, process_name="context")
+    except Exception:
+        # Logging setup is best-effort: a bad log path (unwritable ~/.ccrecall,
+        # disk full) must not crash the hook before it ever reads stdin or
+        # evaluates proactive_alert_block — that fault is exactly the
+        # ALERT_CANT_PERSIST condition this hook exists to report. Fall back to
+        # the bare named logger — with no handler attached it can't raise on
+        # .warning()/.exception() calls (stdlib routes WARNING+ through
+        # logging.lastResort to stderr instead) — and to default settings if
+        # load_settings() itself failed, so the settings.get(...) calls below
+        # still have a dict to work with. Mirrors memory_setup.main()'s guard.
+        log_hook_exception("context")
+        logger = logging.getLogger(LOGGER_NAME)
+        if settings is None:
+            settings = DEFAULT_SETTINGS.copy()
 
     raw = sys.stdin.read()
     try:

--- a/tests/test_context_injection.py
+++ b/tests/test_context_injection.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from unittest.mock import patch
 from uuid import uuid4
 
+from ccrecall.config import DEFAULT_SETTINGS
 from ccrecall.health import (
     ALERT_CANT_PERSIST,
     ALERT_EMBEDDINGS_FAILING,
@@ -1273,3 +1274,51 @@ class TestMemoryContextMalformedInput:
             "Malformed input has no session_id/cwd, so the full context-injection "
             "path (which always includes this directive) must not run"
         )
+
+
+class TestMemoryContextUnwritableRuntimeDir:
+    """Issue #175 regression: an unwritable ~/.ccrecall must not crash main()
+    before proactive_alert_block runs. ALERT_CANT_PERSIST is deliberately
+    evaluated before every early-return gate so it fires even when everything
+    else is broken — including load_settings()/setup_logging() themselves,
+    which previously crashed main() during setup, before stdin was even read.
+    """
+
+    def test_setup_logging_failure_still_emits_envelope_and_cant_persist_alert(self, tmp_path):
+        # A read-only runtime dir reproduces the real fault: setup_logging's
+        # RotatingFileHandler can't open its log file there (simulated directly
+        # via a monkeypatched raise, since the exact raise site doesn't matter
+        # to this test), and probe_filesystem's write probe genuinely fails
+        # against it — the autouse _isolated_runtime_dir fixture already points
+        # health.py's marker path at this directory, so no extra patching is
+        # needed for the alert to fire for real.
+        runtime_dir = tmp_path / "ccrecall-runtime"
+        runtime_dir.mkdir(parents=True, exist_ok=True)
+        runtime_dir.chmod(0o555)
+
+        fake_settings = {
+            **DEFAULT_SETTINGS,
+            "db_path": str(tmp_path / "elsewhere" / "conversations.db"),
+        }
+        stdin_data = json.dumps({"session_id": "sess-1", "cwd": str(tmp_path), "source": "startup"})
+        stdout_capture = io.StringIO()
+
+        def _boom(*_args, **_kwargs):
+            raise PermissionError("simulated unwritable ~/.ccrecall")
+
+        try:
+            with (
+                patch.object(sys, "stdin", io.StringIO(stdin_data)),
+                patch.object(sys, "stdout", stdout_capture),
+                patch.object(memory_context, "load_settings", return_value=fake_settings),
+                patch.object(memory_context, "setup_logging", side_effect=_boom),
+            ):
+                memory_context.main()
+        finally:
+            runtime_dir.chmod(0o755)
+
+        output = stdout_capture.getvalue()
+        parsed = json.loads(output)  # must be valid JSON — proves no crash / no garbage stdout
+        additional_context = parsed.get("hookSpecificOutput", {}).get("additionalContext", "")
+        assert "## ⚠" in additional_context, "Can't-persist alert must fire despite setup_logging failure"
+        assert "persist" in additional_context.lower() or "write" in additional_context.lower()


### PR DESCRIPTION
## Scenario

`ccrecall-context` (the SessionStart context hook) crashed with no stdout envelope on the exact fault its proactive-alert system exists to report: an unwritable `~/.ccrecall`.

`memory_context.main()` called `load_settings()` / `setup_logging()` unguarded at the top of `main()`. `setup_logging()` (`config.py`) does `ensure_parent_dir` and constructs a `RotatingFileHandler` without `delay=True`, so the log file is opened eagerly — an unwritable dir or `ENOSPC` raises there, before stdin is even read and before `proactive_alert_block()` (which owns the `ALERT_CANT_PERSIST` probe) ever runs.

`memory_setup.main()` and `clear_handoff.main()` both already guard this exact failure with a fallback logger and still emit their envelope. `memory_context.main()` did not.

## Fix

Wrapped `load_settings()`/`setup_logging()` in `memory_context.main()` in a `try/except`, mirroring the existing pattern in `memory_setup.py`/`clear_handoff.py`:

- On failure, log the exception best-effort via `log_hook_exception("context")`.
- Fall back to `logging.getLogger(LOGGER_NAME)` with no handler attached — `.warning()`/`.exception()` calls route through `logging.lastResort` to stderr instead of raising, and stdout stays untouched.
- Fall back to `DEFAULT_SETTINGS.copy()` when `load_settings()` itself failed, so downstream `settings.get(...)` calls still have a dict to work with.

Execution then continues normally: stdin is read, `proactive_alert_block()` runs (still evaluated before every early-return gate, so `ALERT_CANT_PERSIST` fires), and the hook emits a valid JSON envelope on stdout.

## Test evidence

Added `TestMemoryContextUnwritableRuntimeDir` in `tests/test_context_injection.py`, committed first as a RED test (failing without the fix — `setup_logging` raising propagated out of `main()` uncaught) and now green after the fix. The test makes the runtime dir read-only (reproducing the real fault for `probe_filesystem`) and monkeypatches `setup_logging` to raise, then asserts `main()` still prints a valid JSON envelope whose `additionalContext` contains the `## ⚠` can't-persist alert.

```
uv run pytest tests/test_context_injection.py -q
47 passed in 0.65s

uv run pytest -q
1315 passed, 2 skipped in 401.54s (0:06:41)

uvx prek run --all-files
uvx prek run --all-files --hook-stage pre-push
All hooks passed (ruff, typos, zizmor, no-mypy-ignore, no-future-annotations,
check-spec-tokens, check-llm-cruft, check-lazy-imports, pyright)
```

Fixes #175
