### PR TITLE
fix: reject null message at the parse boundary and harden extract_text_content against null text

### DIFF
--- a/src/ccrecall/content.py
+++ b/src/ccrecall/content.py
@@ -104,7 +104,11 @@ def extract_text_content(content) -> tuple[str, bool, bool, str | None, str]:
             if isinstance(item, dict):
                 item_type = item.get("type", "")
                 if item_type == "text":
-                    texts.append(item.get("text", ""))
+                    # "text" key present with a null value (probe-confirmed malformed
+                    # shape, #171) must not flow through — `or ""` catches both the
+                    # missing-key and explicit-null cases so the "\n".join below never
+                    # sees a None, preserving the module's never-raises contract.
+                    texts.append(item.get("text") or "")
                 elif item_type == "tool_use":
                     has_tool_use = True
                     tool_name = item.get("name", "")

--- a/src/ccrecall/message_ops.py
+++ b/src/ccrecall/message_ops.py
@@ -21,7 +21,10 @@ def message_content_parts(entry: dict) -> tuple[str, bool, str] | None:
     """Return content fields for entries that should have a messages row."""
     if not is_insertable_message(entry):
         return None
-    content = entry.get("message", {}).get("content", "")
+    # `.get("message", {})` only supplies the {} default when the key is missing;
+    # a present-but-null "message" (rejected at the parse boundary but reachable
+    # if this is called directly, #171) returns None and crashes the .get below.
+    content = (entry.get("message") or {}).get("content", "")
     if entry.get("type") == "user" and is_tool_result(content):
         return None
     text, _has_tool_use, has_thinking, _tool_summary, tool_content = extract_text_content(content)
