### PR TITLE
fix: contain per-file import crashes so one poison transcript cannot wedge the batch

### DIFF
--- a/src/ccrecall/hooks/import_conversations.py
+++ b/src/ccrecall/hooks/import_conversations.py
@@ -250,7 +250,25 @@ def import_project(
         )
         targets = [target for target in targets if target not in processed]
         for target in targets:
-            branches_count, msg_count = import_session(conn, target, project_id, force=repair_group)
+            # Per-file containment (#170): one poison transcript must not wedge the
+            # whole batch. A SAVEPOINT bounds the containment to exactly this
+            # file's writes — the surrounding connection's transaction still spans
+            # the whole project (committed once, in _run, after import_project
+            # returns), so rolling back to the savepoint discards only this
+            # file's partial work without touching already-imported siblings.
+            conn.execute("SAVEPOINT import_file")
+            try:
+                branches_count, msg_count = import_session(conn, target, project_id, force=repair_group)
+            except Exception:
+                conn.execute("ROLLBACK TO SAVEPOINT import_file")
+                conn.execute("RELEASE SAVEPOINT import_file")
+                # Deliberately leave import_log unwritten for this file: it will
+                # be retried on every future run, which is cheap once a single
+                # bad file can no longer take the whole batch down.
+                log.exception("Skipping poison transcript file %s — import_session raised", target)
+                processed.add(target)
+                continue
+            conn.execute("RELEASE SAVEPOINT import_file")
             processed.add(target)
             if branches_count == -1:
                 sessions_skipped += 1
