### PR TITLE
fix: stop loading the embedding stack in the SessionStart setup hook

### DIFF
--- a/src/ccrecall/config.py
+++ b/src/ccrecall/config.py
@@ -56,6 +56,15 @@ LOG_BACKUP_COUNT = 2
 # PID sentinel file permissions: owner read/write only.
 PID_FILE_MODE = 0o600
 
+# Background-job PID keys, centralized here (not in the owning hook module) so
+# memory_setup.py's spawn-if-needed logic can reference them without importing
+# a module that transitively pulls in the heavy fastembed/onnxruntime/sqlite_vec
+# stack (see TestTransitiveImportIsolation in test_db.py). Each owning module
+# still imports its own key from here for its remove_pid_file() call on exit.
+PID_KEY_IMPORT = "ccrecall-import"
+PID_KEY_BACKFILL_SUMMARIES = "ccrecall-backfill-summaries"
+PID_KEY_WARM_MODEL = "ccrecall-warm-model"
+
 
 def ensure_parent_dir(path: Path) -> None:
     """Create ``path``'s parent directory (idempotent) before writing to it.

--- a/src/ccrecall/hooks/backfill_summaries.py
+++ b/src/ccrecall/hooks/backfill_summaries.py
@@ -9,14 +9,11 @@ import sqlite3
 from pathlib import Path
 
 from ccrecall.config import DEFAULT_DB_PATH, load_settings_for_db, remove_pid_file, setup_logging
+from ccrecall.config import PID_KEY_BACKFILL_SUMMARIES as PID_KEY
 from ccrecall.db import CONTENT_ERROR_VERSION, get_connection
 from ccrecall.summarizer import SUMMARY_VERSION, compute_context_summary
 
 BATCH_SIZE = 50
-
-# PID key — must stay in sync with the spawn in memory_setup
-# (`ccrecall backfill summaries`).
-PID_KEY = "ccrecall-backfill-summaries"
 
 
 def run(*, verbose: bool = False, db: Path = DEFAULT_DB_PATH) -> None:

--- a/src/ccrecall/hooks/import_conversations.py
+++ b/src/ccrecall/hooks/import_conversations.py
@@ -14,6 +14,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from ccrecall.config import DEFAULT_DB_PATH, get_db_path, load_settings, remove_pid_file, setup_logging
+from ccrecall.config import PID_KEY_IMPORT as PID_KEY
 from ccrecall.db import DEFAULT_PROJECTS_DIR, get_connection
 from ccrecall.db_vec import TRIGGER_CHUNKS_VEC_AD, vec_available
 from ccrecall.file_hashing import transcript_file_hash
@@ -30,9 +31,6 @@ BYTES_PER_MB = 1024 * 1024
 KB_PER_MB = 1024
 
 log = logging.getLogger(LOGGER_NAME)
-
-# PID key — must stay in sync with the spawn in memory_setup (`ccrecall import`).
-PID_KEY = "ccrecall-import"
 
 
 def _rss_mb() -> float:

--- a/src/ccrecall/hooks/memory_setup.py
+++ b/src/ccrecall/hooks/memory_setup.py
@@ -13,6 +13,9 @@ from pathlib import Path
 from ccrecall.config import (
     DEFAULT_DB_PATH,
     PID_FILE_MODE,
+    PID_KEY_BACKFILL_SUMMARIES,
+    PID_KEY_IMPORT,
+    PID_KEY_WARM_MODEL,
     SYNC_TEMP_PREFIX,
     ensure_parent_dir,
     load_settings,
@@ -21,9 +24,7 @@ from ccrecall.config import (
     setup_logging,
 )
 from ccrecall.db import CONTENT_ERROR_VERSION, get_connection
-from ccrecall.hooks import backfill_summaries, import_conversations
 from ccrecall.hooks.subprocess_utils import detached_popen_kwargs
-from ccrecall.hooks.warm_model import PID_KEY as WARM_MODEL_PID_KEY
 from ccrecall.models import LOGGER_NAME
 from ccrecall.summarizer import SUMMARY_VERSION
 
@@ -153,10 +154,10 @@ def main():
         db_absent = not DEFAULT_DB_PATH.exists()
 
         if db_absent or _needs_reimport(settings, logger):
-            _spawn_background(["ccrecall", "import"], import_conversations.PID_KEY, logger)
+            _spawn_background(["ccrecall", "import"], PID_KEY_IMPORT, logger)
 
         if _needs_backfill(settings, logger):
-            _spawn_background(["ccrecall", "backfill", "summaries"], backfill_summaries.PID_KEY, logger)
+            _spawn_background(["ccrecall", "backfill", "summaries"], PID_KEY_BACKFILL_SUMMARIES, logger)
 
         # Note: embedding backfill is NOT auto-spawned. Embeddings are filled
         # forward by embed-on-write (active leaves only); historical seeding is
@@ -168,7 +169,7 @@ def main():
         # (O_CREAT|O_EXCL): at most one concurrent warm runs at a time.
         # Runs on every SessionStart; fast no-op after the first download since the
         # model is already cached on disk.
-        _spawn_background(["ccrecall-warm-model"], WARM_MODEL_PID_KEY, logger)
+        _spawn_background(["ccrecall-warm-model"], PID_KEY_WARM_MODEL, logger)
     except Exception:
         # Top-level hook guard: must never crash the session start. Log
         # best-effort (no-op unless logging_enabled) so the failure isn't silent.

--- a/src/ccrecall/hooks/warm_model.py
+++ b/src/ccrecall/hooks/warm_model.py
@@ -10,12 +10,9 @@ there is no hot-path concern — but keeping it a direct entry point is consiste
 and avoids coupling the warm to the CLI command lifecycle.
 """
 
