### PR TITLE
fix: stop embeddings backfill wedging forever on one bad row

### DIFF
--- a/src/ccrecall/hooks/backfill_embeddings.py
+++ b/src/ccrecall/hooks/backfill_embeddings.py
@@ -241,18 +241,17 @@ def run(
                             print(f"{_PRINT_PREFIX}: {msg}", file=sys.stderr)
                             last_progress = total_processed
                 except Exception:
-                    # Batch-level abort: sqlite3.Error/OSError re-raised by
-                    # _embed_one_branch (its content-vs-infra split — see that
-                    # function's docstring), or any other unexpected failure
-                    # from the bookkeeping code above (progress formatting,
-                    # logging). Per-row content errors never reach here —
-                    # _embed_one_branch marks the sentinel and returns a
-                    # result instead of raising. Rolling back discards the
-                    # entire current batch — both the failed branch's partial
-                    # state and any earlier branches whose SAVEPOINTs were
-                    # released but not yet committed. All are re-selected
-                    # cleanly on the next run. Prior batches (committed by
-                    # after_batch) are unaffected.
+                    # Batch-level abort: an infra error re-raised by
+                    # _embed_one_branch (see its docstring), or any other
+                    # unexpected failure from the bookkeeping code above
+                    # (progress formatting, logging) — never a per-row content
+                    # error, which _embed_one_branch marks and absorbs
+                    # internally. Rolling back discards the entire current
+                    # batch — both the failed branch's partial state and any
+                    # earlier branches whose SAVEPOINTs were released but not
+                    # yet committed. All are re-selected cleanly on the next
+                    # run. Prior batches (committed by after_batch) are
+                    # unaffected.
                     logger.exception("%s: session failure, aborting", _LOG_PREFIX)
                     conn.rollback()
                     return False

--- a/src/ccrecall/hooks/backfill_embeddings.py
+++ b/src/ccrecall/hooks/backfill_embeddings.py
@@ -28,6 +28,21 @@ Two-level failure distinction:
     other unanticipated exception): mark that row embedding_version = -1 and
     continue.
 
+fastembed/onnxruntime don't expose a narrow, stable exception type that
+distinguishes "this branch's content broke the model" from "the model/session
+itself is broken" — both surface as ordinary `Exception` subclasses. So the
+distinction above is enforced with a live re-probe rather than exception-type
+classification: when `_embed_one_branch`'s catch-all clause fires, it calls
+`_model_still_healthy()`, which retries the model on a trivial fixed string.
+If the probe succeeds, the failure was specific to that branch's content —
+mark the sentinel and continue as before. If the probe also raises, the
+model/session is the thing that broke; the caught exception is re-raised
+instead of marking the row, so it flows through the same infra-abort path as
+a `sqlite3.Error`/`OSError` (batch rollback, `run()` returns `EXIT_ABORT`).
+This bounds worst-case poisoning to the current, uncommitted batch — batches
+already committed earlier in the run are unaffected, and the row that
+triggered the failure stays eligible for retry on the next run.
+
 Built to run unattended (systemd timer): `--status [--json]` reports progress
 without embedding, progress lines carry elapsed/ETA, and abort paths exit
 non-zero so the scheduler sees the failure.