@@ -282,6 +300,18 @@ def run(
     """Import Claude Code conversations into the memory DB."""
     try:
         _run(db=db, projects_dir=projects_dir, project=project, verbose=verbose)
+    except Exception:
+        # Top-level catch (#170): this process is detached and spawned with
+        # stdout/stderr redirected to DEVNULL (see memory_setup._spawn_background),
+        # so an exception reaching here would otherwise exit the process with
+        # no trace anywhere. Per-file containment in import_project/import_session
+        # is the primary defense; this is the backstop for anything outside that
+        # loop (e.g. a failure setting up the connection or scanning projects_dir).
+        # log uses LOGGER_NAME, the same logger _run's setup_logging() call
+        # already attached the ccrecall-import.log rotating handler to, so this
+        # still lands in the log even though _run itself failed.
+        log.exception("Import process failed with an uncaught exception")
+        raise
     finally:
         # Delete PID file so _spawn_background can spawn again next session
         remove_pid_file(PID_KEY)

--- a/tests/test_import_pipeline.py
+++ b/tests/test_import_pipeline.py
@@ -683,6 +683,98 @@ class TestImportProject:
         assert cursor.execute("SELECT COUNT(*) FROM import_log").fetchone()[0] == 0
 
 
+class TestImportPoisonContainment:
+    """Issue #170 — one raising transcript file must not wedge the whole batch.
+
+    Before the fix, a single file that raised during import_session propagated
+    straight out of import_project (and _run), killing the detached import
+    process before any later file in the same directory (or any later
+    project) got a chance to import, and before the crash was logged anywhere.
+    """
+
+    def test_poison_file_does_not_block_sibling_files_in_same_project(self, memory_db, tmp_path, caplog, monkeypatch):
+        """A raising file must be skipped (and logged) while its siblings still import."""
+        project_dir = tmp_path / "-Users-sam-project"
+        project_dir.mkdir()
+
+        # "aaa-poison" sorts before "zzz-good" alphabetically, matching the
+        # real-world failure mode: everything that sorts after the poison
+        # file in projects_dir.iterdir()/glob order never gets a chance.
+        poison_file = project_dir / "aaa-poison.jsonl"
+        good_file = project_dir / "zzz-good.jsonl"
+        shutil.copy(FIXTURE_DIR / "linear_3_exchange.jsonl", poison_file)
+        shutil.copy(FIXTURE_DIR / "linear_3_exchange.jsonl", good_file)
+
+        real_import_session = import_session
+
+        def _raise_on_poison(conn, filepath, project_id, *, force=False):
+            if filepath == poison_file:
+                raise RuntimeError("simulated poison transcript")
+            return real_import_session(conn, filepath, project_id, force=force)
+
+        monkeypatch.setattr("ccrecall.hooks.import_conversations.import_session", _raise_on_poison)
+
+        with caplog.at_level(logging.ERROR, logger="ccrecall"):
+            sessions, _messages, skipped = import_project(memory_db, project_dir)
+
+        # The good file must still have been imported despite the poison file
+        # raising — this is the core containment guarantee.
+        assert sessions > 0 or skipped > 0, "the non-poison file must still be processed"
+
+        cursor = memory_db.cursor()
+        cursor.execute("SELECT COUNT(*) FROM import_log WHERE file_path = ?", (str(good_file),))
+        assert cursor.fetchone()[0] == 1, "the good file must have an import_log entry"
+
+        cursor.execute("SELECT COUNT(*) FROM import_log WHERE file_path = ?", (str(poison_file),))
+        assert cursor.fetchone()[0] == 0, "the poison file must be left unwritten so it retries next run"
+
+        # The crash must be logged with a traceback, not silently discarded.
+        assert any(
+            "poison" in record.message.lower() or "aaa-poison" in record.message
+            for record in caplog.records
+            if record.levelno >= logging.ERROR
+        ), "the poison-file crash must be logged at ERROR level"
+        assert any(record.exc_info for record in caplog.records if record.levelno >= logging.ERROR), (
+            "the logged crash must include a traceback (logger.exception)"
+        )
+
+    def test_poison_file_does_not_corrupt_sibling_transaction(self, memory_db, tmp_path, monkeypatch):
+        """A poison file's partial writes must not leak into the shared connection's
+        uncommitted transaction alongside a sibling file's real work."""
+        project_dir = tmp_path / "-Users-sam-project"
+        project_dir.mkdir()
+
+        poison_file = project_dir / "aaa-poison.jsonl"
+        good_file = project_dir / "zzz-good.jsonl"
+        shutil.copy(FIXTURE_DIR / "linear_3_exchange.jsonl", poison_file)
+        shutil.copy(FIXTURE_DIR / "linear_3_exchange.jsonl", good_file)
+
+        real_import_session = import_session
+
+        def _raise_after_partial_write(conn, filepath, project_id, *, force=False):
+            if filepath == poison_file:
+                # Simulate partial work happening before the crash: write a row,
+                # then raise before it would ever be committed or logged to
+                # import_log by the real import_session.
+                conn.execute(
+                    "INSERT INTO projects (path, key, name) VALUES (?, ?, ?)",
+                    ("/poison/partial", "-poison-partial", "poison_partial"),
+                )
+                raise RuntimeError("simulated poison transcript after partial write")
+            return real_import_session(conn, filepath, project_id, force=force)
+
+        monkeypatch.setattr("ccrecall.hooks.import_conversations.import_session", _raise_after_partial_write)
+
+        import_project(memory_db, project_dir)
+
+        cursor = memory_db.cursor()
+        cursor.execute("SELECT COUNT(*) FROM projects WHERE key = ?", ("-poison-partial",))
+        assert cursor.fetchone()[0] == 0, "partial writes from the poison file must be rolled back, not leaked"
+
+        cursor.execute("SELECT COUNT(*) FROM import_log WHERE file_path = ?", (str(good_file),))
+        assert cursor.fetchone()[0] == 1, "the good file's real work must survive the poison file's rollback"
+
+
 class TestImportRunPathSafety:
     """Test --project path safety checks in the import hook."""
 

--- a/tests/test_import_pipeline.py
+++ b/tests/test_import_pipeline.py
@@ -14,7 +14,7 @@ import sqlite_vec
 from conftest import FIXTURE_DIR, VEC_SKIP, make_vec_conn
 
 from ccrecall.embeddings import EMBEDDING_DIM
-from ccrecall.hooks.import_conversations import _run, import_project, import_session
+from ccrecall.hooks.import_conversations import _run, import_project, import_session, run
 
 _STALE_IMPORT_LOG_SQL = (
     "UPDATE import_log SET file_hash = 'stale', file_size = NULL, file_mtime = NULL WHERE file_path = ?"
@@ -773,6 +773,26 @@ class TestImportPoisonContainment:
 
         cursor.execute("SELECT COUNT(*) FROM import_log WHERE file_path = ?", (str(good_file),))
         assert cursor.fetchone()[0] == 1, "the good file's real work must survive the poison file's rollback"
+
+    def test_run_logs_uncaught_exceptions_before_exiting(self, tmp_path, caplog, monkeypatch):
+        """An exception that reaches run() (outside the per-file loop entirely) must
+        still be logged before the detached process exits — the top-level backstop."""
+
+        def _raise(**_kwargs):
+            raise RuntimeError("simulated catastrophic failure outside the per-file loop")
+
+        monkeypatch.setattr("ccrecall.hooks.import_conversations._run", _raise)
+        monkeypatch.setattr("ccrecall.hooks.import_conversations.remove_pid_file", lambda _key: None)
+
+        with (
+            caplog.at_level(logging.ERROR, logger="ccrecall"),
+            pytest.raises(RuntimeError, match="simulated catastrophic failure"),
+        ):
+            run(db=tmp_path / "memory.db", projects_dir=tmp_path)
+
+        assert any(record.exc_info for record in caplog.records if record.levelno >= logging.ERROR), (
+            "an uncaught exception in run() must be logged with a traceback before the process exits"
+        )
 
 
 class TestImportRunPathSafety:


### PR DESCRIPTION
## Scenario

The batch import (`import_conversations.py`) had no per-file exception containment. One transcript file that raised during `import_session` killed the whole detached `ccrecall import` process with an unlogged traceback (the process is spawned by `memory_setup._spawn_background` with stdout/stderr redirected to `DEVNULL`). Because the crash happened before that file's `import_log` upsert, every future import run re-hit the same file and re-crashed at the same point. All projects sorting after the poison file (by `projects_dir.iterdir()` order) never imported again, permanently, with no user-visible signal.

## Fix

Two failure modes closed:

1. **Per-file containment in `import_project`.** Each transcript file's `import_session` call is now wrapped in a SQLite `SAVEPOINT`. On success the savepoint is released; on any exception it's rolled back to the savepoint and the loop continues to the next file. `import_log` is deliberately left unwritten for the failed file, so it retries every future run — cheap now that a single bad file can no longer take the batch down. The crash is logged via `log.exception(...)` with the file path, matching `sync_current.py`'s existing per-session containment discipline.

2. **Top-level catch in `run()`.** `_run(...)` is now wrapped so any exception that escapes the per-file loop (or arises elsewhere, e.g. connection setup) is logged via `logger.exception` before re-raising, so the detached process can no longer exit without a trace in `~/.ccrecall/ccrecall-import.log`.

## Transaction-boundary reasoning

`get_connection()` commits the whole `with` block on success and rolls back everything on an uncaught exception. `import_conversations._run` already establishes its own coarser unit of work on top of that: it calls `conn.commit()` explicitly once per project directory (or once for a single `--project` run), independent of the connection's own commit-on-`with`-exit. So multiple files within one project share a single *uncommitted* transaction until that project-level `conn.commit()` fires.

Catching per-file at that granularity without more care would mean a raising file's partial writes (e.g. a partially-built session, or messages inserted before the exception) stay part of the *same* uncommitted transaction as its already-succeeded siblings, and would get silently persisted (or interleaved) when the project's `conn.commit()` runs — exactly the "half-committed" corruption the issue calls out to avoid.

The fix nests a `SAVEPOINT` inside that project-level transaction, scoped to exactly one file's writes:

- **Success:** `RELEASE SAVEPOINT` — the file's writes fold into the surrounding project transaction, unaffected by anything else.
- **Exception:** `ROLLBACK TO SAVEPOINT` — undoes only this file's partial writes, leaving every previously-processed sibling file's uncommitted work in this project intact, then continues to the next file.

This mirrors the existing project-level unit of work (`conn.commit()` per project in `_run`) rather than introducing a new commit boundary — no behavior change for files that succeed.

## Test evidence

Three new tests in `tests/test_import_pipeline.py::TestImportPoisonContainment`:

- `test_poison_file_does_not_block_sibling_files_in_same_project` — a file that raises during `import_session` is skipped and logged (ERROR level, with traceback), while a sibling file sorting after it still imports (`import_log` entry present for the good file, absent for the poison file so it retries).
- `test_poison_file_does_not_corrupt_sibling_transaction` — a poison file that performs a partial write before raising leaves no trace in the DB (rolled back via the savepoint), while a sibling file's real work survives in the same connection.
- `test_run_logs_uncaught_exceptions_before_exiting` — an exception that escapes `_run` entirely is logged with a traceback by `run()` before it propagates, verified by first confirming this test fails (`AssertionError`, no log record) against the pre-fix code.

All three were confirmed RED against the pre-fix code before implementing the fix (the first two via a real Bash run showing the `RuntimeError` propagating out of `import_project`; the third via a targeted `git stash` re-run of only that test against the original `import_conversations.py`).

Fresh full-suite run after the fix:

```
1317 passed, 2 skipped in 93.90s
```

`uvx prek run --all-files` — all hooks pass, including `ruff check`, `ruff format`, the lazy-import ban, and `pyright` (pyright ran at push time via the pre-push hook and also passed).

Fixes #170