+from ccrecall.config import PID_KEY_WARM_MODEL as PID_KEY
 from ccrecall.config import load_settings, remove_pid_file, setup_logging
 from ccrecall.embeddings import model_available
-
-# PID key written by _spawn_background in memory_setup (imported there as WARM_MODEL_PID_KEY)
-# and removed by main() here.
-PID_KEY = "ccrecall-warm-model"
 
 
 def main() -> None:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -2256,10 +2256,10 @@ assert not found, f'Heavy modules loaded: {{found}}'
         assert result.returncode == 0, result.stderr
 
     def test_memory_setup_does_not_import_heavy_deps(self):
-        """memory_setup.py must not import the LLM summarizer boundary."""
-        code = "import ccrecall.hooks.memory_setup\nimport sys\nassert 'ccrecall.llm_summarizer' not in sys.modules\n"
-        result = _run_subprocess_probe(code)
-        assert result.returncode == 0, result.stderr
+        """memory_setup.py's PID keys must come from config.py, not from importing
+        import_conversations.py (-> db_vec) or warm_model.py (-> embeddings) just
+        to read their PID_KEY constant (#169)."""
+        self._assert_no_heavy_imports("ccrecall.hooks.memory_setup")
 
     def test_clear_handoff_does_not_import_heavy_deps(self):
         """clear_handoff.py imports only from config.py."""


### PR DESCRIPTION
### Hooks

- `memory_setup.py` (the SessionStart setup hook) was importing `import_conversations`, `backfill_summaries`, and `warm_model` solely to read each module's `PID_KEY` constant before deciding whether to spawn them as background jobs. Those modules transitively import numpy/fastembed/onnxruntime/sqlite_vec — the exact ~1800ms heavy stack the hook hot path is designed to avoid (see the "Hook hot path" invariant in CLAUDE.md). The imports themselves, not the spawned subprocesses, were pulling that stack onto every SessionStart.
- Moved the three PID keys (`PID_KEY_IMPORT`, `PID_KEY_BACKFILL_SUMMARIES`, `PID_KEY_WARM_MODEL`) into `config.py`, which has zero heavy dependencies by design. `memory_setup.py` now reads the keys from `config.py` instead of importing the owning hook modules. Each owning module still imports its own key back from `config.py` for its `remove_pid_file()` call on exit, so the constant has one source of truth.
- Updated `test_memory_setup_does_not_import_heavy_deps` to assert no heavy imports at all (via the existing `_assert_no_heavy_imports` helper) rather than only checking for the now-removed LLM summarizer boundary, which no longer reflects what the hook imports.

Fixes #169
