### PR TITLE
feat: accept positional query on search commands and raise --max-results cap

### DIFF
--- a/src/ccrecall/cli/commands.py
+++ b/src/ccrecall/cli/commands.py
@@ -12,7 +12,7 @@ import sys
 from pathlib import Path
 from typing import Annotated, Literal
 
-from cyclopts import App, ArgumentCollection, Group, Parameter
+from cyclopts import App, Argument, ArgumentCollection, Group, Parameter
 from cyclopts.validators import Number
 
 from ccrecall import health
@@ -36,8 +36,23 @@ from ccrecall.hooks import sync_current as sync_current_mod
 _FLAG = Parameter(negative=[])
 
 
+# Friendly labels for the query-mode conflict/missing-arg messages below —
+# keyed by each argument's cyclopts-assigned name (the positional query's
+# Parameter(name="QUERY") and the --query/-q and --status flag names).
+_SEARCH_MODE_LABELS = {
+    "QUERY": "a positional query argument",
+    "--query": "--query/-q",
+    "--status": "--status",
+}
+
+
+def _search_mode_conflict_message(provided: list[Argument]) -> str:
+    labels = " and ".join(_SEARCH_MODE_LABELS.get(arg.name, arg.name) for arg in provided)
+    return f"{labels} cannot both be given — provide the query once, positionally or via --query/-q."
+
+
 def _exactly_one_query_or_status(arguments: ArgumentCollection) -> None:
-    """Group validator: search needs exactly one of --query / --status.
+    """Group validator: search needs exactly one of positional query / --query / --status.
 
     Runs at parse time so the message renders in cyclopts' boxed error style
     (and exits 2 via the entry-point wrapper), matching every other usage error.
@@ -46,14 +61,29 @@ def _exactly_one_query_or_status(arguments: ArgumentCollection) -> None:
     # arg.tokens is non-empty only when that argument was supplied on the CLI.
     provided = [arg for arg in arguments if arg.tokens]
     if not provided:
-        raise ValueError("one of --query/-q or --status is required")
+        raise ValueError("a query is required: provide it positionally, via --query/-q, or pass --status.")
     if len(provided) > 1:
-        raise ValueError("--query and --status are mutually exclusive")
+        raise ValueError(_search_mode_conflict_message(provided))
 
 
-# Membership in this group (query + status below) is what triggers the
-# exactly-one validator at parse time — the flags carry no logic themselves.
+# Membership in this group (positional query + --query + --status below) is
+# what triggers the exactly-one validator at parse time — the flags carry no
+# logic themselves.
 _SEARCH_MODE = Group("Search mode", validator=_exactly_one_query_or_status)
+
+
+def _exactly_one_query(arguments: ArgumentCollection) -> None:
+    """Group validator: search-messages needs exactly one of positional query / --query."""
+    provided = [arg for arg in arguments if arg.tokens]
+    if not provided:
+        raise ValueError("a query is required: provide it positionally or via --query/-q.")
+    if len(provided) > 1:
+        raise ValueError(_search_mode_conflict_message(provided))
+
+
+# Membership in this group (positional query + --query below) triggers the
+# exactly-one validator for search-messages, which has no --status mode.
+_QUERY_MODE = Group("Search mode", validator=_exactly_one_query)
 
 
 # Output format is global: the meta launcher's --json fills ctx.json_mode, which
