### PR TITLE
fix: surface branch_messages constraint violations instead of INSERT OR IGNORE

### DIFF
--- a/src/ccrecall/branch_ops.py
+++ b/src/ccrecall/branch_ops.py
@@ -185,9 +185,43 @@ def diff_branch_messages(
             (branch_db_id, *to_remove),
         )
     if to_add:
-        cursor.executemany(
-            "INSERT OR IGNORE INTO branch_messages (branch_id, message_id) VALUES (?, ?)",
-            [(branch_db_id, mid) for mid in to_add],
+        insert_branch_message_links(cursor, branch_db_id, to_add)
+
+
+def insert_branch_message_links(
+    cursor: sqlite3.Cursor,
+    branch_db_id: int,
+    message_ids: set[int],
+) -> None:
+    """Link messages to a branch with a plain INSERT, absorbing only duplicates.
+
+    INSERT OR IGNORE would also swallow NOT NULL/FK/CHECK violations — schema
+    drift then drops every link silently while the suite stays green (#155).
+    Callers pre-compute the missing set, so a duplicate link can only come
+    from a concurrent writer; that one case is logged and absorbed, every
+    other constraint violation raises at the point of damage.
+    """
+    for message_id in message_ids:
+        insert_branch_message_link(cursor, branch_db_id, message_id)
+
+
+def insert_branch_message_link(
+    cursor: sqlite3.Cursor,
+    branch_db_id: int,
+    message_id: int,
+) -> None:
+    """Insert one branch_messages link; absorb a duplicate, raise anything else."""
+    try:
+        cursor.execute(
+            "INSERT INTO branch_messages (branch_id, message_id) VALUES (?, ?)",
+            (branch_db_id, message_id),
+        )
+    except sqlite3.IntegrityError as exc:
+        if "UNIQUE constraint failed" not in str(exc):
+            raise
+        log.warning(
+            "duplicate branch_messages link absorbed",
+            extra={"branch_id": branch_db_id, "message_id": message_id},
         )
 
 

--- a/src/ccrecall/hooks/backfill_tool_content.py
+++ b/src/ccrecall/hooks/backfill_tool_content.py
@@ -66,6 +66,7 @@ import time
 from enum import Enum, auto
 from pathlib import Path
 
+from ccrecall.branch_ops import insert_branch_message_links
 from ccrecall.config import DEFAULT_DB_PATH, load_settings_for_db, setup_logging
 from ccrecall.content import extract_text_content
 from ccrecall.db import get_connection
@@ -532,13 +533,8 @@ def backfill_session(cursor: sqlite3.Cursor, session_id: int, filepaths: list[Pa
                 (session_id, *chunk),
             )
             uuid_to_msg_id.update({row[1]: row[0] for row in cursor.fetchall()})
-        for uuid in new_uuids:
-            msg_id = uuid_to_msg_id.get(uuid)
-            if msg_id:
-                cursor.execute(
-                    "INSERT OR IGNORE INTO branch_messages (branch_id, message_id) VALUES (?, ?)",
-                    (branch_db_id, msg_id),
-                )
+        link_ids = {msg_id for uuid in new_uuids if (msg_id := uuid_to_msg_id.get(uuid))}
+        insert_branch_message_links(cursor, branch_db_id, link_ids)
 
     # Rebuild aggregated_content from the branch's existing files/commits
     # metadata (unchanged by this backfill) plus the newly-populated tool

--- a/tests/test_branch_ops.py
+++ b/tests/test_branch_ops.py
@@ -1,0 +1,44 @@
+"""Tests for branch_ops link-table writes (#158).
+
+Every test database is normally built from SCHEMA_CORE, so the code's view of
+branch_messages and the table's real shape can never diverge in tests. These
+tests rebuild the table with drifted DDL on purpose, to assert that a link
+write which violates a constraint raises instead of being silently dropped
+(the failure mode that hid #155 for a week).
+"""
+
+import sqlite3
+
+import pytest
+
+from ccrecall.branch_ops import diff_branch_messages
+
+DRIFTED_BRANCH_MESSAGES_DDL = """
+CREATE TABLE branch_messages (
+  branch_id INTEGER NOT NULL,
+  message_id INTEGER NOT NULL,
+  position INTEGER NOT NULL,
+  PRIMARY KEY (branch_id, message_id)
+)
+"""
+
+
+def rebuild_branch_messages_with_drift(conn: sqlite3.Connection) -> None:
+    """Replace branch_messages with a version carrying an unexpected NOT NULL column."""
+    cursor = conn.cursor()
+    cursor.execute("DROP INDEX IF EXISTS idx_branch_messages_message")
+    cursor.execute("DROP TABLE branch_messages")
+    cursor.execute(DRIFTED_BRANCH_MESSAGES_DDL)
+    conn.commit()
+
+
+def test_diff_branch_messages_raises_on_constraint_violation(memory_db):
+    rebuild_branch_messages_with_drift(memory_db)
+    cursor = memory_db.cursor()
+
+    with pytest.raises(sqlite3.IntegrityError):
+        diff_branch_messages(cursor, 1, ["uuid-1"], {"uuid-1": 42})
+
+    # The write must not be silently dropped: either it lands or it raises.
+    cursor.execute("SELECT COUNT(*) FROM branch_messages")
+    assert cursor.fetchone()[0] == 0

--- a/tests/test_branch_ops.py
+++ b/tests/test_branch_ops.py
@@ -11,7 +11,7 @@ import sqlite3
 
 import pytest
 
-from ccrecall.branch_ops import diff_branch_messages
+from ccrecall.branch_ops import diff_branch_messages, insert_branch_message_links
 
 DRIFTED_BRANCH_MESSAGES_DDL = """
 CREATE TABLE branch_messages (
@@ -42,3 +42,50 @@ def test_diff_branch_messages_raises_on_constraint_violation(memory_db):
     # The write must not be silently dropped: either it lands or it raises.
     cursor.execute("SELECT COUNT(*) FROM branch_messages")
     assert cursor.fetchone()[0] == 0
+
+
+def seed_branch_with_message(conn: sqlite3.Connection) -> tuple[int, int]:
+    """Insert a project/session/branch/message chain; return (branch_id, message_id)."""
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO projects (path, key, name) VALUES (?, ?, ?)",
+        ("/home/user/proj", "-home-user-proj", "proj"),
+    )
+    cursor.execute(
+        "INSERT INTO sessions (uuid, project_id, cwd) VALUES (?, ?, ?)",
+        ("sess-bo-1", cursor.lastrowid, "/home/user/proj"),
+    )
+    sess_id = cursor.lastrowid
+    cursor.execute(
+        "INSERT INTO branches (session_id, leaf_uuid, is_active, exchange_count) VALUES (?, ?, 1, 1)",
+        (sess_id, "leaf-bo-1"),
+    )
+    branch_id = cursor.lastrowid
+    cursor.execute(
+        "INSERT INTO messages (session_id, uuid, role, content, timestamp) VALUES (?, ?, ?, ?, ?)",
+        (sess_id, "msg-bo-1", "user", "hello", "2025-01-01T10:00:00Z"),
+    )
+    msg_id = cursor.lastrowid
+    assert branch_id is not None
+    assert msg_id is not None
+    return branch_id, msg_id
+
+
+def test_insert_branch_message_links_absorbs_duplicate_links(memory_db):
+    branch_id, msg_id = seed_branch_with_message(memory_db)
+    cursor = memory_db.cursor()
+
+    insert_branch_message_links(cursor, branch_id, {msg_id})
+    # A concurrent writer creating the same link first must not raise.
+    insert_branch_message_links(cursor, branch_id, {msg_id})
+
+    cursor.execute("SELECT COUNT(*) FROM branch_messages")
+    assert cursor.fetchone()[0] == 1
+
+
+def test_insert_branch_message_links_raises_on_foreign_key_violation(memory_db):
+    branch_id, _ = seed_branch_with_message(memory_db)
+    cursor = memory_db.cursor()
+
+    with pytest.raises(sqlite3.IntegrityError):
+        insert_branch_message_links(cursor, branch_id, {99999})


### PR DESCRIPTION
## Summary

Both writers of `branch_messages` used `INSERT OR IGNORE`, which suppresses **every** constraint class — NOT NULL, FOREIGN KEY, CHECK — not just the duplicate-link case it was meant to absorb. This is the mechanism that made #155 invisible for about a week: every link insert failed silently, nothing raised, nothing logged, and the suite stayed green.

## Fix

Option 1 from the issue (fail at the point of damage):

- New `insert_branch_message_links()` in `branch_ops.py`: a plain `INSERT` per link that absorbs only `UNIQUE constraint failed` (a concurrent-writer race, logged at WARNING) and re-raises every other `IntegrityError`.
- Both call sites now use it: `diff_branch_messages()` (which already pre-computes the missing set, so duplicates are designed out) and the tool-content backfill's link pass in `hooks/backfill_tool_content.py`.

## Tests

New `tests/test_branch_ops.py` (RED commit first, per repo convention):

- `test_diff_branch_messages_raises_on_constraint_violation` — rebuilds `branch_messages` with an unexpected NOT NULL column (the #155 drift shape) and asserts the write raises instead of vanishing. Failed before the fix (`DID NOT RAISE`).
- `test_insert_branch_message_links_absorbs_duplicate_links` — a pre-existing link is absorbed without raising, row count stays 1.
- `test_insert_branch_message_links_raises_on_foreign_key_violation` — an FK violation propagates.

Full suite: 1317 passed, 2 skipped. `uvx prek run --all-files`: all hooks pass.

Fixes #158
