### PR TITLE
perf: gate the tool-content repair loop on the pending-NULL set

### DIFF
--- a/src/ccrecall/session_ops.py
+++ b/src/ccrecall/session_ops.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from ccrecall.branch_ops import sync_branch
 from ccrecall.db_vec import chunk_vec_queryable
 from ccrecall.formatting import normalize_project_key
-from ccrecall.import_log_ops import import_log_skip_check, upsert_import_log
+from ccrecall.import_log_ops import import_log_skip_check, pending_tool_content_uuids, upsert_import_log
 from ccrecall.message_ops import insert_new_messages, update_missing_tool_content, upsert_session
 from ccrecall.models import LOGGER_NAME
 from ccrecall.parsing import extract_session_metadata, extract_session_uuid, find_all_branches, parse_all_with_uuids
@@ -127,7 +127,17 @@ def sync_session(
     )
     existing_uuids = {row[0] for row in cursor.fetchall()}
 
-    repaired_tool_content = update_missing_tool_content(cursor, session_id, messages, existing_uuids)
+    # The repair loop is only needed for pre-v4 rows whose tool_content is still
+    # NULL. Query the pending set first (cheap — hits idx_messages_tool_content_null)
+    # so the steady state (every session created post-v4) skips the per-message
+    # extract_text_content + UPDATE work entirely instead of paying for it, at
+    # rowcount 0, on every sync.
+    pending_uuids = pending_tool_content_uuids(cursor, session_uuid)
+    if pending_uuids:
+        pending_messages = [e for e in messages if e.get("uuid") in pending_uuids]
+        repaired_tool_content = update_missing_tool_content(cursor, session_id, pending_messages, existing_uuids)
+    else:
+        repaired_tool_content = 0
     new_count = insert_new_messages(cursor, session_id, messages, valid_branch_uuids, existing_uuids)
 
     # all_entries is no longer needed past this point — messages have been

--- a/tests/test_session_ops.py
+++ b/tests/test_session_ops.py
@@ -176,7 +176,34 @@ class TestSyncSessionCreatesBranches:
         assert repaired, "re-sync should repair NULL tool_content without waiting for backfill"
 
 
-class TestSyncSessionWritesNullHashImportLog:
+class TestResyncSkipsRepairLoopWhenNoPendingToolContent:
+    """A session with zero NULL tool_content rows must not pay for the repair loop.
+
+    ``update_missing_tool_content`` iterates messages and runs
+    ``extract_text_content`` + a per-row UPDATE for every already-stored message,
+    even though normal (post-v4) rows always have a non-NULL tool_content and the
+    UPDATE is a guaranteed rowcount-0 no-op. The repair loop should be gated on
+    the pending-NULL set (``pending_tool_content_uuids``) so the steady state
+    (every session synced again after its first sync) skips it entirely.
+    """
+
+    def test_second_sync_does_not_call_repair_loop(self, memory_db):
+        fixture_path = FIXTURE_DIR / "tool_heavy.jsonl"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_dir = Path(tmpdir)
+            sync_session(memory_db, fixture_path, project_dir)
+            memory_db.commit()
+
+            # First sync must have populated tool_content for every row — no NULLs left.
+            cursor = memory_db.cursor()
+            cursor.execute("SELECT COUNT(*) FROM messages WHERE tool_content IS NULL")
+            assert cursor.fetchone()[0] == 0, "Setup: first sync should leave no NULL tool_content rows"
+
+            with patch("ccrecall.session_ops.update_missing_tool_content") as mock_repair:
+                sync_session(memory_db, fixture_path, project_dir)
+
+            mock_repair.assert_not_called()
+
     """Verify sync path writes import_log with file_hash = NULL."""
 
     def test_sync_session_writes_null_hash_import_log(self, memory_db):

--- a/tests/test_session_ops.py
+++ b/tests/test_session_ops.py
@@ -204,6 +204,8 @@ class TestResyncSkipsRepairLoopWhenNoPendingToolContent:
 
             mock_repair.assert_not_called()
 
+
+class TestSyncSessionWritesNullHashImportLog:
     """Verify sync path writes import_log with file_hash = NULL."""
 
     def test_sync_session_writes_null_hash_import_log(self, memory_db):


### PR DESCRIPTION
## Problem

Every sync re-runs `extract_text_content` and a no-op `UPDATE` for **every
already-stored message**, on every Stop hook, forever. The tool-content
repair loop (`update_missing_tool_content`, `message_ops.py:124-149`) is only
needed for pre-v4 rows whose `tool_content` is NULL, but it has no gate —
cost grows linearly with session length and is paid on the detached sync
process's hot inner loop after every single Stop.

Evidence, called unconditionally from `session_ops.py:130`:
- iterates every transcript message whose uuid is already in the DB
- runs `extract_text_content` on each (full content-walk per message)
- executes `UPDATE messages SET tool_content = ? … WHERE … tool_content IS NULL`
  per message — rowcount 0 for all repaired/normal rows (normal rows store
  `''`, never NULL)

The cheap gate already existed: `pending_tool_content_uuids(cursor, session_uuid)`
(`import_log_ops.py:24`) returns the NULL set via the partial index
`idx_messages_tool_content_null` (`db_base.py:222`).

## Fix

`sync_session` (`session_ops.py`) now queries `pending_tool_content_uuids`
first. When the pending set is empty (the steady state for any session
created post-v4), the repair loop is skipped entirely — `update_missing_tool_content`
is not called at all, so no `extract_text_content` and no `UPDATE` run.
When non-empty, only the messages whose uuid is in the pending set are
passed to `update_missing_tool_content`, instead of the full message list.

## Test evidence

Commit sequence proves the bug and the fix:

1. **RED** (`320a765`) — `TestResyncSkipsRepairLoopWhenNoPendingToolContent::test_second_sync_does_not_call_repair_loop`
   syncs a `tool_heavy.jsonl` fixture (leaving zero NULL `tool_content` rows),
   then re-syncs with `update_missing_tool_content` mocked and asserts it was
   not called. Fails before the fix: `AssertionError: Expected
   'update_missing_tool_content' to not have been called. Called 1 times.`
2. **GREEN** (`a6de1a4`) — the gate; same test now passes.

Existing repair coverage (`test_resync_repairs_existing_null_tool_content`,
`TestUpdateMissingToolContent` in `tests/test_message_ops.py`) still passes
unchanged — rows with NULL `tool_content` are still repaired.

```
uv run pytest -q
1315 passed, 2 skipped in 420.00s
```

```
uvx prek run --all-files
... all hooks Passed (ruff check/format, pyright, lazy-import ban, etc.)
```

Fixes #179
