### PR TITLE
fix: treat a slash-command turn as moving on from a rejected question

### DIFF
--- a/src/ccrecall/tail_pending.py
+++ b/src/ccrecall/tail_pending.py
@@ -66,6 +66,24 @@ def typed_instruction(entry: dict) -> str | None:
     return text
 
 
+def _is_command_wrapper(entry: dict) -> bool:
+    """True if this main-chain user entry is a slash-command invocation.
+
+    A slash-command turn's raw content is entirely <command-name>/<command-args>
+    markup, which extract_text_content strips to empty text — so
+    typed_instruction returns None for it and the pending-question detector
+    below would otherwise treat the user as never having moved on. Checked
+    against the raw (pre-strip) content deliberately, so this stays scoped to
+    tail_pending.py rather than teaching content.py a new concept.
+    """
+    if entry.get("type") != "user":
+        return False
+    content = entry.get("message", {}).get("content")
+    if is_tool_result(content) or is_task_notification(content) or is_teammate_message(content):
+        return False
+    return isinstance(content, str) and "<command-name>" in content
+
+
 def find_pending_question(entries: list[dict]) -> dict | None:
     """The last main-chain AskUserQuestion with no genuine answer, or None.
 
@@ -111,8 +129,10 @@ def find_pending_question(entries: list[dict]) -> dict | None:
     if result_is_error.get(tool_id) is False:
         return None
     # No result or is_error=true — only pending if the user didn't move on.
+    # Moving on via a slash command counts too: _is_command_wrapper covers the
+    # entries typed_instruction alone can't see.
     tail = entries[last_entry_idx + 1 :]
-    if any(typed_instruction(e) for e in tail if _is_main_chain(e)):
+    if any((typed_instruction(e) or _is_command_wrapper(e)) for e in tail if _is_main_chain(e)):
         return None
     return payload
 

--- a/src/ccrecall/tail_pending.py
+++ b/src/ccrecall/tail_pending.py
@@ -78,7 +78,7 @@ def _is_command_wrapper(entry: dict) -> bool:
     """
     if entry.get("type") != "user":
         return False
-    content = entry.get("message", {}).get("content")
+    content = (entry.get("message") or {}).get("content")
     if is_tool_result(content) or is_task_notification(content) or is_teammate_message(content):
         return False
     return isinstance(content, str) and "<command-name>" in content

--- a/tests/test_session_tail.py
+++ b/tests/test_session_tail.py
@@ -194,6 +194,18 @@ class TestFindPendingQuestion:
         ]
         assert find_pending_question(entries) is not None
 
+    def test_rejected_then_slash_command_is_not_pending(self):
+        # A slash command user entry is entirely <command-name>/<command-args>
+        # wrapper text, which typed_instruction strips to empty — but the user
+        # visibly moved on, so this must not still be treated as pending.
+        entries = [
+            ask_question("t1", "proceed?", OPTS),
+            user_tool_result("t1", REJECTED, is_error=True),
+            user_text("<command-message>ship</command-message><command-name>/mine-ship</command-name>"),
+            assistant_text("Shipping now."),
+        ]
+        assert find_pending_question(entries) is None
+
 
 class TestTypedInstruction:
     def test_real_text(self):


### PR DESCRIPTION
## Scenario

1. Agent asks an `AskUserQuestion`.
2. User rejects it (`is_error: true` tool result).
3. User runs a slash command (e.g. `/mine-ship`) and the session ends normally (full commit-push-PR).
4. Next `SessionStart` still injects `## ⚠ Unresolved Decision From Prior Session … do not act on the work it gates` — actively telling the next agent to hold off on work the user already un-blocked and shipped.

## Root cause

`find_pending_question` in `src/ccrecall/tail_pending.py` only clears pendingness on a later `typed_instruction`. A slash-command user turn's raw content is entirely `<command-name>…</command-name>`/`<command-args>…</command-args>` wrapper markup, which `extract_text_content` strips to empty text — so `typed_instruction` returns `None` for it and it's invisible to the detector, even though the user visibly moved on.

## Fix

Added `_is_command_wrapper` to `tail_pending.py` (narrower option from the issue — `content.py`/`extract_text_content` untouched, since another in-flight PR is modifying that module). It checks the raw (pre-strip) content of a main-chain, non-tool-result user turn for `<command-name>`. `find_pending_question`'s tail scan now treats `typed_instruction(e) or _is_command_wrapper(e)` as "moved on."

## Test evidence

RED commit (`test: reproduce stale unresolved-decision block after slash-command move-on`) added `test_rejected_then_slash_command_is_not_pending`, which failed against the pre-fix code:

```
AssertionError: assert {'questions': [...]} is None
```

GREEN commit (`fix: treat a slash-command turn as moving on from a rejected question`) makes it pass, alongside the existing `test_rejected_with_no_followup_is_pending` (rejected + genuinely nothing after → block still fires — unchanged).

- Targeted: `uv run pytest tests/test_session_tail.py -q` → 85 passed
- Full suite: `uv run pytest -q` → 1315 passed, 2 skipped
- `uvx prek run --all-files` → all hooks passed (ruff, pyright, typos, custom checks)

Fixes #180