@@ -345,6 +375,11 @@ def cmd_recent(
 
 @app.command(name="search")
 def cmd_search(
+    query_positional: Annotated[
+        str | None,
+        Parameter(name="QUERY", group=_SEARCH_MODE, help="Search keywords (positional form of --query/-q)."),
+    ] = None,
+    /,
     *,
     query: Annotated[str | None, Parameter(name=["--query", "-q"], group=_SEARCH_MODE, help="Search keywords.")] = None,
     status: Annotated[bool, _FLAG, Parameter(group=_SEARCH_MODE, help="Print diagnostic status and exit.")] = False,
@@ -369,12 +404,17 @@ def cmd_search(
 ) -> None:
     """Search conversation sessions (keyword + vector fusion).
 
-    Date filters (--before/--after) are branch-level (session start time).
+    Accepts the query positionally (``ccrecall search "auth bug"``) or via
+    --query/-q — not both. Date filters (--before/--after) are branch-level
+    (session start time).
 
     With --json: {query, ranked, count, results: [{score, session_uuid, handle, project, git_branch, topic, ...}]}
     """
+    # _SEARCH_MODE's group validator already guarantees exactly one of
+    # query_positional / query / status was supplied.
+    resolved_query = query_positional if query_positional is not None else query
     search_mod.run(
-        query=query,
+        query=resolved_query,
         status=status,
         keyword_only=keyword_only,
         max_results=max_results,
@@ -392,8 +432,13 @@ def cmd_search(
 
 @app.command(name="search-messages")
 def cmd_search_messages(
+    query_positional: Annotated[
+        str | None,
+        Parameter(name="QUERY", group=_QUERY_MODE, help="Search query (positional form of --query/-q)."),
+    ] = None,
+    /,
     *,
-    query: Annotated[str, Parameter(name=["--query", "-q"], help="Search query (required).")],
+    query: Annotated[str | None, Parameter(name=["--query", "-q"], group=_QUERY_MODE, help="Search query.")] = None,
     max_results: Annotated[
         int,
         Parameter(
@@ -414,16 +459,22 @@ def cmd_search_messages(
 ) -> None:
     """Search matched exchanges by semantic similarity (chunk-KNN, Entrypoint B).
 
-    Returns matched exchanges ranked by chunk distance — not rolled up to session,
-    so multiple matches within one session all appear as separate results.
+    Accepts the query positionally (``ccrecall search-messages "auth bug"``) or
+    via --query/-q — not both. Returns matched exchanges ranked by chunk
+    distance — not rolled up to session, so multiple matches within one
+    session all appear as separate results.
 
     Date filters (--before/--after) are branch-level (the exchange's session
     start time), not per-exchange, matching search and recent-chats.
 
     With --json: {query, ranked, count, results: [{score, session_uuid, handle, exchange_index, user, assistant, ...}]}
     """
+    # _QUERY_MODE's group validator already guarantees exactly one of
+    # query_positional / query was supplied.
+    resolved_query = query_positional if query_positional is not None else query
+    assert resolved_query is not None  # noqa: S101 — type-checker narrowing; the real guard is the group validator
     search_mod.run_messages(
-        query=query,
+        query=resolved_query,
         max_results=max_results,
         session=session,
         project=project,

--- a/src/ccrecall/search_cli.py
+++ b/src/ccrecall/search_cli.py
@@ -34,7 +34,7 @@ log = logging.getLogger(LOGGER_NAME)
 
 # Upper bound on --max-results, single-sourced here and referenced by the CLI
 # validator (cli/commands.py) so the clamp and the validator can't drift apart.
-MAX_SEARCH_RESULTS = 10
+MAX_SEARCH_RESULTS = 20
 
 
 def format_markdown(cards: list[dict], query: str, ranked: bool, verbose: bool = False) -> str:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -9,7 +9,9 @@ test_backfill_embeddings.py and is not repeated here.
 from unittest.mock import patch
 
 import pytest
+from cyclopts.exceptions import ValidationError
 
+from ccrecall.cli import app
 from ccrecall.cli.commands import (
     cmd_backfill_summaries,
     cmd_backfill_tool_content,
@@ -161,6 +163,61 @@ class TestCmdSearch:
             db=DEFAULT_DB_PATH,
         )
 
+    def test_positional_query_resolves_identically_to_flag(self):
+        """`cmd_search("q")` (positional) must dispatch the same query as `-q`."""
+        with patch("ccrecall.cli.commands.search_mod.run") as mock_run:
+            cmd_search(
+                "test query",
+                status=False,
+                keyword_only=False,
+                max_results=5,
+                session=None,
+                project=None,
+                path=None,
+                before=None,
+                after=None,
+                verbose=False,
+                include_notifications=False,
+                db=DEFAULT_DB_PATH,
+                ctx=DEFAULT_CLI_CONTEXT,
+            )
+        mock_run.assert_called_once_with(
+            query="test query",
+            status=False,
+            keyword_only=False,
+            max_results=5,
+            session=None,
+            project=None,
+            path=None,
+            before=None,
+            after=None,
+            output_format="markdown",
+            verbose=False,
+            include_notifications=False,
+            db=DEFAULT_DB_PATH,
+        )
+
+    def test_app_accepts_positional_query(self):
+        """End-to-end: `ccrecall search "q"` parses and dispatches like `-q "q"`."""
+        with patch("ccrecall.cli.commands.search_mod.run") as mock_run, pytest.raises(SystemExit) as exc_info:
+            app(["search", "auth bug"], exit_on_error=False, print_error=False)
+        assert exc_info.value.code == 0
+        assert mock_run.call_args.kwargs["query"] == "auth bug"
+
+    def test_app_accepts_flagged_query(self):
+        with patch("ccrecall.cli.commands.search_mod.run") as mock_run, pytest.raises(SystemExit) as exc_info:
+            app(["search", "-q", "auth bug"], exit_on_error=False, print_error=False)
+        assert exc_info.value.code == 0
+        assert mock_run.call_args.kwargs["query"] == "auth bug"
+
+    def test_app_rejects_both_positional_and_flag(self):
+        with pytest.raises(ValidationError, match="cannot both be given"):
+            app(["search", "positional query", "-q", "flagged query"], exit_on_error=False, print_error=False)
+
+    def test_app_rejects_no_query_and_no_status(self):
+        with pytest.raises(ValidationError, match="a query is required"):
+            app(["search"], exit_on_error=False, print_error=False)
+
 
 class TestCmdSearchMessages:
     def test_calls_run_messages_with_parsed_arguments(self):
@@ -191,6 +248,59 @@ class TestCmdSearchMessages:
             include_notifications=False,
             db=DEFAULT_DB_PATH,
         )
+
+    def test_positional_query_resolves_identically_to_flag(self):
+        with patch("ccrecall.cli.commands.search_mod.run_messages") as mock_run:
+            cmd_search_messages(
+                "test query",
+                max_results=5,
+                session=None,
+                project=None,
+                path=None,
+                before=None,
+                after=None,
+                verbose=False,
+                include_notifications=False,
+                db=DEFAULT_DB_PATH,
+                ctx=DEFAULT_CLI_CONTEXT,
+            )
+        mock_run.assert_called_once_with(
+            query="test query",
+            max_results=5,
+            session=None,
+            project=None,
+            path=None,
+            before=None,
+            after=None,
+            output_format="markdown",
+            verbose=False,
+            include_notifications=False,
+            db=DEFAULT_DB_PATH,
+        )
+
+    def test_app_accepts_positional_query(self):
+        with patch("ccrecall.cli.commands.search_mod.run_messages") as mock_run, pytest.raises(SystemExit) as exc_info:
+            app(["search-messages", "auth bug"], exit_on_error=False, print_error=False)
+        assert exc_info.value.code == 0
+        assert mock_run.call_args.kwargs["query"] == "auth bug"
+
+    def test_app_accepts_flagged_query(self):
+        with patch("ccrecall.cli.commands.search_mod.run_messages") as mock_run, pytest.raises(SystemExit) as exc_info:
+            app(["search-messages", "-q", "auth bug"], exit_on_error=False, print_error=False)
+        assert exc_info.value.code == 0
+        assert mock_run.call_args.kwargs["query"] == "auth bug"
+
+    def test_app_rejects_both_positional_and_flag(self):
+        with pytest.raises(ValidationError, match="cannot both be given"):
+            app(
+                ["search-messages", "positional query", "-q", "flagged query"],
+                exit_on_error=False,
+                print_error=False,
+            )
+
+    def test_app_rejects_no_query(self):
+        with pytest.raises(ValidationError, match="a query is required"):
+            app(["search-messages"], exit_on_error=False, print_error=False)
 
 
 class TestCmdTail:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -218,6 +218,16 @@ class TestCmdSearch:
         with pytest.raises(ValidationError, match="a query is required"):
             app(["search"], exit_on_error=False, print_error=False)
 
+    def test_app_accepts_max_results_of_20(self):
+        with patch("ccrecall.cli.commands.search_mod.run") as mock_run, pytest.raises(SystemExit) as exc_info:
+            app(["search", "-q", "test", "-n", "20"], exit_on_error=False, print_error=False)
+        assert exc_info.value.code == 0
+        assert mock_run.call_args.kwargs["max_results"] == 20
+
+    def test_app_rejects_max_results_above_20(self):
+        with pytest.raises(ValidationError):
+            app(["search", "-q", "test", "-n", "21"], exit_on_error=False, print_error=False)
+
 
 class TestCmdSearchMessages:
     def test_calls_run_messages_with_parsed_arguments(self):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -19,7 +19,7 @@ from ccrecall.formatting import apply_scores, format_snippet_json, format_snippe
 from ccrecall.fusion import rrf_scored
 from ccrecall.recent_chats import get_recent_sessions
 from ccrecall.schema import SCHEMA, SCHEMA_CORE, detect_fts_support
-from ccrecall.search_cli import format_markdown, print_status, run, run_messages
+from ccrecall.search_cli import MAX_SEARCH_RESULTS, format_markdown, print_status, run, run_messages
 from ccrecall.search_conversations import OVERFETCH_FLOOR, compute_caveat, search_messages, search_sessions
 from ccrecall.search_hydrate import dedup_by_session, hydrate_cards
 from ccrecall.search_query import ScopeFilter
@@ -2680,3 +2680,63 @@ class TestSearchInvalidDateRejected:
         envelope = json.loads(capsys.readouterr().err)
         assert envelope["code"] == "invalid_date"
         assert "--after" in envelope["error"]
+
+
+class TestMaxResultsCap:
+    """MAX_SEARCH_RESULTS is single-sourced in search_cli.py at 20; run()/run_messages()
+    each clamp their max_results backstop against it — this pins that clamp so the
+    constant and the two backstops can't silently drift apart.
+    """
+
+    def test_max_search_results_is_20(self):
+        assert MAX_SEARCH_RESULTS == 20
+
+    def test_run_accepts_max_results_of_20(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        c = sqlite3.connect(str(db_path))
+        c.executescript(SCHEMA_CORE)
+        c.commit()
+        c.close()
+
+        with patch("ccrecall.search_cli.search_sessions", return_value=([], False)) as mock_search:
+            run(query="test", max_results=20, db=db_path)
+
+        assert mock_search.call_args.kwargs["max_results"] == 20
+
+    def test_run_clamps_above_20_to_20(self, tmp_path):
+        """Backstop for direct (non-CLI) callers -- the CLI validator rejects values
+        above MAX_SEARCH_RESULTS before reaching run(), but run() clamps too."""
+        db_path = tmp_path / "test.db"
+        c = sqlite3.connect(str(db_path))
+        c.executescript(SCHEMA_CORE)
+        c.commit()
+        c.close()
+
+        with patch("ccrecall.search_cli.search_sessions", return_value=([], False)) as mock_search:
+            run(query="test", max_results=999, db=db_path)
+
+        assert mock_search.call_args.kwargs["max_results"] == 20
+
+    def test_run_messages_accepts_max_results_of_20(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        c = sqlite3.connect(str(db_path))
+        c.executescript(SCHEMA_CORE)
+        c.commit()
+        c.close()
+
+        with patch("ccrecall.search_cli.search_messages", return_value=([], False)) as mock_search:
+            run_messages(query="test", max_results=20, db=db_path)
+
+        assert mock_search.call_args.kwargs["max_results"] == 20
+
+    def test_run_messages_clamps_above_20_to_20(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        c = sqlite3.connect(str(db_path))
+        c.executescript(SCHEMA_CORE)
+        c.commit()
+        c.close()
+
+        with patch("ccrecall.search_cli.search_messages", return_value=([], False)) as mock_search:
+            run_messages(query="test", max_results=999, db=db_path)
+
+        assert mock_search.call_args.kwargs["max_results"] == 20


### PR DESCRIPTION
## Summary

Implements #68 and #67 together (same CLI surface: `search`/`search-messages`).

### #68 — Positional query on search commands

`search` and `search-messages` now accept the query positionally, alongside the existing `--query`/`-q`:

```
ccrecall search "auth bug"              # positional (new)
ccrecall search -q "auth bug"           # flagged (existing)
ccrecall search --query "auth bug"      # flagged (existing)
```

Implementation: a single positional-only parameter (`query_positional`, shown as `QUERY` in `--help`) shares a cyclopts `Group` with the existing `--query`/`-q` (and `--status` on `search`). The group's validator enforces "exactly one provided" at parse time — this gives conflict handling for free, in the same boxed cyclopts error style as every other usage error, e.g.:

```
$ ccrecall search "positional" -q "flagged"
╭─ Error ──────────────────────────────────────────────────────────────────────╮
│ Invalid values for group Search mode. a positional query argument and        │
│ --query/-q cannot both be given — provide the query once, positionally or    │
│ via --query/-q.                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
```

`search-messages` gets the same treatment with a 2-way group (positional vs. `-q`, no `--status` mode there).

### #67 — Raise `--max-results` cap from 10 to 20

`MAX_SEARCH_RESULTS` in `search_cli.py` raised from 10 to 20. Default stays 5. This constant is the single source referenced by both the CLI validator (`cli/commands.py`) and the `run()`/`run_messages()` backstop clamp, so all three stay in sync.

## Test evidence

Targeted + full suite, both green:

```
$ uv run pytest tests/test_cli_smoke.py tests/test_search.py tests/test_cli.py tests/test_cli_errors.py tests/test_cli_context.py -q
151 passed in 22.53s

$ uv run pytest -q
1331 passed, 2 skipped in 40.76s
```

`uvx prek run --all-files --hook-stage pre-push` (lint, format, pyright, custom checks): all green.

## Real CLI verification

```
$ uv run ccrecall search --help
...
╭─ Search mode ────────────────────────────────────────────────────────────────╮
│ QUERY       Search keywords (positional form of --query/-q).                 │
│ --query -q  Search keywords.                                                 │
│ --status    Print diagnostic status and exit. [default: False]               │
╰──────────────────────────────────────────────────────────────────────────────╯

$ uv run ccrecall search "test" -n 2      # positional
## 1.00  hassette · main · 2026-07-06
...
$ uv run ccrecall search -q "test" -n 2   # flagged — identical output
## 1.00  hassette · main · 2026-07-06
...

$ uv run ccrecall search "positional" -q "flagged"
╭─ Error ──────────────────────────────────────────────────────────────────────╮
│ Invalid values for group Search mode. a positional query argument and        │
│ --query/-q cannot both be given — provide the query once, positionally or    │
│ via --query/-q.                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯

$ uv run ccrecall search -q "test" -n 21
╭─ Error ──────────────────────────────────────────────────────────────────────╮
│ Invalid value "21" for -n. Must be <= 20.                                    │
╰──────────────────────────────────────────────────────────────────────────────╯
```

Ran against a real `~/.ccrecall` database — positional and flagged forms return byte-identical results.

Fixes #68
Fixes #67