@@ -71,7 +74,10 @@ def build_message_row(
     if not uuid or uuid not in valid_branch_uuids or uuid in existing_uuids:
         return None
     text, has_thinking, tool_content = parts
-    content = entry.get("message", {}).get("content", "")
+    # `.get("message", {})` only supplies the {} default when the key is missing;
+    # a present-but-null "message" (rejected at the parse boundary but reachable
+    # if this is called directly, #171) returns None and crashes the .get below.
+    content = (entry.get("message") or {}).get("content", "")
     entry_type = entry.get("type")
     is_notification = entry_type == "user" and (is_task_notification(content) or is_teammate_message(content))
     return (
@@ -139,7 +145,10 @@ def update_missing_tool_content(
         uuid = entry.get("uuid")
         if not uuid or uuid not in existing_uuids:
             continue
-        content = entry.get("message", {}).get("content", "")
+        # `.get("message", {})` only supplies the {} default when the key is missing;
+        # a present-but-null "message" (rejected at the parse boundary but reachable
+        # if this is called directly, #171) returns None and crashes the .get below.
+        content = (entry.get("message") or {}).get("content", "")
         _text, _has_tool_use, _has_thinking, _tool_summary, tool_content = extract_text_content(content)
         cursor.execute(
             "UPDATE messages SET tool_content = ? WHERE session_id = ? AND uuid = ? AND tool_content IS NULL",

--- a/src/ccrecall/models.py
+++ b/src/ccrecall/models.py
@@ -9,7 +9,7 @@ mid-import AttributeError. They stay permissive on unknown fields
 
 import logging
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 # The single logger name setup_logging() configures. Shared so boundary skip-logs
 # and hook exceptions reach the same rotating file as the rest of the app; a module
@@ -66,6 +66,21 @@ class TranscriptEntry(BaseModel):
     is_meta: bool | None = Field(default=None, alias="isMeta")
     session_id: str | None = Field(default=None, alias="sessionId")
     message: EntryMessage | None = None
+
+    @model_validator(mode="after")
+    def _reject_null_message_on_turns(self) -> "TranscriptEntry":
+        """Reject an explicit ``"message": null`` on a user/assistant entry.
+
+        A missing ``message`` key is fine (non-turn entry types like
+        ``summary`` carry none — see ``EntryMessage``'s docstring). But a
+        user/assistant entry with ``message`` explicitly null passes the
+        ``EntryMessage | None`` type as-is and then crashes downstream
+        dereferences (``entry.get("message", {}).get("content")``) that
+        assume a missing key, not a present-but-null one.
+        """
+        if self.type in ("user", "assistant") and "message" in self.model_fields_set and self.message is None:
+            raise ValueError("message must not be null on a user/assistant entry")
+        return self
 
 
 class HookInput(BaseModel):

--- a/src/ccrecall/parsing.py
+++ b/src/ccrecall/parsing.py
@@ -292,7 +292,10 @@ def compute_branch_metadata(
         if entry_type not in ("user", "assistant"):
             continue
 
-        message = entry.get("message", {})
+        # `entry.get("message", {})` only supplies the {} default when the key is
+        # missing; a validator-rejected-but-still-possible `"message": null` would
+        # return None and crash the .get below (#171) — `or {}` covers both.
+        message = entry.get("message") or {}
         content = message.get("content", "")
 
         if entry_type == "user" and is_tool_result(content):

--- a/src/ccrecall/session_tail.py
+++ b/src/ccrecall/session_tail.py
@@ -74,7 +74,10 @@ def last_typed_instruction(entries: list[dict]) -> str | None:
 def last_assistant_text(entries: list[dict]) -> str | None:
     for entry in reversed(entries):
         if entry.get("type") == "assistant":
-            text, _, _, _, _ = extract_text_content(entry.get("message", {}).get("content"))
+            # `.get("message", {})` only supplies the {} default when the key is
+            # missing; a present-but-null "message" (#171) returns None and
+            # crashes the .get below.
+            text, _, _, _, _ = extract_text_content((entry.get("message") or {}).get("content"))
             if text:
                 return text
     return None
@@ -129,7 +132,7 @@ def build_tail(entries: list[dict], k: int) -> list[tuple[str, str]]:
         if not _is_main_chain(entry):
             continue
         kind = entry.get("type")
-        content = entry.get("message", {}).get("content")
+        content = (entry.get("message") or {}).get("content")
         if kind == "user":
             text = typed_instruction(entry)
             if text:

--- a/src/ccrecall/tail_pending.py
+++ b/src/ccrecall/tail_pending.py
@@ -54,7 +54,9 @@ def typed_instruction(entry: dict) -> str | None:
     """
     if entry.get("type") != "user":
         return None
-    content = entry.get("message", {}).get("content")
+    # `.get("message", {})` only supplies the {} default when the key is missing;
+    # a present-but-null "message" (#171) returns None and crashes the .get below.
+    content = (entry.get("message") or {}).get("content")
     if is_tool_result(content) or is_task_notification(content) or is_teammate_message(content):
         return None
     text, _, _, _, _ = extract_text_content(content)
@@ -81,7 +83,7 @@ def find_pending_question(entries: list[dict]) -> dict | None:
     for entry in entries:
         if entry.get("type") != "user":
             continue
-        content = entry.get("message", {}).get("content")
+        content = (entry.get("message") or {}).get("content")
         if not isinstance(content, list):
             continue
         for block in content:
@@ -95,7 +97,7 @@ def find_pending_question(entries: list[dict]) -> dict | None:
     for i, entry in enumerate(entries):
         if not _is_main_chain(entry) or entry.get("type") != "assistant":
             continue
-        content = entry.get("message", {}).get("content")
+        content = (entry.get("message") or {}).get("content")
         if not isinstance(content, list):
             continue
         for block in content:

--- a/tests/test_boundary_validation.py
+++ b/tests/test_boundary_validation.py
@@ -43,6 +43,24 @@ class TestTranscriptValidation:
     def test_rejects_scalar_content(self):
         assert not is_valid_entry({"uuid": "u1", "type": "user", "message": {"content": 42}})
 
+    def test_rejects_null_message_on_user_entry(self):
+        # message: null (key present) is exactly what crashed compute_branch_metadata
+        # via entry.get("message", {}) returning None instead of the {} default (#171).
+        assert not is_valid_entry({"uuid": "u1", "type": "user", "message": None})
+
+    def test_rejects_null_message_on_assistant_entry(self):
+        assert not is_valid_entry({"uuid": "u1", "type": "assistant", "message": None})
+
+    def test_null_message_does_not_crash_compute_branch_metadata(self):
+        # Even if a null-message entry somehow reached compute_branch_metadata,
+        # it must not raise (defense-in-depth alongside the validator rejection).
+        entries = [{"type": "user", "uuid": "u1", "message": None}]
+        count, files, commits, tools = compute_branch_metadata(entries)
+        assert count == 1
+        assert files == []
+        assert commits == []
+        assert tools == {}
+
     def test_parse_jsonl_skips_malformed_keeps_valid(self, tmp_path):
         path = tmp_path / "mixed.jsonl"
         path.write_text(

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -135,6 +135,26 @@ class TestExtractTextContent:
         assert summary is None
         assert tool_content == ""
 
+    def test_null_text_field_does_not_raise(self):
+        # {"type": "text", "text": null} is a probe-confirmed malformed shape
+        # (issue #171) — must never raise, per the module's never-raises contract.
+        content = [{"type": "text", "text": None}]
+        text, has_tool, has_think, summary, tool_content = extract_text_content(content)
+        assert text == ""
+        assert has_tool is False
+        assert has_think is False
+        assert summary is None
+        assert tool_content == ""
+
+    def test_null_text_field_mixed_with_valid_text(self):
+        content = [
+            {"type": "text", "text": "Hello"},
+            {"type": "text", "text": None},
+            {"type": "text", "text": "World"},
+        ]
+        text, _has_tool, _has_think, _summary, _tool_content = extract_text_content(content)
+        assert text == "Hello\n\nWorld"
+
 
 # extract_text_content — tool_content extraction (generic field-join)
 


### PR DESCRIPTION
## Summary

Fixes #171 — two malformed-but-plausible transcript shapes passed `is_valid_entry` and then crashed exactly the functions the parse boundary exists to guard.

### Shape 1: `"message": null`

`models.py`'s `TranscriptEntry.message: EntryMessage | None` already permits null, so `{"type": "user", "uuid": "u1", "message": null}` passed validation. Downstream, `entry.get("message", {})` only supplies the `{}` default when the key is *missing* — a present-but-null value returns `None`, and `.get("content")` on `None` raises `AttributeError`. This hit `compute_branch_metadata` (`parsing.py`), `message_content_parts`/`build_message_row`/`update_missing_tool_content` (`message_ops.py`), and `last_assistant_text`/`build_tail` plus `typed_instruction`/`find_pending_question` (`session_tail.py` and the `tail_pending.py` module it calls into for `ccrecall tail`).

### Shape 2: `{"type": "text", "text": null}`

`content.py:extract_text_content` appended `item.get("text", "")`, which returns `None` when the key is present with a null value, then `"\n".join(texts)` raised `TypeError`. This broke the function's documented never-raises contract (see `CLAUDE.md`'s architecture notes on `content.py`).

## Fix

- **`models.py`**: `TranscriptEntry` gets a `model_validator(mode="after")` that rejects an explicit null `message` on `user`/`assistant` entries. Uses `model_fields_set` to distinguish an *explicit* null from an *omitted* key, so entries with no `message` key at all (e.g. `type: summary`) are unaffected — this preserves the existing `test_accepts_entry_without_message` behavior.
- **`content.py`**: `item.get("text") or ""` instead of `item.get("text", "")`, so a null `text` value can never reach the join.
- **Defense-in-depth**: the dereference sites the issue named (`parsing.py:295`, `message_ops.py`) plus `session_tail.py` and `tail_pending.py` (which `session_tail.build_tail` calls into, and which had the identical pattern in two more places) are hardened with `entry.get("message") or {}` so a null message can't crash them even if reached without going through the validator.

## Probes (from the issue, now passing)

```python
from ccrecall.parsing import is_valid_entry, compute_branch_metadata
e = {"type": "user", "uuid": "u1", "message": None}
is_valid_entry(e)          # False (was True)
compute_branch_metadata([e])  # (1, [], [], {}) — no longer raises

from ccrecall.content import extract_text_content
extract_text_content([{"type": "text", "text": None}])
# ('', False, False, None, '') — no longer raises
```

## Test evidence

- New RED tests committed first (`test: reproduce null message/text crashes at parse boundary`), confirmed failing against pre-fix code.
- Targeted suite: `uv run pytest -q tests/test_boundary_validation.py tests/test_content.py tests/test_parsing.py` → 170 passed.
- Full suite: `uv run pytest -q` → 1319 passed, 2 skipped.
- `uvx prek run --all-files` → all hooks passed (ruff, pyright, lazy-import ban, etc).

Fixes #171