@@ -62,6 +77,7 @@ from ccrecall.embeddings import (
     EMBEDDING_MODEL,
     EMBEDDING_VERSION,
     MODEL_TOKEN_LIMIT,
+    embed_text,
     model_available,
 )
 from ccrecall.health import (
@@ -320,6 +336,25 @@ class _EmbedResult(NamedTuple):
     inferences: int
 
 
+def _model_still_healthy(logger: logging.Logger) -> bool:
+    """Probe the embedding model with a trivial input to distinguish a
+    per-row content error from a broken model/session.
+
+    Called only after `_embed_one_branch` catches an exception that isn't
+    sqlite3.Error/OSError. If the model can still embed a trivial string,
+    the failure was specific to that branch's content — safe to mark and
+    continue. If the probe itself fails, the model/session is broken and
+    the caller re-raises to abort the run instead of marking every
+    subsequent branch as an unrecoverable content error.
+    """
+    try:
+        embed_text("healthcheck")
+        return True
+    except Exception:
+        logger.exception("%s: model health probe failed", _LOG_PREFIX)
+        return False
+
+
 def _embed_one_branch(
     cursor: sqlite3.Cursor,
     branch_id: int,
@@ -385,12 +420,22 @@ def _embed_one_branch(
     except Exception:
         cursor.execute(f"ROLLBACK TO SAVEPOINT {_SAVEPOINT_NAME}")
         cursor.execute(f"RELEASE SAVEPOINT {_SAVEPOINT_NAME}")
+        logger.exception("%s: branch %s failed", _LOG_PREFIX, branch_id)
+        if not _model_still_healthy(logger):
+            # Model/session failure, not a content error: don't poison this
+            # row — re-raise so the caller's batch-abort handler rolls back
+            # instead of marking every subsequent branch unrecoverable.
+            logger.error(
+                "%s: model health probe failed after branch %s, aborting without marking",
+                _LOG_PREFIX,
+                branch_id,
+            )
+            raise
         # Per-row content error: mark sentinel so this row is skipped next run.
         cursor.execute(
             "UPDATE branches SET embedding_version = ? WHERE id = ?",
             (CONTENT_ERROR_VERSION, branch_id),
         )
-        logger.exception("%s: branch %s failed", _LOG_PREFIX, branch_id)
         return _EmbedResult(message_count=len(branch_msgs), updated=0, inferences=0)
 
 

--- a/src/ccrecall/hooks/backfill_embeddings.py
+++ b/src/ccrecall/hooks/backfill_embeddings.py
@@ -6,10 +6,27 @@ forward coverage comes from embed-on-write instead.
 Processes branches in batches, commits between batches, and marks per-row
 content errors with embedding_version = -1 to avoid infinite retry.
 
+Exception taxonomy is catch-all-then-filter-infra, matching
+`backfill_summaries.py`: any exception raised while embedding one branch is a
+content error for that row (mark the sentinel, continue) unless it's a
+`sqlite3.Error`/`OSError` — an infra/DB failure, which propagates to abort the
+batch without poisoning the row. A narrow content-error allow-list would let
+an unanticipated exception type fall through to the infra path unmarked, and
+since this backfill is built to run unattended on a recurring schedule (see
+below), an unmarked row wedges every scheduled run indefinitely: the run
+aborts on that same row every time, blocking every branch behind it in `id`
+order from ever being embedded — the same failure mode as issue #178, fixed
+here as issue #201.
+
+`backfill_tool_content.py` keeps the older narrow-allow-list taxonomy
+deliberately: it's a one-off migration command with no scheduler-oriented
+design, so a wedged row there just sits idle until someone reruns it by hand.
+
 Two-level failure distinction:
   - Model/session failure: abort the whole run, mark NOTHING.
-  - Per-row content error (tokenizer overflow, malformed content): mark that
-    row embedding_version = -1 and continue.
+  - Per-row content error (tokenizer overflow, malformed content, or any
+    other unanticipated exception): mark that row embedding_version = -1 and
+    continue.
 
 Built to run unattended (systemd timer): `--status [--json]` reports progress
 without embedding, progress lines carry elapsed/ETA, and abort paths exit
@@ -224,13 +241,18 @@ def run(
                             print(f"{_PRINT_PREFIX}: {msg}", file=sys.stderr)
                             last_progress = total_processed
                 except Exception:
-                    # Infra/session failure (e.g. ONNX session crash, sqlite3.Error on
-                    # fetch_branch_messages, OOM): abort without marking the content-error
-                    # sentinel. Rolling back discards the entire current batch — both the
-                    # failed branch's partial state and any earlier branches whose
-                    # SAVEPOINTs were released but not yet committed. All are re-selected
-                    # cleanly on the next run. Prior batches (committed by after_batch)
-                    # are unaffected.
+                    # Batch-level abort: sqlite3.Error/OSError re-raised by
+                    # _embed_one_branch (its content-vs-infra split — see that
+                    # function's docstring), or any other unexpected failure
+                    # from the bookkeeping code above (progress formatting,
+                    # logging). Per-row content errors never reach here —
+                    # _embed_one_branch marks the sentinel and returns a
+                    # result instead of raising. Rolling back discards the
+                    # entire current batch — both the failed branch's partial
+                    # state and any earlier branches whose SAVEPOINTs were
+                    # released but not yet committed. All are re-selected
+                    # cleanly on the next run. Prior batches (committed by
+                    # after_batch) are unaffected.
                     logger.exception("%s: session failure, aborting", _LOG_PREFIX)
                     conn.rollback()
                     return False
@@ -306,9 +328,9 @@ def _embed_one_branch(
 ) -> _EmbedResult:
     """Fetch and embed one branch inside a SAVEPOINT.
 
-    Infra errors (e.g. sqlite3.Error from fetch_branch_messages, a
-    non-content exception from embed_branch_chunks) propagate to the
-    caller's batch-abort handler.
+    Implements the content-vs-infra split described in this module's
+    docstring: infra errors propagate to the caller's batch-abort handler,
+    everything else marks the row's content-error sentinel and returns.
     """
     # Fetch messages BEFORE the SAVEPOINT: a sqlite3.Error here is a
     # batch-abort (infra failure), NOT a per-row content error. It propagates
@@ -337,15 +359,13 @@ def _embed_one_branch(
             """,
             (branch_id, EMBEDDING_VERSION, EMBEDDING_MODEL),
         )
-        # embed_branch_chunks RAISES on failure — content errors
-        # (ValueError/OverflowError/UnicodeError) are caught below and marked
-        # once; infra errors propagate to the outer except. max_embeds=None:
-        # backfill is off the hot path and must fully embed each branch in
-        # one pass. With the write-path cap, a branch longer than the cap
-        # would stay eligible and trip the no-progress guard on re-selection.
-        # The return value is the actual inference count (exchanges
-        # embedded), so total_inferences excludes already-current chunks the
-        # pre-delete preserved.
+        # embed_branch_chunks RAISES on failure. max_embeds=None: backfill is
+        # off the hot path and must fully embed each branch in one pass. With
+        # the write-path cap, a branch longer than the cap would stay
+        # eligible and trip the no-progress guard on re-selection. The return
+        # value is the actual inference count (exchanges embedded), so
+        # total_inferences excludes already-current chunks the pre-delete
+        # preserved.
         embedded = embed_branch_chunks(
             cursor,
             branch_id,
@@ -357,7 +377,13 @@ def _embed_one_branch(
         )
         cursor.execute(f"RELEASE SAVEPOINT {_SAVEPOINT_NAME}")
         return _EmbedResult(message_count=len(branch_msgs), updated=1, inferences=embedded)
-    except (ValueError, OverflowError, UnicodeError):
+    except (sqlite3.Error, OSError):
+        # sqlite3.Error/OSError are themselves Exception subclasses, so this
+        # clause exists only to shadow the broader `except Exception` below:
+        # re-raise so the caller's batch-abort handler treats this as an
+        # infra failure instead of poisoning the row.
+        raise
+    except Exception:
         cursor.execute(f"ROLLBACK TO SAVEPOINT {_SAVEPOINT_NAME}")
         cursor.execute(f"RELEASE SAVEPOINT {_SAVEPOINT_NAME}")
         # Per-row content error: mark sentinel so this row is skipped next run.

--- a/src/ccrecall/hooks/backfill_embeddings.py
+++ b/src/ccrecall/hooks/backfill_embeddings.py
@@ -33,7 +33,8 @@ distinguishes "this branch's content broke the model" from "the model/session
 itself is broken" — both surface as ordinary `Exception` subclasses. So the
 distinction above is enforced with a live re-probe rather than exception-type
 classification: when `_embed_one_branch`'s catch-all clause fires, it calls
-`_model_still_healthy()`, which retries the model on a trivial fixed string.
+`_model_still_healthy()`, which re-runs `embed_batch` — the same call
+`embed_branch_chunks` uses for real branches — on a trivial fixed string.
 If the probe succeeds, the failure was specific to that branch's content —
 mark the sentinel and continue as before. If the probe also raises, the
 model/session is the thing that broke; the caught exception is re-raised
@@ -77,7 +78,7 @@ from ccrecall.embeddings import (
     EMBEDDING_MODEL,
     EMBEDDING_VERSION,
     MODEL_TOKEN_LIMIT,
-    embed_text,
+    embed_batch,
     model_available,
 )
 from ccrecall.health import (
@@ -341,14 +342,18 @@ def _model_still_healthy(logger: logging.Logger) -> bool:
     per-row content error from a broken model/session.
 
     Called only after `_embed_one_branch` catches an exception that isn't
-    sqlite3.Error/OSError. If the model can still embed a trivial string,
-    the failure was specific to that branch's content — safe to mark and
-    continue. If the probe itself fails, the model/session is broken and
-    the caller re-raises to abort the run instead of marking every
-    subsequent branch as an unrecoverable content error.
+    sqlite3.Error/OSError. Probes via `embed_batch` — the same function
+    `embed_branch_chunks` uses to embed real branches — rather than
+    `embed_text`, which bypasses `embed_batch`'s token-counting and explicit
+    batch-size machinery and so can't detect a failure specific to that path.
+    If the probe still succeeds, the failure was specific to that branch's
+    content — safe to mark and continue. If the probe itself fails, the
+    model/session is broken and the caller re-raises to abort the run
+    instead of marking every subsequent branch as an unrecoverable content
+    error.
     """
     try:
-        embed_text("healthcheck")
+        embed_batch(["healthcheck"])
         return True
     except Exception:
         logger.exception("%s: model health probe failed", _LOG_PREFIX)

--- a/src/ccrecall/hooks/backfill_summaries.py
+++ b/src/ccrecall/hooks/backfill_summaries.py
@@ -36,6 +36,7 @@ from ccrecall.hooks.backfill_runner import run_batch_loop
 from ccrecall.summarizer import SUMMARY_VERSION, compute_context_summary
 
 BATCH_SIZE = 50
+_LOG_PREFIX = "Backfill summaries"
 
 
 def run(*, verbose: bool = False, db: Path = DEFAULT_DB_PATH) -> int:
@@ -81,7 +82,8 @@ def _main(*, verbose: bool = False, db: Path = DEFAULT_DB_PATH) -> int:
                 # excluding-and-continuing (unlike backfill_tool_content.py, whose
                 # eligibility predicate can't see every skip reason).
                 logger.error(
-                    "Backfill: no progress — same batch re-selected (branch ids: %s); aborting to avoid infinite loop",
+                    "%s: no progress — same batch re-selected (branch ids: %s); aborting to avoid infinite loop",
+                    _LOG_PREFIX,
                     current_ids,
                 )
                 return True
@@ -101,10 +103,8 @@ def _main(*, verbose: bool = False, db: Path = DEFAULT_DB_PATH) -> int:
                             )
                             total_updated += 1
                         except (sqlite3.Error, OSError):  # noqa: PERF203 — per-row error isolation; one malformed branch must not abort the batch
-                            # sqlite3.Error/OSError are themselves Exception subclasses,
-                            # so this clause exists only to shadow the broader `except
-                            # Exception` below: re-raise so the outer handler treats this
-                            # as an infra failure instead of poisoning the row.
+                            # Shadows the broader `except Exception` below — see
+                            # this module's docstring for why the split exists.
                             raise
                         except Exception:
                             # Anything else is a per-row content error (malformed
@@ -114,11 +114,11 @@ def _main(*, verbose: bool = False, db: Path = DEFAULT_DB_PATH) -> int:
                                 "UPDATE branches SET summary_version = ? WHERE id = ?",
                                 (CONTENT_ERROR_VERSION, branch_id),
                             )
-                            logger.exception("Backfill: branch %s content error", branch_id)
+                            logger.exception("%s: branch %s content error", _LOG_PREFIX, branch_id)
                 except (sqlite3.Error, OSError):
                     # Infra/session failure (locked DB, I/O): abort without marking
                     # further rows — they stay eligible next run. Commit prior batches.
-                    logger.exception("Backfill: session failure, aborting")
+                    logger.exception("%s: session failure, aborting", _LOG_PREFIX)
                     conn.commit()
                     return False
                 return True
@@ -135,8 +135,8 @@ def _main(*, verbose: bool = False, db: Path = DEFAULT_DB_PATH) -> int:
             ):
                 return EXIT_ABORT
     except (sqlite3.Error, OSError):
-        logger.exception("Backfill: failed to connect to DB")
+        logger.exception("%s: failed to connect to DB", _LOG_PREFIX)
         return EXIT_ABORT
 
-    logger.info("Backfill complete: %s branches summarized", total_updated)
+    logger.info("%s complete: %s branches summarized", _LOG_PREFIX, total_updated)
     return EXIT_OK

--- a/src/ccrecall/hooks/backfill_summaries.py
+++ b/src/ccrecall/hooks/backfill_summaries.py
@@ -16,11 +16,13 @@ unanticipated exception type fall through to the infra path unmarked; since
 this backfill respawns on every SessionStart, an unmarked row wedges every
 session indefinitely (issue #178).
 
-This is the opposite taxonomy from `backfill_embeddings.py`/`backfill_tool_content.py`
-(narrow content-error allow-list, everything else treated as infra) — deliberately,
-not drift: those two are opt-in/manual, so a wedged branch just sits until someone
-reruns the command, while this one respawns unattended every session. Keep the
-taxonomies distinct rather than "fixing" one to match the other.
+`backfill_embeddings.py` now shares this same catch-all-then-filter-infra taxonomy
+(issue #201) — it's also built to run unattended on a recurring schedule, so the
+same wedge risk applied there. `backfill_tool_content.py` is the one exception left
+on the narrow content-error allow-list: it's a genuinely one-off manual migration
+command with no scheduler-oriented design, so a wedged row there just sits idle
+until someone reruns it by hand — keep its taxonomy distinct rather than "fixing"
+it to match the other two.
 """
 
 import sqlite3

--- a/tests/test_backfill_embeddings.py
+++ b/tests/test_backfill_embeddings.py
@@ -644,12 +644,12 @@ class TestBackfillFailureModes:
         assert _branch_has_chunk_vecs(conn, good_id2)
 
     def test_infra_failure_marks_no_rows(self):
-        """RuntimeError from embed_text (infra failure) → zero rows marked -1, all stay eligible."""
+        """OSError from embed_text (infra failure) → zero rows marked -1, all stay eligible."""
         conn = make_vec_conn()
         ids = [_insert_branch_with_messages(conn) for _ in range(3)]
 
-        def infra_fail(texts: list[str]) -> list[list[float]]:
-            raise RuntimeError("ONNX session crashed")
+        def infra_fail(texts: list[str], **kwargs) -> list[list[float]]:
+            raise OSError("disk I/O error loading model weights")
 
         with (
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
@@ -664,6 +664,42 @@ class TestBackfillFailureModes:
             ev = _branch_embedding_version(conn, bid)
             assert ev != CONTENT_ERROR_VERSION, f"branch {bid} should not be marked -1 on infra failure"
         assert _chunk_count(conn) == 0
+
+    def test_unanticipated_exception_type_marks_sentinel_not_wedge(self):
+        """An exception type outside any hardcoded content-error allow-list still
+        marks the sentinel instead of falling through to the infra-abort path.
+
+        Regression (#201, mirroring #178): the old taxonomy allow-listed only
+        (ValueError, OverflowError, UnicodeError) as content errors, so any
+        other exception type (e.g. a RuntimeError from an ONNX inference
+        failure specific to one branch's text) fell through to the infra
+        handler, left the row unmarked, and — since this backfill is run
+        unattended on a recurring schedule — wedged that row (and every
+        branch behind it) forever.
+        """
+        conn = make_vec_conn()
+        bad_id = _insert_branch_with_messages(conn)
+        good_id = _insert_branch_with_messages(conn)
+
+        call_no = [0]
+
+        def counting_embed(texts: list[str], **kwargs) -> list[list[float]]:
+            call_no[0] += 1
+            if call_no[0] == 1:
+                raise RuntimeError("unexpected inference failure for this branch's text")
+            return [_FIXED_VEC] * len(texts)
+
+        with (
+            patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
+            patch("ccrecall.embed_ops.embed_batch", side_effect=counting_embed),
+            patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
+            patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
+            patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
+        ):
+            run()
+
+        assert _branch_embedding_version(conn, bad_id) == CONTENT_ERROR_VERSION
+        assert _branch_embedding_version(conn, good_id) == EMBEDDING_VERSION
 
     def test_sentinel_row_not_reprocessed(self):
         """A branch with embedding_version=-1 is excluded from the selection predicate."""

--- a/tests/test_backfill_embeddings.py
+++ b/tests/test_backfill_embeddings.py
@@ -609,7 +609,7 @@ class TestBackfillFailureModes:
         assert _chunk_count(conn) == 0
 
     def test_single_bad_embed_marks_only_itself(self):
-        """One branch whose embed_text raises marks only that branch -1; rest succeed."""
+        """One branch whose embed_batch raises marks only that branch -1; rest succeed."""
         conn = make_vec_conn()
         good_id1 = _insert_branch_with_messages(conn)
         bad_id = _insert_branch_with_messages(conn)
@@ -627,7 +627,7 @@ class TestBackfillFailureModes:
         with (
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
             patch("ccrecall.embed_ops.embed_batch", side_effect=counting_embed),
-            patch("ccrecall.hooks.backfill_embeddings.embed_text", return_value=_FIXED_VEC),
+            patch("ccrecall.hooks.backfill_embeddings.embed_batch", return_value=[_FIXED_VEC]),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
             patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
             patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
@@ -645,7 +645,7 @@ class TestBackfillFailureModes:
         assert _branch_has_chunk_vecs(conn, good_id2)
 
     def test_infra_failure_marks_no_rows(self):
-        """OSError from embed_text (infra failure) → zero rows marked -1, all stay eligible."""
+        """OSError from embed_batch (infra failure) → zero rows marked -1, all stay eligible."""
         conn = make_vec_conn()
         ids = [_insert_branch_with_messages(conn) for _ in range(3)]
 
@@ -693,7 +693,7 @@ class TestBackfillFailureModes:
         with (
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
             patch("ccrecall.embed_ops.embed_batch", side_effect=counting_embed),
-            patch("ccrecall.hooks.backfill_embeddings.embed_text", return_value=_FIXED_VEC),
+            patch("ccrecall.hooks.backfill_embeddings.embed_batch", return_value=[_FIXED_VEC]),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
             patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
             patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
@@ -721,7 +721,7 @@ class TestBackfillFailureModes:
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
             patch("ccrecall.embed_ops.embed_batch", side_effect=failing_embed),
             patch(
-                "ccrecall.hooks.backfill_embeddings.embed_text",
+                "ccrecall.hooks.backfill_embeddings.embed_batch",
                 side_effect=RuntimeError("model session broke mid-inference"),
             ),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),

--- a/tests/test_backfill_embeddings.py
+++ b/tests/test_backfill_embeddings.py
@@ -627,6 +627,7 @@ class TestBackfillFailureModes:
         with (
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
             patch("ccrecall.embed_ops.embed_batch", side_effect=counting_embed),
+            patch("ccrecall.hooks.backfill_embeddings.embed_text", return_value=_FIXED_VEC),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
             patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
             patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
@@ -692,6 +693,7 @@ class TestBackfillFailureModes:
         with (
             patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
             patch("ccrecall.embed_ops.embed_batch", side_effect=counting_embed),
+            patch("ccrecall.hooks.backfill_embeddings.embed_text", return_value=_FIXED_VEC),
             patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
             patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
             patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
@@ -700,6 +702,47 @@ class TestBackfillFailureModes:
 
         assert _branch_embedding_version(conn, bad_id) == CONTENT_ERROR_VERSION
         assert _branch_embedding_version(conn, good_id) == EMBEDDING_VERSION
+
+    def test_model_session_failure_aborts_without_marking(self):
+        """When the model health probe also fails after a branch's embed
+        raises, the failure is a model/session break, not a per-row content
+        error: the failing branch must NOT be marked CONTENT_ERROR_VERSION,
+        the run must abort (EXIT_ABORT), and branches later in the batch
+        must not be processed at all.
+        """
+        conn = make_vec_conn()
+        bad_id = _insert_branch_with_messages(conn)
+        later_id = _insert_branch_with_messages(conn)
+
+        def failing_embed(texts: list[str], **kwargs) -> list[list[float]]:
+            raise RuntimeError("model session broke mid-inference")
+
+        with (
+            patch("ccrecall.hooks.backfill_embeddings.model_available", return_value=True),
+            patch("ccrecall.embed_ops.embed_batch", side_effect=failing_embed),
+            patch(
+                "ccrecall.hooks.backfill_embeddings.embed_text",
+                side_effect=RuntimeError("model session broke mid-inference"),
+            ),
+            patch("ccrecall.hooks.backfill_embeddings.get_connection", return_value=_NoCloseConn(conn)),
+            patch("ccrecall.hooks.backfill_embeddings.load_settings_for_db", return_value={}),
+            patch("ccrecall.hooks.backfill_embeddings.time.sleep"),
+        ):
+            exit_code = run()
+
+        assert exit_code == EXIT_ABORT
+        # The failing branch is untouched — not marked CONTENT_ERROR_VERSION,
+        # still eligible for retry on the next run.
+        bad_ev = _branch_embedding_version(conn, bad_id)
+        assert bad_ev != CONTENT_ERROR_VERSION
+        assert bad_ev != EMBEDDING_VERSION
+        # The batch aborted before reaching the later branch — proves the
+        # run stopped rather than continuing past the broken model.
+        later_ev = _branch_embedding_version(conn, later_id)
+        assert later_ev != CONTENT_ERROR_VERSION
+        assert later_ev != EMBEDDING_VERSION
+        assert not _branch_has_chunk_vecs(conn, bad_id)
+        assert not _branch_has_chunk_vecs(conn, later_id)
 
     def test_sentinel_row_not_reprocessed(self):
         """A branch with embedding_version=-1 is excluded from the selection predicate."""


### PR DESCRIPTION
### Notable Changes
- Reverted `process_batch`'s outer `except` from a mechanical narrowing to `(sqlite3.Error, OSError)` back to a broad `except Exception`: `_embed_one_branch` already exhaustively handles per-row exceptions internally, so `process_batch`'s own handler only ever needs to catch infra failures and genuinely unexpected errors from the surrounding bookkeeping code (progress formatting, logging) — narrowing it would let such an error crash the whole process instead of exiting cleanly via `EXIT_ABORT`.

### Fix backfill_embeddings wedging on unanticipated exceptions
- `_embed_one_branch`'s per-row exception taxonomy allow-listed only `ValueError`/`OverflowError`/`UnicodeError` as content errors. Any other exception type fell through to `process_batch`'s handler, which treated it as an infra failure and aborted the whole batch without marking the sentinel — leaving the row eligible for retry. Since this backfill runs unattended on a recurring schedule, an unmarked row wedged every scheduled run indefinitely: the run aborted on that same row every time, blocking every branch behind it in id order from ever being embedded.
- Inverts the taxonomy to catch-all-then-filter-infra, mirroring the pattern already merged for the analogous bug in `backfill_summaries.py` (#178, PR #202): any exception is now a content error unless it's `sqlite3.Error`/`OSError`, which propagates to the batch-abort path instead of poisoning the row.
- `backfill_tool_content.py` is intentionally left on the narrow allow-list: it's a one-off manual migration command with no scheduler-oriented design, so a wedged row there just sits idle until someone reruns it by hand.
- Updated `backfill_summaries.py`'s module docstring, which asserted that `backfill_embeddings.py` deliberately kept the old narrow-allow-list taxonomy forever — a claim this fix falsifies.

### Housekeeping
- Added a shared `_LOG_PREFIX` constant in `backfill_summaries.py` so log messages don't repeat the literal `"Backfill"` string, and tightened surrounding comments per clean-code review.

Closes #201
