### PR TITLE
chore: add changelog-review command and release quality rule

### DIFF
--- a/.claude/commands/changelog-review.md
+++ b/.claude/commands/changelog-review.md
@@ -1,0 +1,115 @@
+# Changelog Review
+
+Review and rewrite the release-please changelog PR before merging.
+
+## Context
+
+- release-please config: !`cat release-please-config.json 2>/dev/null`
+- Changelog quality rule: !`cat .claude/rules/changelog-quality.md 2>/dev/null`
+
+No `## [x.y.z]` release-please-generated section in `CHANGELOG.md` has been through this cleanup yet. Every one is still in release-please's raw, unedited format (flat `### Features` / `### Bug Fixes` with `([commit-sha])` links). The section you rewrite in Step 4 becomes the style reference for every `## [x.y.z]` review after it.
+
+There is also a run of dated sections (`## 2026-08-24` down to `## 2026-08-04`) between v0.21.1 and v0.21.0, from before this repo adopted release-please headings. They're already short, user-facing bullets with `(#NNN)` refs and no commit SHAs: close to the target style already. Leave them alone; Step 5 only scans `## [x.y.z]` sections.
+
+## Step 1: Find the release PR
+
+Run `gh pr list --search "chore(main): release" --state open --json number,title,headRefName --limit 5`.
+
+If no PR found, stop and tell the user. If multiple, ask which one.
+
+## Step 2: Checkout and read
+
+1. Fetch and checkout the release-please branch.
+2. Read the new release section in `CHANGELOG.md` (the topmost `## [x.y.z]` heading).
+3. List the commits in this release: `git log --oneline <prev-tag>..<base-commit>`.
+
+## Step 3: Gather PR context
+
+For each commit that produced a changelog entry, fetch its PR body via `gh pr view <number> --json title,body` using the `(#NNN)` reference in the commit subject. Focus on:
+
+- What user-facing behavior changed
+- Breaking change migration details
+- Whether the change is internal-only
+
+## Step 3.5: Check for external contributors
+
+Run `uv run python scripts/release_contributors.py <prev-tag> <base-commit>` (using the same range from Step 3).
+
+If external contributors are found, surface them as a finding:
+
+> **External contributors detected. Ensure attribution in the changelog:**
+>
+> <script output>
+
+When rewriting entries in Step 4, add "thanks @username!" (or "thanks Name!" if no GitHub username is available) to the relevant changelog bullet.
+
+If no external contributors are found, continue silently.
+
+## Step 4: Rewrite
+
+Rewrite the release section per `.claude/rules/changelog-quality.md`:
+
+**Remove entirely:**
+- `docs:` entries for prior art research, internal design docs
+- `ci:` entries (CI pipeline changes)
+- `test:` entries (test infrastructure, not test utilities shipped to users)
+- `chore:` entries (gitignore, changelog meta, dependency bumps)
+- `refactor:` entries with no user-visible behavior change
+- Internal framework plumbing that users never interact with
+
+**Keep and rewrite:**
+- `feat:` entries → describe what users can now do
+- `fix:` entries → describe what was broken and is now fixed
+- `perf:` entries → describe what got faster
+- `docs:` entries for user-facing docs (README, `/ccr-*` skill help text, CLI `--help` output)
+- `refactor:` entries that change user-facing APIs (CLI flags, hook contracts, skill behavior)
+
+**Breaking changes:**
+Each must explain (1) what changed, (2) what user code is affected, (3) what to do. Use field-by-field details when types changed. Put these in a `### Breaking Changes` section at the top.
+
+**Grouping:**
+When 5+ entries remain, group by feature area with `### Section` headers:
+- `### Breaking Changes` (always first if present)
+- Topic sections like `### Search`, `### Embeddings`, `### Hooks`, `### Sync`, `### CLI`
+- `### Bug Fixes` (always last)
+- `### Documentation` (only if user-facing docs changed)
+
+**Format:**
+- `- ` bullets with bold lead-in for breaking changes
+- Issue references as `(#NNN)`, no commit SHAs
+- Preserve the `## [x.y.z](compare-link) (date)` heading exactly
+
+## Step 5: Check older releases
+
+Scan the older `## [x.y.z]` sections in `CHANGELOG.md` (skip the dated `## YYYY-MM-DD` legacy sections; see Context above, they don't need this treatment). If any `## [x.y.z]` section still has the raw release-please format (flat `### Features` / `### Bug Fixes` with `([commit-sha])` links), ask:
+
+```
+AskUserQuestion:
+  question: "Older releases (listed below) still have raw release-please formatting. Clean those up too?"
+  header: "Older entries"
+  multiSelect: false
+  options:
+    - label: "Yes, clean them all"
+      description: "Apply the same rewrite to older unreviewed releases"
+    - label: "No, just this release"
+      description: "Only edit the new release section"
+```
+
+## Step 6: Push
+
+1. Show a summary: entries removed, entries rewritten, breaking changes added.
+2. Ask for approval:
+
+```
+AskUserQuestion:
+  question: "Ready to push the rewritten changelog to the release-please branch?"
+  header: "Push"
+  multiSelect: false
+  options:
+    - label: "Push it"
+      description: "Commit and push to the release-please branch"
+    - label: "Show the diff"
+      description: "Show the full diff first, then ask again"
+```
+
+3. Commit with `docs: rewrite changelog with user-facing descriptions` and push.

--- a/.claude/rules/changelog-quality.md
+++ b/.claude/rules/changelog-quality.md
@@ -1,0 +1,144 @@
+# Changelog Quality (release-please)
+
+This project uses [release-please](https://github.com/googleapis/release-please) to generate changelog entries from conventional commit messages. Every PR that lands on `main` becomes a changelog line item unless its type is excluded. Write commit messages (and therefore PR titles) with this in mind.
+
+## Which types appear in the changelog
+
+Only these types generate changelog entries (configured in `release-please-config.json`):
+
+| Type | Changelog section | Use for |
+|---|---|---|
+| `feat` | Features | New user-facing functionality |
+| `fix` | Bug Fixes | Something was broken, now it works |
+| `perf` | Performance Improvements | Measurable performance gains |
+| `refactor` | Refactoring | Structural changes notable enough for users to know about |
+| `docs` | Documentation | User-facing documentation (README, public CLI/skill help text) |
+
+These types are **excluded from the changelog**. Use them for internal work:
+
+| Type | Use for |
+|---|---|
+| `chore` | Internal work: `design/`, `research/`, CLAUDE.md, deps, tooling, internal scripts |
+| `ci` | CI/CD pipeline changes |
+| `test` | Test infrastructure, coverage improvements |
+
+**Key distinction:** `docs:` is for documentation that users read (README, skill help text, public docstrings on the `ccrecall` CLI or the `/ccr-*` skills). Work in `design/`, `.claude/`, research briefs, or internal tooling docs should use `chore:` so it stays out of the changelog.
+
+## How release-please reads commits
+
+| Source | What it becomes |
+|---|---|
+| Commit subject line | Changelog bullet point |
+| `BREAKING CHANGE:` footer in commit body | Breaking change description |
+| `feat!:` / `fix!:` bang in subject | Triggers "Breaking Changes" section header, but **only uses the subject line** if no `BREAKING CHANGE:` footer exists |
+
+GitHub squash-merge uses the PR title as the commit subject and the PR body as the commit body. This repo is squash-merge-only (`mergeCommitAllowed`/`rebaseMergeAllowed` are both off), so the PR title is always what release-please parses.
+
+## PR titles are changelog entries
+
+The PR title becomes the one-line changelog entry that users read. Write it as a **user-facing description**, not a developer-facing one.
+
+**Good** examples that tell a user what changed for them:
+- `fix: cap sync-path embedding memory to prevent OOM freezes`
+- `feat: add opt-in LLM branch resume briefs`
+- `fix!: rename embedding-status.json reason codes to match health.py's mapping`
+
+**Bad** examples with internal jargon, implementation details, or vague bundling:
+- `refactor: session_ops.py decomposition into four modules`
+- `fix: bundle five small-scope issue fixes`
+- `chore: wave 3 structural decompositions (db.py, session_tail.py, embed_branch_chunks)` (fine as `chore`/internal, but would read as noise if ever typed `feat`/`fix`)
+
+### Rules
+
+1. **Imperative mood, lowercase.** `add X`, `fix Y`, not `Added X` or `Adds Y`.
+2. **Describe the user-visible outcome.** What can the user now do, or what broke that's now fixed?
+3. **No bundle PRs in the title.** If a PR bundles N fixes, the title should describe the theme, and individual items belong in the PR body or commit body where release-please won't pick them up.
+4. **No internal-only entries.** If the PR is purely internal (CI, test infra, prior art research, design docs), use `chore:`, `ci:`, or `test:` type; these are excluded from the changelog entirely. Do not use `docs:` for internal documents (`design/`, `.claude/`, research briefs); `docs:` appears in the changelog and is reserved for user-facing documentation.
+
+## Breaking changes MUST have a footer
+
+When a PR contains a breaking change (`feat!:`, `fix!:`, `refactor!:`), the **PR body must end with a `BREAKING CHANGE:` footer** that explains:
+1. What changed
+2. What user code is affected
+3. What the user needs to do
+
+The footer goes at the very end of the PR body (after a blank line), and becomes the breaking change description in the changelog.
+
+### Example PR body structure
+
+```markdown
+## Summary
+
+<description of what the PR does>
+
+## Breaking Changes
+
+<detailed explanation for the PR reviewer>
+
+BREAKING CHANGE: `ccrecall search` no longer accepts `--legacy-fts`; it now
+always uses the hybrid FTS+vector path. Scripts passing that flag must drop it.
+```
+
+The `BREAKING CHANGE:` footer is a [conventional commit trailer](https://www.conventionalcommits.org/en/v1.0.0/#specification). It must be:
+- Preceded by a blank line
+- On its own line starting with `BREAKING CHANGE: ` (with the colon and space)
+- Can span multiple lines (continuation lines are indented or just flow naturally)
+
+### Multiple breaking changes
+
+Do **not** use multiple `BREAKING CHANGE:` footers. Verified directly against release-please's
+own commit parser (`src/commit.ts`, `@conventional-commits/parser`): only the *first* `BREAKING
+CHANGE:` footer in a commit becomes a note; every subsequent one is silently dropped, not merged
+and not appended. A PR with four separate footers will surface exactly one breaking-change bullet
+in the changelog.
+
+Use **one** `BREAKING CHANGE:` footer, with a `####` header + `- ` bulleted list for each
+additional item on the lines that follow. This is release-please's documented extended-context
+format (see `hasExtendedContext` in `commit.ts`) and is confirmed to survive parsing intact,
+including all bullets. Real example, from this repo's own #134 (which predates this rule and used
+a looser `**Breaking:**` inline note rather than a proper footer; a footer-conformant version would
+have read):
+
+```
+BREAKING CHANGE: This release removes the deleted LLM summary enrichment subsystem's surface area.
+#### Removed JSON fields
+- `display_title` and `summary_preview` no longer appear in `ccrecall --json search` /
+  `search-messages` card output; consumers reading either key will find it absent, not null.
+#### Removed commands and config keys
+- The `ccrecall backfill llm-summaries` command and `ccrecall-llm-summaries` console script are
+  gone, as are the `llm_summaries_enabled`, `llm_summary_model`, `llm_summary_effort`,
+  `llm_summary_timeout_seconds`, `llm_summary_max_budget_usd`, and `llm_summary_min_exchanges`
+  config keys. Unknown keys in `config.json` are ignored, so stale entries are harmless.
+```
+
+## Pre-release changelog review
+
+Before merging a release-please PR, review the generated changelog and manually edit the **CHANGELOG.md file** on the release-please branch to:
+
+1. **Remove internal entries.** Prior art research, CI changes, test infrastructure, refactors with no user-visible behavior change.
+2. **Expand vague entries.** If a commit subject is too terse, add context from the PR body.
+3. **Group by feature area.** Reorganize flat lists into topic-grouped sections when a release has 5+ entries.
+4. **Verify breaking change descriptions.** Ensure they tell the user what to do, not just what changed internally.
+
+Use `/changelog-review` to drive this process; see `.claude/commands/changelog-review.md`.
+
+### Do NOT edit the PR body (CRITICAL)
+
+Only edit the `CHANGELOG.md` file on the release-please branch. **Never rewrite the PR description body on GitHub.**
+
+Release-please uses its own PR body format (the `:robot: I have created a release *beep* *boop*` block) to recognize merged release PRs. After a release PR is squash-merged, release-please runs again, finds the PR by title, and parses the body to confirm it's a release PR. If the body doesn't match the expected format, release-please treats the merge as a normal commit: no tag, no GitHub Release, no publish.
+
+This is a documented failure mode in projects that use this same command (hassette's v0.34.0: the PR body was rewritten to match the curated changelog, release-please couldn't parse it, and the release silently failed). Recovery required manually creating the tag, GitHub Release, and triggering the publish workflows.
+
+**What to edit:** `CHANGELOG.md` on the branch (commit and push to the release-please branch)
+**What to leave alone:** The PR description on GitHub; release-please owns that
+
+### Recovery: manual release
+
+If a release-please PR is merged but no tag/release appears:
+
+1. Check the post-merge workflow run. Look for `✖ Pull request body did not match`.
+2. Create the tag: `git tag v<version> <merge-commit-sha> && git push origin v<version>`
+3. Create the GitHub Release: `gh release create v<version> --target <sha> --notes-file <changelog-excerpt>`
+4. Trigger publish manually: re-run the "Release Please" workflow, or the equivalent publish job, for that tag
+5. Close any spurious release-please PR that was opened for the next version

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,11 @@ on:
     push:
         branches: [main]
     workflow_dispatch:
+        inputs:
+            tag_name:
+                description: "Release tag to publish (e.g. v0.24.0). Skips release-please and publishes directly."
+                required: true
+                type: string
 
 # release-please opens/updates the release PR and, when that PR merges, creates
 # the GitHub release + tag and bumps the version in pyproject.toml. It authenticates
@@ -22,6 +27,13 @@ on:
 # version would otherwise stay stale until a contributor's next `uv sync`, surfacing
 # as a spurious lockfile diff. The sync-lockfile job below closes that gap by
 # re-locking on the release PR branch so the bump lands in the same PR.
+#
+# The sync-release-notes job replaces release-please's auto-generated GitHub
+# Release notes with the curated CHANGELOG.md section (see
+# .claude/rules/changelog-quality.md and .claude/commands/changelog-review.md).
+# workflow_dispatch.tag_name lets both that job and publish-pypi be re-run
+# manually against an already-tagged release, without going through
+# release-please again.
 permissions:
     contents: write
     pull-requests: write
@@ -31,7 +43,11 @@ concurrency:
     cancel-in-progress: false
 
 jobs:
+    # Skipped on workflow_dispatch — that path skips release-please entirely and
+    # publishes an already-tagged release directly (see the manual-publish/recovery
+    # steps in .claude/rules/changelog-quality.md).
     release-please:
+        if: github.event_name == 'push'
         runs-on: ubuntu-latest
         timeout-minutes: 15
         outputs:
@@ -117,9 +133,79 @@ jobs:
                   git commit -m "chore: sync uv.lock to release version"
                   git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "HEAD:${PR_BRANCH}"
 
+    # After a release is created, replace the auto-generated GitHub Release notes
+    # with the curated section from CHANGELOG.md (edited on the release-please
+    # branch before merging — see .claude/commands/changelog-review.md). The
+    # auto-generated notes are release-please's raw PR list; the curated version
+    # groups by topic, removes internal entries, and adds contributor attribution.
+    sync-release-notes:
+        needs: release-please
+        # always() lets this run when release-please is skipped (the workflow_dispatch
+        # path). It's safe on the push path too: release_created only comes from
+        # release-please-action's single step, so a failed release-please job and a
+        # true release_created output can't both happen.
+        if: >-
+            always()
+            && (
+              (github.event_name == 'push' && needs.release-please.outputs.release_created == 'true')
+              || github.event_name == 'workflow_dispatch'
+            )
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        permissions:
+            contents: write
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+              with:
+                  ref: ${{ needs.release-please.outputs.tag_name || inputs.tag_name }}
+                  persist-credentials: false
+
+            # github.token (not the app token) is sufficient here: we only need
+            # contents:write to edit the release body, and unlike sync-lockfile's
+            # git push, this doesn't need to re-trigger downstream workflows.
+            - name: Extract and sync release notes
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  TAG_NAME: ${{ needs.release-please.outputs.tag_name || inputs.tag_name }}
+              run: |
+                  set -euo pipefail
+
+                  version="${TAG_NAME#v}"
+
+                  # Extract the section for this version from CHANGELOG.md.
+                  # Captures everything between "## [<version>]" and the next "## [" heading.
+                  notes=$(awk -v ver="$version" '
+                    /^## \[/ {
+                      if (found) exit
+                      if (index($0, "## [" ver "]")) found=1
+                      next
+                    }
+                    found { print }
+                  ' CHANGELOG.md)
+
+                  if [ -z "$notes" ]; then
+                      echo "::warning::No CHANGELOG.md section found for version ${version} — skipping release notes sync"
+                      exit 0
+                  fi
+
+                  echo "Syncing $(echo "$notes" | wc -l) lines of curated notes to GitHub Release ${TAG_NAME}"
+                  notes_file=$(mktemp)
+                  printf '%s\n' "$notes" > "$notes_file"
+                  gh release edit "$TAG_NAME" --notes-file "$notes_file"
+                  rm -f "$notes_file"
+
     publish-pypi:
         needs: release-please
-        if: needs.release-please.outputs.release_created == 'true'
+        # always() lets this run when release-please is skipped (the workflow_dispatch
+        # path). It's safe on the push path too: release_created only comes from
+        # release-please-action's single step, so a failed release-please job and a
+        # true release_created output can't both happen.
+        if: >-
+            always()
+            && (
+              (github.event_name == 'push' && needs.release-please.outputs.release_created == 'true')
+              || github.event_name == 'workflow_dispatch'
+            )
         runs-on: ubuntu-latest
         timeout-minutes: 15
         # Trusted Publishing exchanges this OIDC token for a short-lived PyPI
@@ -135,7 +221,7 @@ jobs:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                   persist-credentials: false
-                  ref: ${{ needs.release-please.outputs.tag_name }}
+                  ref: ${{ needs.release-please.outputs.tag_name || inputs.tag_name }}
 
             - name: Install uv
               uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/scripts/release_contributors.py
+++ b/scripts/release_contributors.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Find external contributors between two git tags.
+
+Usage:
+    uv run python scripts/release_contributors.py v0.23.0 v0.24.0
+    uv run python scripts/release_contributors.py v0.23.0 HEAD
+    uv run python scripts/release_contributors.py              # auto: second-latest tag..latest tag
+
+Scans git log for authors who are not the repo owner or bots, and prints
+each contributor with their associated PRs.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+
+OWNER_EMAILS = frozenset(
+    {
+        "8505845+NodeJSmith@users.noreply.github.com",
+        "12jessicasmith34@gmail.com",
+    }
+)
+
+OWNER_NAMES = frozenset(
+    {
+        "Jessica Smith",
+    }
+)
+
+BOT_PATTERNS = re.compile(r"\[bot\]|dependabot|renovate", re.IGNORECASE)
+
+
+def git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def get_latest_tags(count: int = 2) -> list[str]:
+    output = git("tag", "--sort=-v:refname", "--list", "v*")
+    return output.splitlines()[:count]
+
+
+def get_commits(from_ref: str, to_ref: str) -> list[dict[str, str]]:
+    sep = "§§"
+    log_format = f"%an{sep}%ae{sep}%s"
+    output = git("log", f"--format={log_format}", f"{from_ref}..{to_ref}")
+    if not output:
+        return []
+
+    commits = []
+    for line in output.splitlines():
+        parts = line.split(sep, 2)
+        if len(parts) != 3:
+            continue
+        commits.append({"name": parts[0], "email": parts[1], "subject": parts[2]})
+    return commits
+
+
+def is_external(name: str, email: str) -> bool:
+    if name in OWNER_NAMES or email in OWNER_EMAILS:
+        return False
+    if BOT_PATTERNS.search(name) or BOT_PATTERNS.search(email):
+        return False
+    return True
+
+
+def parse_github_username(email: str) -> str | None:
+    m = re.match(r"(?:\d+\+)?(.+)@users\.noreply\.github\.com", email)
+    return m.group(1) if m else None
+
+
+def find_external_contributors(from_ref: str, to_ref: str) -> dict[str, list[dict[str, str]]]:
+    commits = get_commits(from_ref, to_ref)
+    contributors: dict[str, list[dict[str, str]]] = {}
+
+    for commit in commits:
+        if not is_external(commit["name"], commit["email"]):
+            continue
+
+        name = commit["name"]
+        entry = {"subject": commit["subject"], "email": commit["email"]}
+
+        if name not in contributors:
+            contributors[name] = []
+        contributors[name].append(entry)
+
+    return contributors
+
+
+def print_contributors(
+    contributors: dict[str, list[dict[str, str]]],
+    from_ref: str,
+    to_ref: str,
+) -> None:
+    if not contributors:
+        print(f"No external contributors found in {from_ref}..{to_ref}")
+        return
+
+    print(f"External contributors in {from_ref}..{to_ref}:\n")
+    for name, entries in sorted(contributors.items()):
+        username = None
+        for entry in entries:
+            username = parse_github_username(entry["email"])
+            if username:
+                break
+
+        display = f"@{username}" if username else name
+        print(f"  {display}")
+        for entry in entries:
+            print(f"    - {entry['subject']}")
+        print()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Find external contributors between git tags.")
+    parser.add_argument("from_ref", nargs="?", help="Start ref (default: second-latest tag)")
+    parser.add_argument("to_ref", nargs="?", default="HEAD", help="End ref (default: HEAD)")
+    args = parser.parse_args()
+
+    if args.from_ref is None:
+        tags = get_latest_tags(2)
+        if len(tags) < 1:
+            print("No tags found. Provide explicit refs.", file=sys.stderr)
+            return 1
+        if len(tags) < 2:
+            args.from_ref = tags[0]
+            print(f"Only one tag found, scanning {args.from_ref}..HEAD\n")
+        else:
+            args.from_ref = tags[1]
+            args.to_ref = tags[0]
+            print(f"Auto-detected range: {args.from_ref}..{args.to_ref}\n")
+
+    contributors = find_external_contributors(args.from_ref, args.to_ref)
+    print_contributors(contributors, args.from_ref, args.to_ref)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Ports hassette's proven `/changelog-review` workflow into this repo, adapted for ccrecall's domain and repo settings.

- `.claude/commands/changelog-review.md` — a slash command that checks out the open release-please PR, gathers PR context for each commit, checks for external contributors, rewrites the new release section into grouped, user-facing prose, and pushes back to the release-please branch (never touching its PR body — see the rule file for why that matters).
- `.claude/rules/changelog-quality.md` — documents which conventional-commit types land in the changelog, how PR titles become changelog entries (this repo is squash-merge-only, verified), the `BREAKING CHANGE:` footer format including the single-footer/extended-context gotcha, and the do-not-edit-the-PR-body failure mode with a manual recovery procedure.
- `scripts/release_contributors.py` — finds external (non-owner, non-bot) contributors between two git refs, for changelog attribution. `OWNER_EMAILS`/`OWNER_NAMES` verified against this repo's actual commit history.
- `.github/workflows/release-please.yml` — adds a `sync-release-notes` job (also ported from hassette) that replaces release-please's raw auto-generated GitHub Release notes with the curated `CHANGELOG.md` section once a release is created. Adds `workflow_dispatch.inputs.tag_name` so this job (and `publish-pypi`) can be re-run manually against an already-tagged release, and gates the `release-please` job to the `push` trigger only so it doesn't also try to run on manual dispatch.

Both instruction files and the workflow diff were reviewed by `instruction-quality-reviewer`, `writing-quality-reviewer`, `code-reviewer`, and `integration-reviewer`, and revised for: two accuracy issues in the docs (a stale claim about `CHANGELOG.md`'s state, a fabricated function-rename example replaced with a real one from #134), em-dash-heavy prose, and a workflow permissions/comment tightening (scope `sync-release-notes` to `contents: write` only, explain the `always()` usage).

## Test plan

- `uvx prek run --all-files` — all hooks pass (ran automatically pre-commit and pre-push, including `zizmor` for the workflow YAML).
- No application code changed; this is tooling/instructions/CI only.
- The `sync-release-notes` job itself will get its first real exercise when #195 (the open `chore(main): release 0.24.0` PR) merges, once this PR is merged first.
